### PR TITLE
Mission name to BI forum convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Tweaked: Faster initial sector sorting.
 * Tweaked: Stringtable key names categorized.
 * Tweaked: Formatting and comments in preset files.
+* Tweaked: Mission name now fits the [name standard](https://forums.bohemia.net/forums/topic/217676-mission-name-standard/).
 
 ## 0.963a (10th April 2018 as "legacy support" release)
 * Added: Action to raise/lower object while building. Thanks to [darrell-aevum](https://github.com/darrell-aevum)

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -12,7 +12,7 @@
     <!-- Portuguese localization made by NomadRomeo: https://github.com/NomadRomeo -->
     <Package name="General">
         <Key ID="STR_MISSION_TITLE">
-            <Original>KP Liberation v0.97dev</Original>
+            <Original>CTI 34 KP Liberation v0.97dev</Original>
         </Key>
         <Key ID="STR_MISSION_VERSION">
             <Original>v0.97dev</Original>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no |
| Fixed issues | #449 |

### Description:
One of the smallest pull requests we'll have I guess.
Changed the name to the naming standard from the BI Forum:
https://forums.bohemia.net/forums/topic/217676-mission-name-standard/

### Content:
- [x] Changed name in stringtable.xml

### Tested on:
- [x] Local MP Vanilla
- [x] ~~Local MP ACE~~
- [x] Dedicated MP Vanilla
- [x] ~~Dedicated MP ACE~~