### PR TITLE
Floating build camera at FOB

### DIFF
--- a/Missionframework/KPLIB_functions.hpp
+++ b/Missionframework/KPLIB_functions.hpp
@@ -16,6 +16,7 @@ class CfgFunctions {
         // Include procedures and functions from each module
         #include "modules\00_init\functions.hpp"
         #include "modules\01_core\functions.hpp"
+        #include "modules\02_build\functions.hpp"
         #include "modules\99_playerOptions\functions.hpp"
     };
 };

--- a/Missionframework/KPLIB_ui.hpp
+++ b/Missionframework/KPLIB_ui.hpp
@@ -13,4 +13,5 @@
 
 #include "modules\00_init\ui.hpp"
 #include "modules\01_core\ui.hpp"
+#include "modules\02_build\ui.hpp"
 #include "modules\99_playerOptions\ui.hpp"

--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -35,6 +35,7 @@ diag_log format [
 
 // Call module inits
 call compile preprocessFileLineNumbers "modules\01_core\initModule.sqf";
+call compile preprocessFileLineNumbers "modules\02_build\initModule.sqf";
 call compile preprocessFileLineNumbers "modules\99_playerOptions\initModule.sqf";
 
 KPLIB_initDone = true;

--- a/Missionframework/modules/02_build/fnc/fn_build_camera_close.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_camera_close.sqf
@@ -1,0 +1,27 @@
+/*
+    KPLIB_fnc_build_open
+
+    File: fn_build_open.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Opens the build camera and creates build overlay
+
+    Parameter(s):
+    NONE
+
+    Returns:
+    BOOL
+*/
+
+// Close camera
+camDestroy (missionNamespace getVariable ["KPLIB_build_camera", objNull]);
+// Close overlay display
+(uiNamespace getVariable ["KPLIB_build_display", displayNull]) closeDisplay 1;
+// Stop PFH
+call KPLIB_fnc_build_camera_ticker_stop;
+
+true

--- a/Missionframework/modules/02_build/fnc/fn_build_camera_open.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_camera_open.sqf
@@ -39,20 +39,7 @@ call KPLIB_fnc_build_camera_ticker_start;
 
 KPLIB_build_camera = _camera;
 
-// Open overlay Display
-private _display = uiNamespace getVariable ["KPLIB_build_display", displayNull];
-
 private _display = (findDisplay 46) createDisplay "KPLIB_build";
 uiNamespace setVariable ["KPLIB_build_display", _display];
-
-private _vignette = _display displayCtrl 1202;
-_vignette ctrlShow false;
-
-// Block ESC close
-_display displayAddEventHandler ["keyDown", {
-    if (_this select 1 == 1) then {
-        call KPLIB_fnc_build_camera_close;
-    };
-}];
 
 true

--- a/Missionframework/modules/02_build/fnc/fn_build_camera_open.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_camera_open.sqf
@@ -1,0 +1,58 @@
+/*
+    KPLIB_fnc_build_open
+
+    File: fn_build_open.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Opens the build camera and creates build overlay
+
+    Parameter(s):
+    NONE
+
+    Returns:
+    BOOL
+*/
+
+private _camera = "CamCurator" camCreate (eyePos player);
+
+// Animate player
+player playactionnow "gear";
+
+_camera cameraEffect ["internal", "back"];
+_camera camCommand "maxPitch 89";
+_camera camCommand "minPitch -89";
+// Same speed no matter the height
+_camera camCommand "surfaceSpeed off";
+// Do not track terrain
+_camera camCommand "atl off";
+
+_camera camCommand format ["speedDefault %1", 1];
+_camera camCommand format ["speedMax %1", 1.5];
+// Enable display of GUI in camera
+cameraEffectEnableHUD true;
+
+call KPLIB_fnc_build_camera_ticker_start;
+
+KPLIB_build_camera = _camera;
+
+// Open overlay Display
+private _display = uiNamespace getVariable ["KPLIB_build_display", displayNull];
+
+private _display = (findDisplay 46) createDisplay "KPLIB_build";
+uiNamespace setVariable ["KPLIB_build_display", _display];
+
+private _vignette = _display displayCtrl 1202;
+_vignette ctrlShow false;
+
+// Block ESC close
+_display displayAddEventHandler ["keyDown", {
+    if (_this select 1 == 1) then {
+        call KPLIB_fnc_build_camera_close;
+    };
+}];
+
+true

--- a/Missionframework/modules/02_build/fnc/fn_build_camera_ticker_start.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_camera_ticker_start.sqf
@@ -1,0 +1,26 @@
+/*
+    KPLIB_fnc_build_camera_ticker_start
+
+    File: fn_build_camera_ticker_start.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Build camera per frame ticker
+
+    Parameter(s):
+    NONE
+
+    Returns:
+    BOOL
+*/
+
+KPLIB_cam_arrow = "Sign_Arrow_Large_Blue_F" createVehicle [0,0,0];
+KPLIB_build_ticker = addMissionEventHandler ["EachFrame", {
+    private _pos = screenToWorld [0.5, 0.5];
+    KPLIB_cam_arrow setPosASL (AGLToASL _pos);
+}];
+
+true

--- a/Missionframework/modules/02_build/fnc/fn_build_camera_ticker_stop.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_camera_ticker_stop.sqf
@@ -1,0 +1,23 @@
+/*
+    KPLIB_fnc_build_camera_ticker_stop
+
+    File: fn_build_camera_ticker_stop.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Stops build camera per frame ticker
+
+    Parameter(s):
+    NONE
+
+    Returns:
+    BOOL
+*/
+
+removeMissionEventHandler ["EachFrame", missionNamespace getVariable ["KPLIB_build_ticker", -1]];
+deleteVehicle (missionNamespace getVariable ["KPLIB_cam_arrow", objNull]);
+
+true

--- a/Missionframework/modules/02_build/fnc/fn_build_displayScript.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_displayScript.sqf
@@ -1,5 +1,22 @@
 #include "..\ui\defines.inc"
 /*
+    KPLIB_fnc_build_displayScript
+
+    File: fn_build_displayScript.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    This function handles whole build display logic
+
+    Parameter(s):
+        0: STRING - Action identifier, used to detect what action is required be handled by script
+        1: ARRAY - Additional parameters of action
+
+    Returns:
+    NOTHING
 */
 
 params [

--- a/Missionframework/modules/02_build/fnc/fn_build_displayScript.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_displayScript.sqf
@@ -1,0 +1,139 @@
+#include "..\ui\defines.inc"
+/*
+*/
+
+params [
+    ["_mode", nil, [""]],
+    ["_parameters", nil, [[]]]
+];
+
+switch _mode do {
+    case "onLoad": {
+        diag_log "onload";
+        _parameters params [["_display", nil, [displayNull]]];
+
+        private _vignette = _display displayCtrl 1202;
+        _vignette ctrlShow false;
+
+        showHUD true;
+
+        // ESC closes whole camera
+        _display displayAddEventHandler ["keyDown", {
+            if (_this select 1 == 1) then {
+                call KPLIB_fnc_build_camera_close;
+            };
+        }];
+
+        // Handle item selection
+        private _itemsList = _display displayCtrl KPLIB_IDC_BUILD_ITEM_LIST;
+        _itemsList ctrlAddEventHandler ["LBSelChanged", {
+            params ["_control", "_selectedIndex"];
+
+            private _display = uiNamespace getVariable "KPLIB_build_display";
+            private _mode = _display getVariable "KPLIB_buildMode";
+
+            if(_selectedIndex == -1) exitWith {
+                _display setVariable ["KPLIB_buildItem", nil];
+            };
+
+            private _buildList = KPLIB_preset_buildLists select _mode;
+            private _selectedItem = _buildList select _selectedIndex;
+
+            _display setVariable ["KPLIB_buildItem", _selectedItem];
+        }];
+
+        // Handle build confirmation
+        private _confirmButton = _display displayCtrl KPLIB_IDC_BUILD_CONFIRM;
+        _confirmButton ctrlAddEventHandler ["buttonClick", {
+            private _display = uiNamespace getVariable "KPLIB_build_display";
+            private _buildItem = _display getVariable ["KPLIB_buildItem", nil];
+
+            if(!isNil "_buildItem") then {
+                [_buildItem select 0, getPosATL KPLIB_cam_arrow] call KPLIB_fnc_common_spawnVehicle;
+            };
+        }];
+
+        // Add tab change handler and scale tab images down
+        {
+            _ctrl = _display displayCtrl _x;
+            _ctrl ctrlAddEventHandler ["buttonClick", {
+                ["tabChanged", _this] call KPLIB_fnc_build_displayScript
+            }];
+
+            [_ctrl, 0.8] call BIS_fnc_ctrlSetScale;
+        } forEach KPLIB_BUILD_TABS_IDCS_ARRAY;
+
+        // Initialize with infantry tab selected
+        ["tabChanged", [_display displayCtrl KPLIB_IDC_BUILD_TAB_INFANTRY]] call KPLIB_fnc_build_displayScript;
+    };
+
+    case "tabChanged": {
+        _parameters params [["_selectedControl", nil, [controlNull]]];
+
+        private _display = ctrlParent _selectedControl;
+
+        _selectedMode = 0;
+        {
+            _ctrl = _display displayctrl _x;
+            _ctrl ctrlsettextcolor [1,1,1,0.5];
+            _scale = 0.8;
+            _color = [1,1,1,0.5];
+            // Selected tab will be scaled up and highlighted
+            if (_ctrl == _selectedControl) then {
+                _scale = 1;
+                _color = [1,1,1,1];
+                _selectedMode = _foreachindex;
+            };
+            _ctrl ctrlSetTextColor _color;
+            [_ctrl, _scale, 0.1] call BIS_fnc_ctrlSetScale;
+        } foreach KPLIB_BUILD_TABS_IDCS_ARRAY;
+
+        // If clicked mode is different than current mode fire change event
+        if(_display getVariable ["KPLIB_buildMode", -1] != _selectedMode) then {
+            _display setVariable ["KPLIB_buildMode", _selectedMode];
+            ["modeChanged", [_display, _selectedMode]] call KPLIB_fnc_build_displayScript;
+        };
+    };
+
+    case "modeChanged": {
+        _parameters params [
+            ["_display", nil, [displayNull]],
+            ["_selectedMode", 0, [0]]
+        ];
+        // CfgVehicles config for shorter access
+        private _cfg = configFile >> "CfgVehicles";
+        private _listElements = KPLIB_preset_buildLists select _selectedMode;
+
+        private _listBox = _display displayCtrl KPLIB_IDC_BUILD_ITEM_LIST;
+        _listBox lbSetCurSel -1; // Unselect current row as it sticks between clearing
+        lnbClear _listBox;
+        {
+            // All but squad build mode
+            if (_selectedMode != 7) then {
+                _x params ["_className", "_priceSupp", "_priceAmmo", "_priceFuel"];
+                private _name = getText (_cfg >> _className >> "displayName");
+
+                _listBox lnbAddRow [_name, str _priceSupp, str _priceAmmo, str _priceFuel];
+
+                _icon = getText ( _cfg >> _className >> "icon");
+                if(isText (configFile >> "CfgVehicleIcons" >> _icon)) then {
+                    _icon = (getText (configFile >> "CfgVehicleIcons" >> _icon));
+                };
+                _listBox lnbSetPicture [[((lnbSize _listBox) select 0) - 1, 0], _icon];
+
+            } else {
+                // TODO handle squad build mode
+                systemChat "Not implemented yet!";
+            };
+
+        } foreach _listElements;
+    };
+
+    case "buildConfirm": {
+
+    };
+
+    default {
+        diag_log format ["[KP LIBERATION] Inorrect mode passed to build display script: %1", _this];
+    };
+}

--- a/Missionframework/modules/02_build/fnc/fn_build_setupPlayerActions.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_setupPlayerActions.sqf
@@ -1,0 +1,45 @@
+/*
+    KPLIB_fnc_build_setupPlayerActions
+
+    File: fn_build_setupPlayerActions.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Initialization of actions availible to players.
+
+    Parameter(s):
+    NONE
+
+    Returns:
+    BOOL
+*/
+
+// Actions avalible LOCALLY to player
+if(hasInterface) then {
+    ["player_fob", {
+        params ["_player", "_fob"];
+
+        private _buildActionId = _player getVariable ["KPLIB_actionId_build", nil];
+
+        // Remove redeploy action if player had one avalible
+        if (_fob isEqualTo "" || _fob isEqualTo "KPLIB_eden_startbase_marker") then {
+            if (!isNil "_buildActionId") then {
+                _player removeAction _buildActionId;
+                _player setVariable ["KPLIB_actionId_build", nil];
+            };
+        } else {
+            // If entered fob and had no action
+            if (isNil "_buildActionId") then {
+                // Add action to player
+                _buildActionId = _player addAction [localize "STR_ACTION_FOB_BUILD", {[] spawn KPLIB_fnc_build_camera_open}, nil, -1000, false, true, "", "vehicle player == player", 10];
+                // Save action id so it can we removed when out of FOB
+                _player setVariable ["KPLIB_actionId_build", _buildActionId];
+            };
+        };
+    }] call KPLIB_fnc_event_addHandler
+};
+
+true

--- a/Missionframework/modules/02_build/functions.hpp
+++ b/Missionframework/modules/02_build/functions.hpp
@@ -25,4 +25,6 @@ class build {
     class build_camera_ticker_stop {};
 
     class build_setupPlayerActions {};
+
+    class build_displayScript {};
 };

--- a/Missionframework/modules/02_build/functions.hpp
+++ b/Missionframework/modules/02_build/functions.hpp
@@ -1,0 +1,28 @@
+/*
+    KP LIBERATION MODULE FUNCTIONS
+
+    File: functions.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Defines for all functions, which are brought by this module.
+*/
+
+class build {
+    file = "modules\02_build\fnc";
+
+    // Close build camera
+    class build_camera_close {};
+
+    // Open build menu
+    class build_camera_open {};
+
+    class build_camera_ticker_start {};
+
+    class build_camera_ticker_stop {};
+
+    class build_setupPlayerActions {};
+};

--- a/Missionframework/modules/02_build/globals.sqf
+++ b/Missionframework/modules/02_build/globals.sqf
@@ -1,0 +1,18 @@
+/*
+    KP LIBERATION MODULE GLOBALS
+
+    File: globals.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Initializes the global variables which are brought by this module.
+*/
+
+// Build camera
+KPLIB_build_camera = objNull;
+
+// Build camera PFH ticker id
+KPLIB_build_ticker = -1;

--- a/Missionframework/modules/02_build/initModule.sqf
+++ b/Missionframework/modules/02_build/initModule.sqf
@@ -1,0 +1,19 @@
+/*
+    KP LIBERATION MODULE INITIALIZATION
+
+    File: initModule.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    This module provides building functionalities
+
+    Dependencies:
+        * 01_core
+*/
+
+call compile preprocessFileLineNumbers "modules\02_build\globals.sqf";
+
+call KPLIB_fnc_build_setupPlayerActions;

--- a/Missionframework/modules/02_build/ui.hpp
+++ b/Missionframework/modules/02_build/ui.hpp
@@ -1,0 +1,14 @@
+/*
+    KP LIBERATION MODULE UI FILE
+
+    File: KPLIB_ui.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Initializes the ui defines, dialogs and elements which are brought by this module.
+*/
+
+#include "ui\KPLIB_buildDisplay.hpp"

--- a/Missionframework/modules/02_build/ui/KPLIB_buildDisplay.hpp
+++ b/Missionframework/modules/02_build/ui/KPLIB_buildDisplay.hpp
@@ -1,0 +1,57 @@
+
+#include "..\..\00_init\ui\KPLIB_defines.hpp"
+/*
+    KP Liberation build display defines
+
+    File: KPLIB_defines.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Overlay of build camera with all building controls
+*/
+
+class KPLIB_build {
+    idd = -1;
+    movingEnable = false;
+
+    class ControlsBackground {
+
+        class KPLIB_ItemsTitle: KPLIB_Title {
+            text = "Units list";
+            x = KPLIB_GUI_POS_X_CORNER;
+            y = KPLIB_GUI_POS_Y_CORNER;
+            w = KPLIB_GUI_WIDTH_CORNER;
+        };
+        class KPLIB_ItemsArea: KPLIB_AreaBackground {
+            x = KPLIB_GUI_POS_X_AREA_CORNER;
+            y = KPLIB_GUI_POS_Y_AREA_CORNER;
+            w = KPLIB_GUI_WIDTH_AREA_CORNER;
+            h = KPLIB_GUI_HEIGHT_AREA_CORNER;
+        };
+
+    };
+
+    class Controls {
+
+        class KPLIB_CloseDisplay: KPLIB_CloseCross {
+            x = KPLIB_GUI_POS_X_CROSS_CORNER;
+            y = KPLIB_GUI_POS_Y_CROSS_CORNER;
+            // Close whole build camera
+            action = "call KPLIB_fnc_build_camera_close";
+        };
+
+        class KPLIB_BuildListGroup: KPLIB_ControlsGroup {
+            x = KPLIB_GUI_POS_X_AREA_CORNER;
+            y = KPLIB_GUI_POS_Y_AREA_CORNER;
+            w = KPLIB_GUI_WIDTH_AREA_CORNER;
+            h = KPLIB_GUI_HEIGHT_AREA_CORNER;
+
+            class Controls {
+            };
+        };
+
+    };
+};

--- a/Missionframework/modules/02_build/ui/KPLIB_buildDisplay.hpp
+++ b/Missionframework/modules/02_build/ui/KPLIB_buildDisplay.hpp
@@ -1,5 +1,6 @@
 
 #include "..\..\00_init\ui\KPLIB_defines.hpp"
+#include "defines.inc"
 /*
     KP Liberation build display defines
 
@@ -13,14 +14,17 @@
     Overlay of build camera with all building controls
 */
 
+// Build display
 class KPLIB_build {
     idd = -1;
     movingEnable = false;
 
+    onLoad = "['onLoad', _this] call KPLIB_fnc_build_displayScript";
+
     class ControlsBackground {
 
         class KPLIB_ItemsTitle: KPLIB_Title {
-            text = "Units list";
+            text = "$STR_BUILD";
             x = KPLIB_GUI_POS_X_CORNER;
             y = KPLIB_GUI_POS_Y_CORNER;
             w = KPLIB_GUI_WIDTH_CORNER;
@@ -43,14 +47,114 @@ class KPLIB_build {
             action = "call KPLIB_fnc_build_camera_close";
         };
 
-        class KPLIB_BuildListGroup: KPLIB_ControlsGroup {
+        class KPLIB_BuildTabsGroup: KPLIB_ControlsGroupNoScrollbars {
             x = KPLIB_GUI_POS_X_AREA_CORNER;
             y = KPLIB_GUI_POS_Y_AREA_CORNER;
             w = KPLIB_GUI_WIDTH_AREA_CORNER;
-            h = KPLIB_GUI_HEIGHT_AREA_CORNER;
+            h = KPLIB_BUILD_TAB_WIDTH + KPLIB_BUILD_TAB_Y_OFFSET;
 
             class Controls {
+
+                class KPLIB_ModeUnits: KPLIB_ActivePicture {
+                    text = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeUnits_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 0;
+                    y = 0;
+
+                    w = KPLIB_BUILD_TAB_WIDTH;
+                    h = KPLIB_BUILD_TAB_WIDTH;
+
+                    idc = KPLIB_IDC_BUILD_TAB_INFANTRY;
+                };
+
+                class KPLIB_ModeLight: KPLIB_ModeUnits {
+                    text = "\A3\ui_f\data\map\vehicleicons\iconCar_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 1;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_LIGHT;
+                };
+
+                class KPLIB_ModeHeavy: KPLIB_ModeUnits {
+                    text = "\A3\ui_f\data\map\vehicleicons\iconTank_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 2;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_HEAVY;
+                };
+
+                class KPLIB_ModeAir: KPLIB_ModeUnits {
+                    text = "\A3\ui_f\data\map\vehicleicons\iconHelicopter_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 3;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_AIR;
+                };
+
+                class KPLIB_ModeStatic: KPLIB_ModeUnits {
+                    text = "\A3\ui_f\data\map\vehicleicons\iconStaticCannon_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 4;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_STATIC;
+                };
+
+                class KPLIB_ModeBuilding: KPLIB_ModeUnits {
+                    text = "\A3\ui_f\data\map\mapcontrol\Bunker_CA.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 5;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_BUILDING;
+                };
+
+                class KPLIB_ModeSupport: KPLIB_ModeUnits {
+                    text = "\A3\ui_f\data\map\vehicleicons\iconCrateAmmo_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 6;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_SUPPORT;
+                };
+
+                class KPLIB_ModeSquad: KPLIB_ModeUnits {
+                    text = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
+
+                    x = KPLIB_BUILD_TAB_WIDTH * 7;
+                    y = 0;
+
+                    idc = KPLIB_IDC_BUILD_TAB_SQUAD;
+                };
+
             };
+        };
+
+        class KPLIB_BuildList: KPLIB_ListNBox {
+            idc = 201;
+
+            x = KPLIB_GUI_POS_X_AREA_CORNER;
+            y = KPLIB_GUI_POS_Y_AREA_CORNER + KPLIB_BUILD_TAB_WIDTH + KPLIB_BUILD_TAB_Y_OFFSET;
+            w = KPLIB_GUI_WIDTH_AREA_CORNER;
+            h = KPLIB_GUI_HEIGHT_AREA_CORNER - KPLIB_BUILD_TAB_WIDTH - KPLIB_BUILD_TAB_Y_OFFSET;
+
+            columns[] = { 0, 0.65, 0.75, 0.85 };
+        };
+
+        class KPLIB_BuildConfirm: KPLIB_ButtonMenu {
+            idc = KPLIB_IDC_BUILD_CONFIRM;
+
+            x = KPLIB_GUI_POS_X_AREA_CORNER + KPLIB_GUI_WIDTH_AREA_CORNER * (1 - 0.3);
+            // TODO improve positioning
+            y = (KPLIB_GUI_POS_Y_AREA_CORNER + KPLIB_BUILD_TAB_WIDTH + KPLIB_BUILD_TAB_Y_OFFSET) + (KPLIB_GUI_HEIGHT_AREA_CORNER - KPLIB_BUILD_TAB_WIDTH - KPLIB_BUILD_TAB_Y_OFFSET);
+
+            w = KPLIB_GUI_WIDTH_AREA_CORNER * 0.3;
+            h = GUI_GRID_H * 1;
+
+            text = "$STR_BUILD";
         };
 
     };

--- a/Missionframework/modules/02_build/ui/defines.inc
+++ b/Missionframework/modules/02_build/ui/defines.inc
@@ -1,0 +1,21 @@
+
+// General defines
+#define KPLIB_BUILD_TAB_WIDTH               (KPLIB_GUI_WIDTH_AREA_CORNER / 8)
+#define KPLIB_BUILD_TAB_Y_OFFSET            0.02
+
+// IDCs
+#define KPLIB_IDC_BUILD_TAB_INFANTRY        100
+#define KPLIB_IDC_BUILD_TAB_LIGHT           101
+#define KPLIB_IDC_BUILD_TAB_HEAVY           102
+#define KPLIB_IDC_BUILD_TAB_AIR             103
+#define KPLIB_IDC_BUILD_TAB_STATIC          104
+#define KPLIB_IDC_BUILD_TAB_BUILDING        105
+#define KPLIB_IDC_BUILD_TAB_SUPPORT         106
+#define KPLIB_IDC_BUILD_TAB_SQUAD           107
+
+#define KPLIB_IDC_BUILD_ITEM_LIST           201
+
+#define KPLIB_IDC_BUILD_CONFIRM             301
+
+// All tabs IDCs
+#define KPLIB_BUILD_TABS_IDCS_ARRAY         [100,101,102,103,104,105,106,107]

--- a/Missionframework/modules/02_build/ui/defines.inc
+++ b/Missionframework/modules/02_build/ui/defines.inc
@@ -1,3 +1,15 @@
+/*
+    KP LIBERATION BUILD UI DEFINES
+
+    File: defines.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-07-01
+    Last Update: 2018-07-01
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Common defines for build module UI elements
+*/
 
 // General defines
 #define KPLIB_BUILD_TAB_WIDTH               (KPLIB_GUI_WIDTH_AREA_CORNER / 8)

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1305,6 +1305,18 @@
             <Turkish>-- YENİDEN SEÇ --</Turkish>
             <Portuguese>-- REMOBILIZAR --</Portuguese>
         </Key>
+        <Key ID="STR_ACTION_FOB_BUILD">
+            <Original>-- BUILD --</Original>
+            <French>-- CONSTRUIRE --</French>
+            <German>-- BAUEN --</German>
+            <Spanish>-- CONSTRUIR --</Spanish>
+            <Russian>-- ОБЕСПЕЧЕНИЕ --</Russian>
+            <Italian>-- COSTRUISCI --</Italian>
+            <Chinesesimp>-- 建造 --</Chinesesimp>
+            <Chinese>-- 建造 --</Chinese>
+            <Turkish>-- İnşa Et --</Turkish>
+            <Portuguese>-- CONSTRUIR --</Portuguese>
+        </Key>
         <Key ID="STR_ACTION_PLAYER_OPTIONS">
             <Original>-- KPLIB Player Options --</Original>
             <German>-- KPLIB Spieler Optionen --</German>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1237,6 +1237,18 @@
             <Turkish>Canlan</Turkish>
             <Portuguese>Mobilizar</Portuguese>
         </Key>
+        <Key ID="STR_BUILD">
+            <Original>BUILD</Original>
+            <French>CONSTRUIRE</French>
+            <German>BAUEN</German>
+            <Spanish>CONSTRUIR</Spanish>
+            <Russian>ОБЕСПЕЧЕНИЕ</Russian>
+            <Italian>COSTRUISCI</Italian>
+            <Chinesesimp>建造</Chinesesimp>
+            <Chinese>建造</Chinese>
+            <Turkish>İnşa Et</Turkish>
+            <Portuguese>CONSTRUIR</Portuguese>
+        </Key>
     </Package>
     <Package name="Debriefings">
         <Key ID="STR_DEBRIEF_WINTITLE">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes<!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> |
| Fixed issues | #415  <!-- #-prefixed issue number(s), if any --> |

### Description:

Initial implementation of build camera. For now it is really simple, it has no resource system integration as it is not ready yet.

### Content:
- [x] Floating camera available at FOB
- [x] Dialog that allows to select what has to be built
- [x] Build selected object at position

### Flaws that need to be fixed in further development:
- Scrolling the item list zooms camera
- Missing item collision detection
- Camera is not limited to FOB area
- When tab is switched tab buttons "vibrate" a little bit, Might be not possible to fix this, also happens in vanilla zeus. (optionaly _scale_ animation can be removed)
- Camera should be closed when player is killed
- Main display handling script is too **fat**, some logic needs to be moved to outside functions

### Tested on:
- [x] Local MP Vanilla
- [x] ~~Local MP ACE~~
- [x] Dedicated MP Vanilla
- [x] ~~Dedicated MP ACE~~
