### PR TITLE
Fix rearm on vehicles with dynamic loadout support

### DIFF
--- a/Missionframework/scripts/shared/functions/F_rearmVehicle.sqf
+++ b/Missionframework/scripts/shared/functions/F_rearmVehicle.sqf
@@ -1,2 +1,2 @@
 params [ "_veh" ];
-_veh setVehicleAmmoDef 1;
+_veh setVehicleAmmo 1;

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ class Missions
 * Fixed: File name instead of mission name in mission selection screen.
 * Fixed: "Taking Command" spam from AI after players death.
 * Fixed: Fixed range for recycling and start of building instead of using FOB range. 
+* Fixed: Some vehicles with dynamic loadout support lost their weapons when rearmed by Liberation rearm module.
 
 ### 0.963 (05th January 2018)
 * Added: Some missing RHS vehicles for the ACE medical system.


### PR DESCRIPTION
`setVehicleAmmoDef` resets vehicle weapons to these defined in their base config, this means that vehicles with dynamic loadout loose their customizations when rearmed, changing this to `setVehicleAmmo ` fixes the issue.