### PR TITLE
Fix stringtable whitespace

### DIFF
--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1,6141 +1,6734 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project name="Liberation">
-	<Package name="Liberation">
-		<!-- French localization made by zbug: https://github.com/GreuhZbug -->
-		<!-- German localization made by Wyqer: https://github.com/Wyqer -->
-		<!-- Italian localization made by k4s0: https://github.com/k4s0 -->
-		<!-- Spanish localization made by regiregi22: https://github.com/regiregi22 -->
-		<!-- Russion localization made by _KOC_: Constantin.rogozin@ya.ru -->
-		<!-- English corrections / proofreading by Applejakerie: https://github.com/Applejakerie -->
-		<!-- Chinese Simplified localization made by Nercon: https://github.com/nercon -->
-		<!-- Chinese Traditional localization made by John M. Rodriguez: https://github.com/KOEI5113 -->
-		<!-- (WIP) Turkish localization made by Carbneth: https://github.com/Carbneth -->
-		<!-- Portuguese localization made by NomadRomeo: https://github.com/NomadRomeo -->
-		<Key ID="STR_MISSION_TITLE">
-			<Original>KP Liberation v0.963a</Original>
-			<German>KP Liberation v0.963a</German>
-			<Spanish>KP Liberation v0.963a</Spanish>
-			<Italian>KP Liberation v0.963a</Italian>
-			<Chinesesimp>KP Liberation v0.963a</Chinesesimp>
-			<Chinese>KP Liberation v0.963a</Chinese>
-			<Turkish>KP Liberation v0.963a</Turkish>
-			<Portuguese>KP Liberation v0.963a</Portuguese>
-		</Key>
-		<Key ID="STR_MISSION_VERSION">
-			<Original>v0.963a</Original>
-			<German>v0.963a</German>
-			<Spanish>v0.963a</Spanish>
-			<Italian>v0.963a</Italian>
-			<Chinesesimp>v0.963a</Chinesesimp>
-			<Chinese>v0.963a</Chinese>
-			<Turkish>v0.963a</Turkish>
-			<Portuguese>v0.963a</Portuguese>
-		</Key>
-		<Key ID="STR_Deploy_OnPoint">
-			<Original>Deploy</Original>
-			<French>Déploiement</French>
-			<German>Bereitstellen</German>
-			<Spanish>Despliegue</Spanish>
-			<Russian>Развёртывание</Russian>
-			<Italian>Schierati</Italian>
-			<Chinesesimp>部署</Chinesesimp>
-			<Chinese>佈署</Chinese>
-			<Turkish>Atla</Turkish>
-			<Portuguese>Mobilizar</Portuguese>
-		</Key>
-		<Key ID="STR_Deploy_InProgress">
-			<Original>Deployment in progress ...</Original>
-			<French>Déploiement en cours ...</French>
-			<German>Bereitstellung in Arbeit</German>
-			<Spanish>Despliegue en curso ...</Spanish>
-			<Russian>Развёртывание в процессе ...</Russian>
-			<Italian>Schieramento in Corso ...</Italian>
-			<Chinesesimp>正在部署中...</Chinesesimp>
-			<Chinese>正在佈署中...</Chinese>
-			<Turkish>Atlama işlemi devam ediyor ...</Turkish>
-			<Portuguese>Mobilização em andamento...</Portuguese>
-		</Key>
-		<Key ID="STR_CLOSE">
-			<Original>Close</Original>
-			<French>Fermer</French>
-			<German>Schliessen</German>
-			<Spanish>Cerca</Spanish>
-			<Russian>Закрыть</Russian>
-			<Italian>Chiudi</Italian>
-			<Chinesesimp>关闭</Chinesesimp>
-			<Chinese>關閉</Chinese>
-			<Turkish>Kapat</Turkish>
-			<Portuguese>Fechar</Portuguese>
-		</Key>
-		<Key ID="STR_REVIVE_LABEL">
-			<Original>YOU ARE WOUNDED</Original>
-			<French>VOUS ETES BLESSE</French>
-			<German>DU BIST VERWUNDET</German>
-			<Spanish>ESTAS HERIDO</Spanish>
-			<Russian>ВЫ БЕЗ СОЗНАНИЯ</Russian>
-			<Italian>SEI STATO UCCISO</Italian>
-			<Chinesesimp>你受伤了</Chinesesimp>
-			<Chinese>你受傷了</Chinese>
-			<Turkish>Ağır yaralandın!</Turkish>
-			<Portuguese>VOCÊ ESTÁ FERIDO!</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_ACTION">
-			<Original>-- BUILD --</Original>
-			<French>-- CONSTRUIRE --</French>
-			<German>-- BAUEN --</German>
-			<Spanish>-- CONSTRUIR --</Spanish>
-			<Russian>-- ОБЕСПЕЧЕНИЕ --</Russian>
-			<Italian>-- COSTRUISCI --</Italian>
-			<Chinesesimp>-- 建造 --</Chinesesimp>
-			<Chinese>-- 建造 --</Chinese>
-			<Turkish>-- İnşa Et --</Turkish>
-			<Portuguese>-- CONSTRUIR --</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_TITLE">
-			<Original>BUILD MENU</Original>
-			<French>CONSTRUCTION</French>
-			<German>BAUMENÜ</German>
-			<Spanish>MENU DE CONSTRUCCIÓN</Spanish>
-			<Russian>ОБЕСПЕЧЕНИЕ</Russian>
-			<Italian>MENU COSTRUZIONI</Italian>
-			<Chinesesimp>建造菜单</Chinesesimp>
-			<Chinese>建造選單</Chinese>
-			<Turkish>İNŞA MENÜSÜ</Turkish>
-			<Portuguese>MENU DE CONSTRUÇÃO</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_BUTTON">
-			<Original>Build</Original>
-			<French>Construire</French>
-			<German>Bauen</German>
-			<Spanish>Construir</Spanish>
-			<Russian>Построить</Russian>
-			<Italian>Costruisci</Italian>
-			<Chinesesimp>建造</Chinesesimp>
-			<Chinese>建造</Chinese>
-			<Turkish>İnşa Et</Turkish>
-			<Portuguese>Construir</Portuguese>
-		</Key>
-		<Key ID="STR_MANPOWER">
-			<Original>Supplies</Original>
-			<French>Effectifs</French>
-			<German>Nachschub</German>
-			<Spanish>Efectivos</Spanish>
-			<Russian>Персонал</Russian>
-			<Italian>Personale</Italian>
-			<Chinesesimp>补给</Chinesesimp>
-			<Chinese>補給</Chinese>
-			<Turkish>Kaynaklar</Turkish>
-			<Portuguese>Suprimentos</Portuguese>
-		</Key>
-		<Key ID="STR_AMMO">
-			<Original>Ammunition</Original>
-			<French>Munitions</French>
-			<German>Munition</German>
-			<Spanish>Munición</Spanish>
-			<Russian>Вооружение</Russian>
-			<Italian>Munizioni</Italian>
-			<Chinesesimp>弹药</Chinesesimp>
-			<Chinese>彈藥</Chinese>
-			<Turkish>Muhimmatlar</Turkish>
-			<Portuguese>Munição</Portuguese>
-		</Key>
-		<Key ID="STR_FUEL">
-			<Original>Fuel</Original>
-			<French>Carburant</French>
-			<German>Kraftstoff</German>
-			<Spanish>Combustible</Spanish>
-			<Russian>Топливо</Russian>
-			<Italian>Carburante</Italian>
-			<Chinesesimp>燃料</Chinesesimp>
-			<Chinese>油料</Chinese>
-			<Turkish>Yakıt</Turkish>
-			<Portuguese>Combustível</Portuguese>
-		</Key>
-		<Key ID="STR_BLEEDOUT_MESSAGE">
-			<Original>Bleedout in %1 seconds</Original>
-			<French>Mort dans %1 secondes</French>
-			<German>Ausbluten in %1 Sekunden</German>
-			<Spanish>Desangrado en %1 segundos</Spanish>
-			<Russian>Вы умрёте через %1 секунд</Russian>
-			<Italian>Morte per dissanguamento fra %1 secondi</Italian>
-			<Chinesesimp>将于%1秒后失血阵亡</Chinesesimp>
-			<Chinese>將於 %1 秒後失血致死</Chinese>
-			<Turkish>%1 saniyedir kanıyorsun</Turkish>
-			<Portuguese>Morte por hemorragia em %1 segundos</Portuguese>
-		</Key>
-		<Key ID="STR_BLEEDOUT_STABILIZED">
-			<Original>Stabilized</Original>
-			<French>Stabilisé</French>
-			<German>Stabilisiert</German>
-			<Spanish>Estabilizado</Spanish>
-			<Russian>Стабильно</Russian>
-			<Italian>Stabilizzato</Italian>
-			<Chinesesimp>伤情稳定</Chinesesimp>
-			<Chinese>傷勢穩定</Chinese>
-			<Turkish>Stabilize</Turkish>
-			<Portuguese>Hemorragia estancada</Portuguese>
-		</Key>
-		<Key ID="STR_ROTATION">
-			<Original>-- Rotation</Original>
-			<French>-- Rotation</French>
-			<German>-- Rotieren</German>
-			<Spanish>-- Rotación</Spanish>
-			<Russian>-- Вращать</Russian>
-			<Italian>-- Ruota</Italian>
-			<Chinesesimp>-- 旋转</Chinesesimp>
-			<Chinese>-- 旋轉</Chinese>
-			<Turkish>-- Döndür</Turkish>
-			<Portuguese>-- Rotação</Portuguese>
-		</Key>
-		<Key ID="STR_PLACEMENT">
-			<Original>-- Build</Original>
-			<French>-- Construire</French>
-			<German>-- Bauen</German>
-			<Spanish>-- Construir</Spanish>
-			<Russian>-- Поставить</Russian>
-			<Italian>-- Costruisci</Italian>
-			<Chinesesimp>-- 建造</Chinesesimp>
-			<Chinese>-- 建造</Chinese>
-			<Turkish>-- Kur</Turkish>
-			<Portuguese>-- Construir</Portuguese>
-		</Key>
-		<Key ID="STR_PLACEMENT_BIS">
-			<Original>-- Build and Repeat</Original>
-			<French>-- Construire et Répéter</French>
-			<German>-- Bauen und Wiederholen</German>
-			<Spanish>-- Construir y repetir</Spanish>
-			<Russian>-- Поставить и повторить</Russian>
-			<Italian>-- Costruisci e Ripeti</Italian>
-			<Chinesesimp>-- 建造并重复</Chinesesimp>
-			<Chinese>-- 建造並重複</Chinese>
-			<Turkish>-- Kur ve tekrarla</Turkish>
-			<Portuguese>-- Construir e repetir</Portuguese>
-		</Key>
-		<Key ID="STR_CANCEL">
-			<Original>-- Cancel</Original>
-			<French>-- Annuler</French>
-			<German>-- Abbrechen</German>
-			<Spanish>-- Cancelar</Spanish>
-			<Russian>-- Отмена</Russian>
-			<Italian>-- Annulla</Italian>
-			<Chinesesimp>-- 取消</Chinesesimp>
-			<Chinese>-- 取消</Chinese>
-			<Turkish>-- İptal</Turkish>
-			<Portuguese>-- Cancelar</Portuguese>
-		</Key>
-		<Key ID="STR_CANCEL_HINT">
-			<Original>Building canceled.</Original>
-			<French>Construction annulée.</French>
-			<German>Bauen abgebrochen.</German>
-			<Spanish>Construcción cancelada</Spanish>
-			<Russian>Постройка отменена</Russian>
-			<Italian>Costruzione cancellata.</Italian>
-			<Chinesesimp>建造取消。</Chinesesimp>
-			<Chinese>建造取消。</Chinese>
-			<Turkish>İnşa iptal edildi.</Turkish>
-			<Portuguese>Construção cancelada.</Portuguese>
-		</Key>
-		<Key ID="STR_CONFIRM_HINT">
-			<Original>Building confirmed.</Original>
-			<French>Construction confirmée.</French>
-			<German>Bauen bestätigt.</German>
-			<Spanish>Construcción confirmada.</Spanish>
-			<Russian>Постройка подтверждена</Russian>
-			<Italian>Costruzione confermata.</Italian>
-			<Chinesesimp>建造完成。</Chinesesimp>
-			<Chinese>建造成功。</Chinese>
-			<Turkish>İnşa kuruldu.</Turkish>
-			<Portuguese>Construção confirmada.</Portuguese>
-		</Key>
-		<Key ID="STR_PLACEMENT_IMPOSSIBLE">
-			<Original>Can't place here: there are %1 object(s) within %2 meters of the object position.</Original>
-			<French>Impossible de placer ici : il y a %1 objet(s) dans les %2 mètres de la position voulue.</French>
-			<German>Kann hier nicht platziert werden: %1 Objekt(e) innerhalb von %2 Meter der Position</German>
-			<Spanish>Imposible de colocar aqui: hay 1% objeto(s) a %2 metros de la posición del objeto</Spanish>
-			<Russian>Нельзя разместить здесь:  в %2 метрах есть 1% объект(а).</Russian>
-			<Italian>impossibile piazzare qui: ci sono %1 oggetti vicini %2 metri dalla posizione dell'oggetto in costruzione</Italian>
-			<Chinesesimp>无法安置在这里：当前位置%2米内有%1个物体阻挡。</Chinesesimp>
-			<Chinese>無法在此建造：目前 %2 公尺內有 %1 個物件存在。</Chinese>
-			<Turkish>Buraya kurulamaz: %2 metre içinde %1 obje bulunuyor.</Turkish>
-			<Portuguese>Impossível inserir aqui: Há %1 objeto(s) dentro de %2 metros da posição deste item.</Portuguese>
-		</Key>
-		<Key ID="STR_PLACEMENT_POSSIBLE">
-			<Original>This position is valid.</Original>
-			<French>Cette position est valide.</French>
-			<German>Diese Position ist gültig.</German>
-			<Spanish>Esta posición es válida</Spanish>
-			<Russian>Это место подходит.</Russian>
-			<Italian>Questa posizione è valida</Italian>
-			<Chinesesimp>可安置于此处。</Chinesesimp>
-			<Chinese>可在此建造。</Chinese>
-			<Turkish>Bu pozisyon uygun.</Turkish>
-			<Portuguese>Esta posição é válida.</Portuguese>
-		</Key>
-		<Key ID="STR_ARSENAL_ACTION">
-			<Original>-- ARSENAL --</Original>
-			<French>-- ARSENAL --</French>
-			<German>-- ARSENAL --</German>
-			<Spanish>-- ARSENAL --</Spanish>
-			<Russian>-- АРСЕНАЛ --</Russian>
-			<Italian>-- ARSENALE --</Italian>
-			<Chinesesimp>-- 军火库 --</Chinesesimp>
-			<Chinese>-- 軍火庫 --</Chinese>
-			<Turkish>-- CEPHANE --</Turkish>
-			<Portuguese>-- ARSENAL --</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_LOAD_BOX">
-			<Original>-- LOAD CRATE</Original>
-			<French>-- CHARGER MUNITIONS</French>
-			<German>-- KISTE AUFLADEN</German>
-			<Spanish>-- CARGAR CAJA DE MUNICIÓN</Spanish>
-			<Russian>-- ЗАГРУЗИТЬ ЯЩИК С БОЕПРИПАСАМИ</Russian>
-			<Italian>-- CARICA CASSA</Italian>
-			<Chinesesimp>-- 装载货箱</Chinesesimp>
-			<Chinese>-- 裝載貨物</Chinese>
-			<Turkish>-- KUTUYU YÜKLE</Turkish>
-			<Portuguese>-- CARREGAR CAIXA NO TRANSPORTE</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_UNLOAD_BOX">
-			<Original>-- UNLOAD CRATES</Original>
-			<French>-- DECHARGER MUNITIONS</French>
-			<German>-- KISTEN ABLADEN</German>
-			<Spanish>-- DESCARGAR CAJA DE MUNICIÓN</Spanish>
-			<Russian>-- ВЫГРУЗИТЬ ЯЩИК С БОЕПРИПАСАМИ</Russian>
-			<Italian>-- SCARICA CASSA</Italian>
-			<Chinesesimp>-- 卸载货箱</Chinesesimp>
-			<Chinese>-- 卸載貨物</Chinese>
-			<Turkish>-- KUTUYU İNDİR</Turkish>
-			<Portuguese>-- DESCARREGAR CAIXAS</Portuguese>
-		</Key>
-		<Key ID="STR_BOX_LOADED">
-			<Original>Ammo box successfully loaded on the transport vehicle.</Original>
-			<French>La caisse de munitions a été chargée sur le véhicule de transport.</French>
-			<German>Munitionskiste erfolgreich auf das Transportfahrzeug geladen.</German>
-			<Spanish>Caja de munición cargada correctamente en el vehículo de transporte</Spanish>
-			<Russian>Ящик с боеприпасами загружен в транспортное средство</Russian>
-			<Italian>Cassa munizioni correttamente caricata sul camion da trasporto</Italian>
-			<Chinesesimp>货箱已装载到运输载具中。</Chinesesimp>
-			<Chinese>貨物已上至運輸載具中。</Chinese>
-			<Turkish>Mermi kutusu başarıyla taşıma aracına yüklendi.</Turkish>
-			<Portuguese>Caixa de munição carregada com sucesso no veículo de transporte.</Portuguese>
-		</Key>
-		<Key ID="STR_BOX_UNLOADED">
-			<Original>Ammo box successfully unloaded from the transport vehicle.</Original>
-			<French>La caisse de munitions a été déchargée du véhicule de transport.</French>
-			<German>Munitionskiste erfolgreich vom Transportfahrzeug abgeladen.</German>
-			<Spanish>Caja de munición descargada correctamente del vehículo de transporte</Spanish>
-			<Russian>Ящик с боеприпасами выгружен из транспортного средства</Russian>
-			<Italian>Cassa munizioni correttamente scaricata dal camion da trasporto</Italian>
-			<Chinesesimp>货箱已从运输载具中卸载。</Chinesesimp>
-			<Chinese>貨物已從運輸載具中卸下。</Chinese>
-			<Turkish>Mermi kutusu başarıyla taşıma aracından indirildi.</Turkish>
-			<Portuguese>Caixa de munição descarregada com sucesso do veículo de transporte.</Portuguese>
-		</Key>
-		<Key ID="STR_BOX_CANTLOAD">
-			<Original>There is no nearby vehicle capable of carrying the ammo box.</Original>
-			<French>Aucun véhicule à proximité capable de charger la caisse de munitions.</French>
-			<German>Kein Fahrzeug in der Nähe, das die Munitionskiste aufnehmen kann.</German>
-			<Spanish>No hay ningún vehículo cercano capaz de cagar la caja de munición</Spanish>
-			<Russian>Рядом нет техники способной перевозить ящики с боеприпасами.</Russian>
-			<Italian>Non ci sono veicoli vicino alla cassa munizioni capaci di caricarla</Italian>
-			<Chinesesimp>附近没有能够装载货箱的载具。</Chinesesimp>
-			<Chinese>附近沒有具備足夠空間裝載貨物的載具。</Chinese>
-			<Turkish>Yakınlarda bu kutuyu taşıyabilecek araç yok.</Turkish>
-			<Portuguese>Não existe veículo nas proximidades capaz de carregar a caixa de munição.</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_ACTION">
-			<Original>-- DEPLOY FOB --</Original>
-			<French>-- DEPLOYER FOB --</French>
-			<German>-- FOB BEREITSTELLEN --</German>
-			<Spanish>-- DESPLEGAR FOB --</Spanish>
-			<Russian>-- РАЗВЕРНУТЬ FOB --</Russian>
-			<Italian>-- COSTRUISCI FOB --</Italian>
-			<Chinesesimp>-- 部署前哨 --</Chinesesimp>
-			<Chinese>-- 佈署前線基地 --</Chinese>
-			<Turkish>-- FOB KUR --</Turkish>
-			<Portuguese>-- INSTALAR FOB --</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_BUILDING_IMPOSSIBLE">
-			<Original>Can't deploy a new FOB here, you must be at least %1 meters away from every other FOB. Nearest FOB is %2 meters away.</Original>
-			<French>Impossible de déployer une nouvelle FOB ici, vous devez être à au moins %1 mètres de toutes les autres FOB. La FOB la plus proche est à %2 mètres d'ici.</French>
-			<German>Kann hier keine FOB platzieren, du musst min. %1 Meter von der anderen FOB entfernt sein. Die nächste FOB ist %2 Meter entfernt.</German>
-			<Spanish>Imposible desplegar una nueva FOB aquí, debes estar al menos a 1% metros de cualquier otra FOB. La FOB más cercana está a %2 metros.</Spanish>
-			<Russian>Нельзя развернуть FOB здесь, вы должны находится в %1 метрах от другой FOB. Ближайшая FOB в %2 метрах.</Russian>
-			<Italian>Impossibile creare la nuova FOB qui, devi essere almeno %1 metri distante dalla FOB più vicina. La FOB più vicina si trova a %2 metri.</Italian>
-			<Chinesesimp>无法在此部署前哨，前哨之间的距离不得低于%1米。最近的前哨在%2米开外。</Chinesesimp>
-			<Chinese>無法在這裡佈署前線基地，前線基地之間的距離不得低於 %1 公尺，最近的前線基地離此 %2 公尺。</Chinese>
-			<Turkish>Buraya FOB koyamazsın. Diğer FOB'lerden %1 metre uzakta olmalısın. En yakındaki FOB %2 metre uzaklıkta.</Turkish>
-			<Portuguese>Não é possível instalar a FOB aqui, você precisa estar no mínimo a %1 metros de distância de outra FOB. A FOB mais próxima está a %2 metros.</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_BUILDING_IMPOSSIBLE_SECTOR">
-			<Original>Can't deploy a new FOB here, you must be at least %1 meters away from every capturable zone. Nearest zone is %2 meters away.</Original>
-			<French>Impossible de déployer une nouvelle FOB ici, vous devez être à au moins %1 mètres de toutes les zones capturables. La zone la plus proche est à %2 mètres d'ici.</French>
-			<German>Kann hier keine FOB platzieren, du musst min. %1 Meter von allen Sektoren entfernt sein. Der nächste Sektor ist %2 Meter entfernt.</German>
-			<Spanish>Imposible desplegar una nueva FOB aquí, debes estar al menos a %1 metros de cualquier zona capturable. La zona más cercana está a %2 metros</Spanish>
-			<Russian>Нельзя развернуть FOB здесь, вы должны находится в %1 метрах от захваченной зоны. Ближайшиая зона в %2 метрах.</Russian>
-			<Italian>Impossibile creare la nuova FOB qui, devi essere almeno %1 metri distante dalla Zona catturabile più vicina. La Zona Catturabile più vicina si trova a %2 metri.</Italian>
-			<Chinesesimp>无法在此部署前哨，前哨与战区之间的距离不得低于%1米。最近的战区在%2米开外。</Chinesesimp>
-			<Chinese>無法在此佈署前線基地，前線基地與戰區之間的距離不得低於 %1 公尺，最近的戰區離此 %2 公尺。</Chinese>
-			<Turkish>Buraya FOB açılamaz. Ele geçirilebilir bölgelerden en az %1 metre uzakta olmalısınız. En yakın bölge %2 metre uzakta.</Turkish>
-			<Portuguese>Não é possível instalar a FOB aqui, você precisa estar no mínimo a %1 metros de distância de qualquer setor capturável. O setor mais próima está a %2 metros.</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_ERROR_WATER">
-			<Original>Can't build on water.</Original>
-			<French>Impossible de construire sur l'eau.</French>
-			<German>Kann nicht auf Wasser gebaut werden.</German>
-			<Spanish>Imposible construir sobre el agua.</Spanish>
-			<Russian>Нельзя построить в воде.</Russian>
-			<Italian>Impossibile costruire sull'acqua.</Italian>
-			<Chinesesimp>无法在水面上建造。</Chinesesimp>
-			<Chinese>無法建造在水面上。</Chinese>
-			<Turkish>Su içine kurulamaz.</Turkish>
-			<Portuguese>Não é possível construir na água.</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_ERROR_DISTANCE">
-			<Original>Can't build further than %1 meters away from the FOB.</Original>
-			<French>Impossible de construire à plus de %1 mètres de la FOB.</French>
-			<German>Kann nicht weiter als %1 Meter von der FOB entfernt sein.</German>
-			<Spanish>Imposible construir más lejos de %1 metros de la FOB</Spanish>
-			<Russian>Нельзя построить дальше чем  в %1 метрах от FOB.</Russian>
-			<Italian>Impossibile costruire a più di %1 metri dalla FOB.</Italian>
-			<Chinesesimp>无法在超出前哨%1米外的区域建造。</Chinesesimp>
-			<Chinese>無法在距離前線基地 %1 公尺外的區域建造</Chinese>
-			<Turkish>Diğer FOB'den %1 metre uzakta olmalısınız.</Turkish>
-			<Portuguese>Não é possível construir com mais de %1 metros de distância da FOB.</Portuguese>
-		</Key>
-		<Key ID="STR_FOBBOX">
-			<Original>FOB Container</Original>
-			<French>Container FOB</French>
-			<German>FOB Container</German>
-			<Spanish>Contenedor de FOB</Spanish>
-			<Russian>FOB контейнер</Russian>
-			<Chinesesimp>前哨部署柜</Chinesesimp>
-			<Chinese>前線基地貨櫃</Chinese>
-			<Turkish>FOB Konternırı</Turkish>
-			<Portuguese>FOB no Contêiner</Portuguese>
-		</Key>
-		<Key ID="STR_FOBTRUCK">
-			<Original>FOB Truck</Original>
-			<French>Camion FOB</French>
-			<German>FOB Lastwagen</German>
-			<Spanish>Camión de FOB</Spanish>
-			<Russian>FOB грузовик </Russian>
-			<Italian>Camion FOB</Italian>
-			<Chinesesimp>前哨部署车</Chinesesimp>
-			<Chinese>前線基地車</Chinese>
-			<Turkish>FOB Kamyoneti</Turkish>
-			<Portuguese>FOB transportável</Portuguese>
-		</Key>
-		<Key ID="STR_RESPAWN_TRUCK">
-			<Original>Mobile respawn</Original>
-			<French>Respawn mobile</French>
-			<German>Mobiler Respawn</German>
-			<Spanish>Respawn móvil</Spanish>
-			<Russian>Мобильная КШМ</Russian>
-			<Italian>Respawn Mobile</Italian>
-			<Chinesesimp>机动复活载具</Chinesesimp>
-			<Chinese>機動復活載具</Chinese>
-			<Turkish>Respawn Aracı</Turkish>
-			<Portuguese>Respawn móvel</Portuguese>
-		</Key>
-		<Key ID="STR_ARSENAL_BOX">
-			<Original>Arsenal box</Original>
-			<French>Caisse à arsenal</French>
-			<German>Arsenalkiste</German>
-			<Spanish>Caja de Arsenal</Spanish>
-			<Russian>Ящик с арсеналом</Russian>
-			<Italian>Cassa Arsenale</Italian>
-			<Chinesesimp>军火箱</Chinesesimp>
-			<Chinese>軍火箱</Chinese>
-			<Turkish>Arsenal Kutusu</Turkish>
-			<Portuguese>Caixa de Arsenal</Portuguese>
-		</Key>
-		<Key ID="STR_DEPLOY_TITLE">
-			<Original>DEPLOYMENT</Original>
-			<French>DEPLOIEMENT</French>
-			<German>EINSATZ</German>
-			<Spanish>DESPLIEGUE</Spanish>
-			<Russian>ДИСЛОКАЦИЯ</Russian>
-			<Italian>SCHIERAMENTO</Italian>
-			<Chinesesimp>部署</Chinesesimp>
-			<Chinese>佈署</Chinese>
-			<Turkish>CANLANMA</Turkish>
-			<Portuguese>MOBILIZAÇÃO</Portuguese>
-		</Key>
-		<Key ID="STR_DEPLOY_BUTTON">
-			<Original>Deploy</Original>
-			<French>Déploiment</French>
-			<German>Einsetzen</German>
-			<Spanish>Desplegar</Spanish>
-			<Russian>РАЗМЕСТИТЬ</Russian>
-			<Italian>Schierati</Italian>
-			<Chinesesimp>部署</Chinesesimp>
-			<Chinese>佈署</Chinese>
-			<Turkish>Canlan</Turkish>
-			<Portuguese>Mobilizar</Portuguese>
-		</Key>
-		<Key ID="STR_DEPLOY_ACTION">
-			<Original>-- REDEPLOY --</Original>
-			<French>-- REDEPLOIEMENT --</French>
-			<German>-- NEU EINSETZEN --</German>
-			<Spanish>-- REDESPLEGAR --</Spanish>
-			<Russian>-- ПЕРЕМЕСТИТЬСЯ --</Russian>
-			<Italian>-- RISCHIERAMENTO --</Italian>
-			<Chinesesimp>-- 重新部署 --</Chinesesimp>
-			<Chinese>-- 重新佈署 --</Chinese>
-			<Turkish>-- YENİDEN SEÇ --</Turkish>
-			<Portuguese>-- REMOBILIZAR --</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_CREW">
-			<Original>Build (Crew)</Original>
-			<French>Construire (Equipage)</French>
-			<German>Bauen (Besatzung)</German>
-			<Spanish>Construir (Equipo)</Spanish>
-			<Russian>Создать (Экипаж)</Russian>
-			<Italian>Crea Equipaggio</Italian>
-			<Chinesesimp>建造（含成员）</Chinesesimp>
-			<Chinese>建造（包含成員）</Chinese>
-			<Turkish>Ekip Yarat</Turkish>
-			<Portuguese>Construir (tripulado)</Portuguese>
-		</Key>
-		<Key ID="STR_LIGHT_RIFLE_SQUAD">
-			<Original>Light Rifle Squad</Original>
-			<French>Escouade Fusiliers Légère</French>
-			<German>Leichter Waffentrupp</German>
-			<Spanish>Escuadra de fusileros ligeros</Spanish>
-			<Russian>Легкий Стрелковый Отряд</Russian>
-			<Italian>Squadra Fucilieri Leggeri</Italian>
-			<Chinesesimp>轻装步枪班</Chinesesimp>
-			<Chinese>輕裝步槍班</Chinese>
-			<Turkish>Hafif Silah Timi</Turkish>
-			<Portuguese>Grupo de Combate de Infantaria Leve</Portuguese>
-		</Key>
-		<Key ID="STR_RIFLE_SQUAD">
-			<Original>Heavy Rifle Squad</Original>
-			<French>Escouade Fusiliers Lourde</French>
-			<German>Schwerer Waffentrupp</German>
-			<Spanish>Escuadra de fusileros pesados</Spanish>
-			<Russian>Тяжёлый Стрелковый Отряд</Russian>
-			<Italian>Squadra Fucilieri Pesanti</Italian>
-			<Chinesesimp>重装步枪班</Chinesesimp>
-			<Chinese>重裝步槍班</Chinese>
-			<Turkish>Ağır Silah Timi</Turkish>
-			<Portuguese>Grupo de Combate de Infantaria Pesada</Portuguese>
-		</Key>
-		<Key ID="STR_AT_SQUAD">
-			<Original>AT Squad</Original>
-			<French>Escouade AT</French>
-			<German>Panzerbekämpfungstrupp</German>
-			<Spanish>Escuadra Antitanque</Spanish>
-			<Russian>Отряд ПТ</Russian>
-			<Italian>Squadra Anticarro</Italian>
-			<Chinesesimp>反坦克班</Chinesesimp>
-			<Chinese>反坦班</Chinese>
-			<Turkish>Anti-Tank Timi</Turkish>
-			<Portuguese>Grupo de Combate Anti-Blindagem</Portuguese>
-		</Key>
-		<Key ID="STR_AA_SQUAD">
-			<Original>AA Squad</Original>
-			<French>Escouade AA</French>
-			<German>Luftabwehrtrupp</German>
-			<Spanish>Escuadra Antiaérea</Spanish>
-			<Russian>Отряд ПВО</Russian>
-			<Italian>Squadra Antiaerea</Italian>
-			<Chinesesimp>防空班</Chinesesimp>
-			<Chinese>防空班</Chinese>
-			<Turkish>Anti-Hava Timi</Turkish>
-			<Portuguese>Grupo de Combate Anti-Aéreo</Portuguese>
-		</Key>
-		<Key ID="STR_RECON_SQUAD">
-			<Original>Recon Squad</Original>
-			<French>Escouade Recon</French>
-			<German>Aufklärungstrupp</German>
-			<Spanish>Escuadra de reconocimiento</Spanish>
-			<Russian>Отряд Разведчиков</Russian>
-			<Italian>Squadra Ricognitori</Italian>
-			<Chinesesimp>侦察班</Chinesesimp>
-			<Chinese>偵查班</Chinese>
-			<Turkish>Gözcü Timi</Turkish>
-			<Portuguese>Grupo de Combate de Reconhecimento</Portuguese>
-		</Key>
-		<Key ID="STR_PARA_SQUAD">
-			<Original>Paratroopers Squad</Original>
-			<French>Escouade Parachutistes</French>
-			<German>Fallschirmjägertrupp</German>
-			<Spanish>Escuadra de paracaidistas</Spanish>
-			<Russian>Отряд Десантников</Russian>
-			<Italian>Squadra Paracadutisti</Italian>
-			<Chinesesimp>空降班</Chinesesimp>
-			<Chinese>傘兵班</Chinese>
-			<Turkish>Paraşütçü Asker Timi</Turkish>
-			<Portuguese>Grupo de Combate de Paraquedistas</Portuguese>
-		</Key>
-		<Key ID="STR_UNITCAP">
-			<Original>Unit cap</Original>
-			<French>Limite</French>
-			<German>Einheitenbegrenzung</German>
-			<Spanish>Límite de unidades</Spanish>
-			<Russian>Мобилизованных</Russian>
-			<Italian>Limite delle Unità</Italian>
-			<Chinesesimp>单位上限</Chinesesimp>
-			<Chinese>單位上限</Chinese>
-			<Turkish>Ünit Limiti</Turkish>
-			<Portuguese>Limite de unidades</Portuguese>
-		</Key>
-		<Key ID="STR_WIPE_TITLE">
-			<Original>Wipe savegame</Original>
-			<French>Effacer la sauvegarde</French>
-			<German>Spielstand löschen</German>
-			<Spanish>Borrar partida guardada</Spanish>
-			<Russian>Удалить сохранённый прогресс</Russian>
-			<Italian>Elimina Salvataggi</Italian>
-			<Chinesesimp>清空存档</Chinesesimp>
-			<Chinese>刪除存檔</Chinese>
-			<Turkish>Kayıtlı oyunu sil</Turkish>
-			<Portuguese>Apagar jogo salvo</Portuguese>
-		</Key>
-		<Key ID="STR_WIPE_TITLE_2">
-			<Original>Confirm : wipe savegame</Original>
-			<French>Confirmer : effacer la sauvegarde</French>
-			<German>Bestätige: Spielstand löschen</German>
-			<Spanish>Confirmar : Borrar partida guardada</Spanish>
-			<Russian>Подтвердить : Удалить сохранённый прогресс</Russian>
-			<Italian>Confermare : Elimina Salvataggi</Italian>
-			<Chinesesimp>确认 ： 清空存档</Chinesesimp>
-			<Chinese>確認：刪除存檔</Chinese>
-			<Turkish>Onayla : Kayıtlı oyunu sil</Turkish>
-			<Portuguese>Confirmar: Apagar jogo salvo</Portuguese>
-		</Key>
-		<Key ID="STR_WIPE_NO">
-			<Original>No</Original>
-			<French>Non</French>
-			<German>Nein</German>
-			<Spanish>No</Spanish>
-			<Russian>Нет</Russian>
-			<Italian>No</Italian>
-			<Chinesesimp>否</Chinesesimp>
-			<Chinese>否</Chinese>
-			<Turkish>Hayır</Turkish>
-			<Portuguese>Não</Portuguese>
-		</Key>
-		<Key ID="STR_WIPE_YES">
-			<Original>!! THE SAVEGAME WILL BE WIPED, NO RECOVERY POSSIBLE !!</Original>
-			<French>!! LA SAUVEGARDE SERA EFFACEE SANS RECUPERATION POSSIBLE !!</French>
-			<German>!! SPIELSTAND WIRD GELÖSCHT, KEIN WIEDERHERSTELLEN MÖGLICH !!</German>
-			<Spanish>!! LA PARTIDA GUARDADA SERÁ BORRADA, SIN RECUPERACIÓN POSIBLE !!</Spanish>
-			<Russian>!! СОХРАНЁННЫЙ ПРОГРЕСС БУДЕТ УДАЛЕН, ВОССТАНОВИТЬ БУДЕТ НЕВОЗМОЖНО !!</Russian>
-			<Italian>!! I SALVATAGGI SARANNO ELIMINATI, SENZA POSSIBILITA' DI RECUPERO !!</Italian>
-			<Chinesesimp>!!存档将被移除，且无法恢复!!</Chinesesimp>
-			<Chinese>！！警告，存檔將被刪除，且無法復原！！</Chinese>
-			<Turkish>!! KAYITLI OYUN SİLİNECEKTİR, GERİ GETİRELEMEZ !!</Turkish>
-			<Portuguese>!! O JOGO SALVO SERÁ APAGADO, NÃO SERÁ POSSÍVEL RECUPERÁ-LO !!</Portuguese>
-		</Key>
-		<Key ID="STR_UNFLIP">
-			<Original>-- UNFLIP</Original>
-			<French>-- UNFLIP</French>
-			<German>-- UMDREHEN</German>
-			<Spanish>-- RECOLOCAR VEHÍCULO</Spanish>
-			<Russian>-- ПЕРЕВЕРНУТЬ</Russian>
-			<Italian>-- RIADDRIZZA</Italian>
-			<Chinesesimp>-- 复位</Chinesesimp>
-			<Chinese>-- 翻正</Chinese>
-			<Turkish>-- TERS DÖNDÜR</Turkish>
-			<Portuguese>-- DESVIRAR</Portuguese>
-		</Key>
-		<Key ID="STR_GRID">
-			<Original>-- Grid mode</Original>
-			<French>-- Mode grille</French>
-			<German>-- Rastermodus</German>
-			<Spanish>-- Modo rejilla</Spanish>
-			<Russian>-- Режим сетки</Russian>
-			<Italian>-- Modalità Griglia</Italian>
-			<Chinesesimp>-- 网格模式</Chinesesimp>
-			<Chinese>-- 網格模式</Chinese>
-			<Turkish>-- Grid modu</Turkish>
-			<Portuguese>-- Modo "grid"</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_CAPTURE">
-			<Original>-- CAPTURE</Original>
-			<French>-- CAPTURER</French>
-			<German>-- GEFANGENNEHMEN</German>
-			<Spanish>-- CAPTURAR</Spanish>
-			<Russian>-- ЗАХВАТИТЬ</Russian>
-			<Italian>-- CATTURA</Italian>
-			<Chinesesimp>-- 俘虏</Chinesesimp>
-			<Chinese>-- 俘虜</Chinese>
-			<Turkish>-- YAKALA</Turkish>
-			<Portuguese>-- CAPTURAR</Portuguese>
-		</Key>
-		<Key ID="STR_SQUAD_MEMBER">
-			<Original>Squad member</Original>
-			<French>Membre d'escouade</French>
-			<German>Truppenmitglieder</German>
-			<Spanish>Miembro de escuadra</Spanish>
-			<Russian>Член отряда</Russian>
-			<Italian>Membri Squadra</Italian>
-			<Chinesesimp>班组成员</Chinesesimp>
-			<Chinese>班級成員</Chinese>
-			<Turkish>Tim üyesi</Turkish>
-			<Portuguese>Membro do Grupo</Portuguese>
-		</Key>
-		<Key ID="STR_SPAWN_NEAR">
-			<Original>Near</Original>
-			<French>Près de</French>
-			<German>Nah</German>
-			<Spanish>Cerca</Spanish>
-			<Russian>Рядом</Russian>
-			<Italian>Vicino</Italian>
-			<Chinesesimp>就近</Chinesesimp>
-			<Chinese>附近</Chinese>
-			<Turkish>Yakın</Turkish>
-			<Portuguese>Próximo de</Portuguese>
-		</Key>
-		<Key ID="STR_RECYCLE">
-			<Original>-- RECYCLE</Original>
-			<French>-- RECYCLER</French>
-			<German>-- WIEDERVERWERTEN</German>
-			<Spanish>-- RECICLAR</Spanish>
-			<Russian>-- УТИЛИЗИРОВАТЬ</Russian>
-			<Italian>-- RICICLA</Italian>
-			<Chinesesimp>-- 回收</Chinesesimp>
-			<Chinese>-- 回收</Chinese>
-			<Turkish>-- GERİ DÖNÜŞTÜR</Turkish>
-			<Portuguese>-- RECICLAR</Portuguese>
-		</Key>
-		<Key ID="STR_RECYCLING">
-			<Original>Recycling</Original>
-			<French>Recyclage</French>
-			<German>Wiederverwerten</German>
-			<Spanish>Reciclando</Spanish>
-			<Russian>Утилизация</Russian>
-			<Italian>Riciclando</Italian>
-			<Chinesesimp>正在回收</Chinesesimp>
-			<Chinese>回收中</Chinese>
-			<Turkish>Geri Dönüştürme</Turkish>
-			<Portuguese>Reciclando</Portuguese>
-		</Key>
-		<Key ID="STR_RECYCLING_YIELD">
-			<Original>Recycling this %1 will yield:</Original>
-			<French>Le recyclage de %1 rapportera :</French>
-			<German>Die Wiederverwertung von %1 erbringt:</German>
-			<Spanish>Reciclando este %1 obtienes:</Spanish>
-			<Russian>Утилизируя %1 получим </Russian>
-			<Italian>Riciclando questo %1 otterrai:</Italian>
-			<Chinesesimp>回收%1将会获得：</Chinesesimp>
-			<Chinese>回收%1將會獲得：</Chinese>
-			<Turkish>Geri dönüştürme %1 verecektir:</Turkish>
-			<Portuguese>Reciclando este %1, irá obter:</Portuguese>
-		</Key>
-		<Key ID="STR_RECYCLING_PROCEED">
-			<Original>Recycle</Original>
-			<French>Recycler</French>
-			<German>Wiederverwerten</German>
-			<Spanish>Reciclar</Spanish>
-			<Russian>Утилизировать</Russian>
-			<Italian>Riciclato</Italian>
-			<Chinesesimp>回收</Chinesesimp>
-			<Chinese>回收</Chinese>
-			<Turkish>Geri Dönüştür</Turkish>
-			<Portuguese>Reciclar</Portuguese>
-		</Key>
-		<Key ID="STR_RECYCLING_CANCEL">
-			<Original>Cancel</Original>
-			<French>Annuler</French>
-			<German>Abbrechen</German>
-			<Spanish>Cancelar</Spanish>
-			<Russian>Отмена</Russian>
-			<Italian>Annulla</Italian>
-			<Chinesesimp>取消</Chinesesimp>
-			<Chinese>取消</Chinese>
-			<Turkish>İptal</Turkish>
-			<Portuguese>Cancelar</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORCAPTURED_TITLE">
-			<Original>SECTOR CAPTURED</Original>
-			<French>SECTEUR CAPTURE</French>
-			<German>SEKTOR EINGENOMMEN</German>
-			<Spanish>SECTOR CAPTURADO</Spanish>
-			<Russian>ЗОНА ЗАХВАЧЕНА</Russian>
-			<Italian>SETTORE CATTURATO</Italian>
-			<Chinesesimp>战区已占领</Chinesesimp>
-			<Chinese>戰區已占領</Chinese>
-			<Turkish>SEKTÖR ELE GEÇİRİLDİ</Turkish>
-			<Portuguese>SETOR CAPTURADO</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORCAPTURED_TEXT">
-			<Original>Our forces have captured %1.</Original>
-			<French>Nos forces ont capturé %1.</French>
-			<German>Unsere Truppen haben %1 eingenommen.</German>
-			<Spanish>Nuestras fuerzas han capturado %1</Spanish>
-			<Russian>Наши войска захватили %1.</Russian>
-			<Italian>Le nostre unità hanno catturato %1</Italian>
-			<Chinesesimp>我军部队已占领%1。</Chinesesimp>
-			<Chinese>我軍已佔領 %1。</Chinese>
-			<Turkish>Birliklerimiz %1 'i almayı başardı</Turkish>
-			<Portuguese>Nossas forças capturaram %1.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORATTACKED_TITLE">
-			<Original>SECTOR ATTACKED</Original>
-			<French>SECTEUR ATTAQUE</French>
-			<German>SEKTOR ANGEGRIFFEN</German>
-			<Spanish>SECTOR ATACADO</Spanish>
-			<Russian>ЗОНА АТАКОВАНА</Russian>
-			<Italian>SETTORE SOTTO ATTACCO</Italian>
-			<Chinesesimp>战区遭到攻击</Chinesesimp>
-			<Chinese>戰區遭到襲擊</Chinese>
-			<Turkish>SEKTÖR SALDIRI ALTINDA</Turkish>
-			<Portuguese>SETOR ATACADO</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORATTACKED_TEXT">
-			<Original>Hostiles forces are attacking %1!</Original>
-			<French>Des forces hostiles attaquent %1!</French>
-			<German>Gegnerische Truppen greifen %1 an!</German>
-			<Spanish>Fuerzas hostiles están atacando %1</Spanish>
-			<Russian>Вражеские силы атакуют %1!</Russian>
-			<Italian>Forze ostili attaccano %1!</Italian>
-			<Chinesesimp>敌军部队正在进攻%1！</Chinesesimp>
-			<Chinese>敵軍正在進攻 %1！</Chinese>
-			<Turkish>Düşman birlikleri %1 'e saldırıyor'</Turkish>
-			<Portuguese>Forças hostis estão atacando %1!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORLOST_TITLE">
-			<Original>SECTOR LOST</Original>
-			<French>SECTEUR LOST</French>
-			<German>SEKTOR VERLOREN</German>
-			<Spanish>SECTOR PERDIDO</Spanish>
-			<Russian>ЗОНА ПОТЕРЯНА</Russian>
-			<Italian>SETTORE PERSO</Italian>
-			<Chinesesimp>战区已丢失</Chinesesimp>
-			<Chinese>已失去戰區</Chinese>
-			<Turkish>SEKTÖR KAYBEDİLDİ</Turkish>
-			<Portuguese>SETOR PERDIDO</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORLOST_TEXT">
-			<Original>We have lost control over %1!</Original>
-			<French>Nous avons perdu le contrôle de %1!</French>
-			<German>Wir haben die Kontrolle über %1 verloren!</German>
-			<Spanish>Hemos perdido el control sobre %1!</Spanish>
-			<Russian>Мы потеряли контроль над %1!</Russian>
-			<Italian>Abbiamo perso il controllo di %1!</Italian>
-			<Chinesesimp>我们失去了%1的控制权！</Chinesesimp>
-			<Chinese>我們失去了 %1 ！</Chinese>
-			<Turkish>%1 'deki hakimiyetimizi kaybettik!'</Turkish>
-			<Portuguese>Perdemos controle de %1!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORSAFE_TITLE">
-			<Original>SECTOR SAFE</Original>
-			<French>SECTEUR SECURISE</French>
-			<German>SEKTOR SICHER</German>
-			<Spanish>SECTOR SEGURO</Spanish>
-			<Russian>ЗОНА В БЕЗОПАСНОСТИ</Russian>
-			<Italian>SETTORE AL SICURO</Italian>
-			<Chinesesimp>战区已安全</Chinesesimp>
-			<Chinese>戰區已安全</Chinese>
-			<Turkish>SEKTÖR GÜVENDE</Turkish>
-			<Portuguese>SETOR SEGURO</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECTORSAFE_TEXT">
-			<Original>%1 is no longer under threat.</Original>
-			<French>%1 n'est plus menacé(e).</French>
-			<German>%1 ist außer Gefahr.</German>
-			<Spanish>%1 ya no está bajo amenaza.</Spanish>
-			<Russian>%1 больше не под угрозой.</Russian>
-			<Italian>%1 non è più sotto attacco.</Italian>
-			<Chinesesimp>%1脱离了危险。</Chinesesimp>
-			<Chinese>%1 脫離了危險。</Chinese>
-			<Turkish>%1 tehlike altında değil.</Turkish>
-			<Portuguese>%1 não está mais sob ameaça.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBBUILT_TITLE">
-			<Original>NEW FOB BUILT</Original>
-			<French>NOUVELLE FOB</French>
-			<German>NEUE FOB GEBAUT</German>
-			<Spanish>NUEVA FOB CONSTRUIDA</Spanish>
-			<Russian>НОВАЯ FOB ПОСТРОЕНА</Russian>
-			<Italian>NUOVA FOB COSTRUITA</Italian>
-			<Chinesesimp>新的前哨部署完成</Chinesesimp>
-			<Chinese>新的前線基地佈署完畢</Chinese>
-			<Turkish>YENİ FOB KURULDU</Turkish>
-			<Portuguese>NOVA FOB CONSTRUÍDA</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBBUILT_TEXT">
-			<Original>FOB %1 is now operational.</Original>
-			<French>La FOB %1 est opérationnelle.</French>
-			<German>FOB %1 nun funktionsfähig.</German>
-			<Spanish>La FOB %1 es operacional</Spanish>
-			<Russian>FOB %1 сейчас действует.</Russian>
-			<Italian>La FOB %1 è operativa.</Italian>
-			<Chinesesimp>%1前哨现已入役。</Chinesesimp>
-			<Chinese>前線基地 %1 已啟用。</Chinese>
-			<Turkish>FOB %1 şimdi yürürlükte.</Turkish>
-			<Portuguese>FOB %1 está operacional.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBSAFE_TITLE">
-			<Original>FOB SAFE</Original>
-			<French>FOB SECURISEE</French>
-			<German>FOB SICHER</German>
-			<Spanish>FOB SEGURA</Spanish>
-			<Russian>FOB В БЕЗОПАСНОСТИ</Russian>
-			<Italian>FOB AL SICURO</Italian>
-			<Chinesesimp>前哨已安全</Chinesesimp>
-			<Chinese>前線基地已安全</Chinese>
-			<Turkish>FOB GÜVENDE</Turkish>
-			<Portuguese>FOB SEGURA</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBSAFE_TEXT">
-			<Original>FOB %1 is no longer under threat.</Original>
-			<French>La FOB %1 n'est plus menacée.</French>
-			<German>FOB %1 ist außer Gefahr.</German>
-			<Spanish>FOB %1 ya no está bajo amenaza</Spanish>
-			<Russian>FOB %1 больше не находится под угрозой.</Russian>
-			<Italian>La FOB %1 non è più in pericolo.</Italian>
-			<Chinesesimp>%1前哨脱离了危险。</Chinesesimp>
-			<Chinese>前線基地 %1 已脫離危險。</Chinese>
-			<Turkish>FOB %1 artık güvende.</Turkish>
-			<Portuguese>FOB %1 não está mais sob ameaça.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBATTACKED_TITLE">
-			<Original>FOB ATTACKED</Original>
-			<French>FOB ATTAQUEE</French>
-			<German>FOB ANGEGRIFFEN</German>
-			<Spanish>FOB ATACADA</Spanish>
-			<Russian>FOB АТАКОВАНА</Russian>
-			<Italian>FOB SOTTO ATTACCO</Italian>
-			<Chinesesimp>前哨遭到攻击</Chinesesimp>
-			<Turkish>FOB SALDIRI ALTINDA</Turkish>
-			<Portuguese>FOB ATACADA</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBATTACKED_TEXT">
-			<Original>FOB %1 is under attack!</Original>
-			<French>La FOB %1 est attaquée !</French>
-			<German>FOB %1 wird angegriffen !</German>
-			<Spanish>FOB %1 está bajo ataque!</Spanish>
-			<Russian>FOB %1 атакована!</Russian>
-			<Italian>la FOB %1 è sotto attacco!</Italian>
-			<Chinesesimp>%1前哨受到了攻击！</Chinesesimp>
-			<Chinese>前線基地 %1 受到攻擊！</Chinese>
-			<Turkish>FOB %1 Saldırı altında</Turkish>
-			<Portuguese>FOB %1 está sob ataque!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBLOST_TITLE">
-			<Original>FOB DESTROYED</Original>
-			<French>FOB DETRUITE</French>
-			<German>FOB ZERSTÖRT</German>
-			<Spanish>FOB DESTRUIDA</Spanish>
-			<Russian>FOB УНИЧТОЖЕНА</Russian>
-			<Italian>FOB DISTRUTTA</Italian>
-			<Chinesesimp>前哨被摧毁</Chinesesimp>
-			<Chinese>前線基地被摧毀</Chinese>
-			<Turkish>FOB YOK EDİLDİ</Turkish>
-			<Portuguese>FOB DESTRUÍDA</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOBLOST_TEXT">
-			<Original>FOB %1 has been destroyed!</Original>
-			<French>La FOB %1 a été détruite !</French>
-			<German>FOB %1 wurde zerstört!</German>
-			<Spanish>La FOB %1 ha sido destruida!</Spanish>
-			<Russian>FOB %1 была уничтожена!</Russian>
-			<Italian>La FOB %1 è stata distrutta!</Italian>
-			<Chinesesimp>%1前哨被摧毁了！</Chinesesimp>
-			<Turkish>FOB %1 kaybedildi!</Turkish>
-			<Portuguese>FOB %1 foi destruída!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_BATTLEGROUP_TITLE">
-			<Original>HOSTILE FORCES INCOMING</Original>
-			<French>FORCES HOSTILES EN APPROCHE</French>
-			<German>GEGNERISCHE TRUPPEN TREFFEN EIN</German>
-			<Spanish>FUERZAS HOSTILES ACERCÁNDOSE</Spanish>
-			<Russian>ПОДХОДЯТ ВРАЖЕСКИЕ СИЛЫ</Russian>
-			<Italian>FORZE OSTILI IN ARRIVO</Italian>
-			<Chinesesimp>敌军部队接近中</Chinesesimp>
-			<Chinese>敵軍靠近中</Chinese>
-			<Turkish>DÜŞMAN BİRLİKLERİ GELİYOR</Turkish>
-			<Portuguese>FORÇAS HOSTIS A CAMINHO</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_BATTLEGROUP_TEXT">
-			<Original>Hostile forces spotted near %1.</Original>
-			<French>Forces hostiles repérées près de %1.</French>
-			<German>Gegnerische Truppen nahe %1 gesichtet.</German>
-			<Spanish>Fuerzas hosstiles avistadas cerca de %1</Spanish>
-			<Russian>Вражеские силы замечены рядом с %1.</Russian>
-			<Italian>Forze ostili avvistate vicino %1</Italian>
-			<Chinesesimp>%1附近发现了敌军部队。</Chinesesimp>
-			<Chinese>%1 附近發現了敵方的部隊</Chinese>
-			<Turkish>DÜŞMANLAR %1 yakınlarında göründü.</Turkish>
-			<Portuguese>Forças hostis identificadas nas proximidades de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_INTEL_TITLE">
-			<Original>NEW INTELLIGENCE</Original>
-			<French>NOUVEAUX RENSEIGNEMENTS</French>
-			<German>NEUE INFORMATIONEN</German>
-			<Spanish>NUEVA INTELIGENCIA</Spanish>
-			<Russian>НОВЫЕ РАЗВЕДДАННЫЕ</Russian>
-			<Italian>NUOVO INTEL</Italian>
-			<Chinesesimp>新情报</Chinesesimp>
-			<Chinese>新情報</Chinese>
-			<Turkish>YENİ İSTİHBAHRAT</Turkish>
-			<Portuguese>NOVA INTELIGÊNCIA</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_FOB_TEXT">
-			<Original>Hostile FOB near %1.</Original>
-			<French>FOB hostile près de %1.</French>
-			<German>Gegnerische FOB nahe %1.</German>
-			<Spanish>FOB hostil cerca de %1</Spanish>
-			<Russian>Вражеская FOB рядом %1.</Russian>
-			<Italian>FOB ostile vicino %1.</Italian>
-			<Chinesesimp>%1附近发现了敌军前哨。</Chinesesimp>
-			<Chinese>%1 附近發現了敵方的前線基地。</Chinese>
-			<Turkish>Düşman FOB'si %1 taraflarında.</Turkish>
-			<Portuguese>FOB hostil nas proximidades de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_PRISONER_TEXT">
-			<Original>We have interrogated a prisoner.</Original>
-			<French>Nous avons interroger un prisonnier.</French>
-			<German>Wir haben einen Gefangenen verhört.</German>
-			<Spanish>Hemos interrogado a un prisionero.</Spanish>
-			<Russian>Мы можем допросить пленного.</Russian>
-			<Italian>Abbiamo interrogato il prigioniero.</Italian>
-			<Chinesesimp>我们审讯了一名战犯。</Chinesesimp>
-			<Chinese>我們審問了一名俘虜。</Chinese>
-			<Turkish>Başarıyla bir tutsağı sorguladık.</Turkish>
-			<Portuguese>Interrogamos um prisioneiro.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_DOCUMENT_TEXT">
-			<Original>We have found secret documents.</Original>
-			<French>Nous avons trouvé des documents secrets</French>
-			<German>Wir haben geheime Dokumente gefunden.</German>
-			<Spanish>Hemos encontrado documentos secretos</Spanish>
-			<Russian>Мы нашли секретные документы.</Russian>
-			<Italian>Abbiamo trovato dei documenti segreti.</Italian>
-			<Chinesesimp>我们找到了机密文件。</Chinesesimp>
-			<Chinese>我們找到了機密文件。</Chinese>
-			<Turkish>Gizli istihbahrat dosyası bulduk.</Turkish>
-			<Portuguese>Localizamos documentos secretos.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECONDARY_TITLE">
-			<Original>SECONDARY OBJECTIVE</Original>
-			<French>OBJECTIF SECONDAIRE</French>
-			<German>SEKUNDÄRZIEL</German>
-			<Spanish>OBJETIVO SECUNDARIO</Spanish>
-			<Russian>ДОПОЛНИТЕЛЬНАЯ ЗАДАЧА</Russian>
-			<Italian>OBIETTIVI SECONDARI</Italian>
-			<Chinesesimp>次要目标</Chinesesimp>
-			<Chinese>次要任務</Chinese>
-			<Turkish>İKİNCİ GÖREV</Turkish>
-			<Portuguese>OBJETIVO SECUNDÁRIO</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SECONDARY_TEXT">
-			<Original>Hostile FOB destroyed</Original>
-			<French>FOB hostile détruite.</French>
-			<German>Gegnerische FOB zerstört.</German>
-			<Spanish>FOB hostil destruída</Spanish>
-			<Russian>Вражеская FOB уничтожена</Russian>
-			<Italian>FOB ostile distrutta.</Italian>
-			<Chinesesimp>敌军前哨已摧毁</Chinesesimp>
-			<Chinese>敵方前線基地已遭摧毀</Chinese>
-			<Turkish>Düşman FOB'si yok edildi.</Turkish>
-			<Portuguese>FOB hostil destruída</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_REINFORCEMENTS_TITLE">
-			<Original>HOSTILE REINFORCEMENTS</Original>
-			<French>RENFORTS HOSTILES</French>
-			<German>GEGNERISCHER NACHSCHUB</German>
-			<Spanish>REFUERZOS HOSTILES</Spanish>
-			<Russian>ВРАЖЕСКОЕ ПОДКРЕПЛЕНИЕ</Russian>
-			<Italian>RINFORZI OSTILI</Italian>
-			<Chinesesimp>敌军增援</Chinesesimp>
-			<Chinese>敵方增援</Chinese>
-			<Turkish>DÜŞMAN TAKVİYE KUVVETLERİ</Turkish>
-			<Portuguese>REFORÇOS HOSTIS</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_REINFORCEMENTS_TEXT">
-			<Original>Hostile forces reinforcing %1.</Original>
-			<French>Forces hostiles en renfort à %1.</French>
-			<German>Gegnerische Truppen verstärken %1.</German>
-			<Spanish>Fuerzas hostiles reforzando %1</Spanish>
-			<Russian>Вражеские подкрепления подходят в %1.</Russian>
-			<Italian>Forze ostili rinforzano le truppe su %1</Italian>
-			<Chinesesimp>敌军部队正在向%1增援。</Chinesesimp>
-			<Chinese>敵軍正在向 %1 增援。</Chinese>
-			<Turkish>Düşmanlar %1 'e takviye kuvvet yolladılar.'</Turkish>
-			<Portuguese>Forças hostis reforçando %1.</Portuguese>
-		</Key>
-		<Key ID="STR_VICTORY_TITLE">
-			<Original>BLUFOR VICTORY</Original>
-			<French>VICTOIRE BLUFOR</French>
-			<German>BLUFOR SIEGREICH</German>
-			<Spanish>VICTORIA DE BLUFOR</Spanish>
-			<Russian>СИНИЕ ПОБЕДИЛИ</Russian>
-			<Italian>VITTORIA PER I BLUFOR</Italian>
-			<Chinesesimp>我军胜利</Chinesesimp>
-			<Chinese>我軍勝利</Chinese>
-			<Turkish>BLUFOR ZAFERİ</Turkish>
-			<Portuguese>VITÓRIA DAS FORÇAS DA COALIZÃO (BLUFOR)</Portuguese>
-		</Key>
-		<Key ID="STR_VICTORY_TEXT">
-			<Original>You have liberated the island from the OPFOR oppression.</Original>
-			<French>Vous avez libéré Altis de l'oppression de l'OPFOR.</French>
-			<German>Du hast Altis von der OPFOR Besatzung befreit.</German>
-			<Spanish>Has liberado a Altis de la opresión del OPFOR</Spanish>
-			<Russian>Вы освободили Алтис от оккупации OPFOR.</Russian>
-			<Italian>Siete riusciti a liberare l'isola dall'oppressione degli OPFOR</Italian>
-			<Chinesesimp>你已将本岛从敌人的压迫中解救了出来。</Chinesesimp>
-			<Chinese>你已將從敵人的統治之中解放了此區域。</Chinese>
-			<Turkish>Bu adayı OPFOR işgalinden kurtardınız.</Turkish>
-			<Portuguese>Você libertou o território da opressão das tropas inimigas.</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_DAY">
-			<Original>days</Original>
-			<French>jours</French>
-			<German>Tage</German>
-			<Spanish>días</Spanish>
-			<Russian>дней</Russian>
-			<Italian>Giorni</Italian>
-			<Chinesesimp>日</Chinesesimp>
-			<Chinese>日</Chinese>
-			<Turkish>günler</Turkish>
-			<Portuguese>dias</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_HOURS">
-			<Original>hours</Original>
-			<French>heures</French>
-			<German>Stunden</German>
-			<Spanish>horas</Spanish>
-			<Russian>часов</Russian>
-			<Italian>Ore</Italian>
-			<Chinesesimp>时</Chinesesimp>
-			<Chinese>時</Chinese>
-			<Turkish>saatler</Turkish>
-			<Portuguese>horas</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_MINUTES">
-			<Original>minutes</Original>
-			<French>minutes</French>
-			<German>Minuten</German>
-			<Spanish>minutos</Spanish>
-			<Russian>минут</Russian>
-			<Italian>Minuti</Italian>
-			<Chinesesimp>分</Chinesesimp>
-			<Chinese>分</Chinese>
-			<Turkish>dakikalar</Turkish>
-			<Portuguese>minutos</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_SECONDS">
-			<Original>seconds</Original>
-			<French>secondes</French>
-			<German>Sekunden</German>
-			<Spanish>segundos</Spanish>
-			<Russian>секунд</Russian>
-			<Italian>Secondi</Italian>
-			<Chinesesimp>秒</Chinesesimp>
-			<Chinese>秒</Chinese>
-			<Turkish>saniyeler</Turkish>
-			<Portuguese>segundos</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_PLAYTIME">
-			<Original>Playtime:</Original>
-			<French>Temps de jeu :</French>
-			<German>Spielzeit:</German>
-			<Spanish>Tiempo de juego:</Spanish>
-			<Russian>Игрового времени:</Russian>
-			<Italian>tempo di Gioco:</Italian>
-			<Chinesesimp>游戏时间：</Chinesesimp>
-			<Chinese>遊戲時間：</Chinese>
-			<Turkish>Oynama süresi:</Turkish>
-			<Portuguese>Tempo de jogo:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_1">
-			<Original>OPFOR infantry killed:</Original>
-			<French>Infanterie OPFOR tuée :</French>
-			<German>OPFOR Infanterie getötet:</German>
-			<Spanish>Infantería OPFOR eliminada:</Spanish>
-			<Russian>OPFOR пехоты убито:</Russian>
-			<Italian>Fanteria OPFOR ha ucciso:</Italian>
-			<Chinesesimp>被击杀的敌军步兵：</Chinesesimp>
-			<Chinese>被擊殺的敵方步兵：</Chinese>
-			<Turkish>Öldürülen OPFOR:</Turkish>
-			<Portuguese>Baixas inimigas em combate:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_2">
-			<Original>OPFOR infantry killed by players:</Original>
-			<French>Infanterie OPFOR tuée par les joueurs :</French>
-			<German>OPFOR Infanterie von Spielern getötet:</German>
-			<Spanish>Infantería OPFOR eliminada por jugadores:</Spanish>
-			<Russian>OPFOR пехоты убито игроками:</Russian>
-			<Italian>Fanteria OPFOR uccisa da:</Italian>
-			<Chinesesimp>被玩家击杀的敌军步兵：</Chinesesimp>
-			<Chinese>被玩家擊殺的敵方步兵：</Chinese>
-			<Turkish>Oyuncular tarafından öldürülen OPFOR sayısı:</Turkish>
-			<Portuguese>Infantaria inimiga eliminada por jogadores:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_3">
-			<Original>BLUFOR infantry killed:</Original>
-			<French>Infanterie BLUFOR tuée :</French>
-			<German>BLUFOR Infanterie getötet:</German>
-			<Spanish>Infantería BLUFOR eliminada:</Spanish>
-			<Russian>BLUFOR пехоты убито:</Russian>
-			<Italian>Fanteria BLUFOR ha ucciso:</Italian>
-			<Chinesesimp>被击杀的我军步兵：</Chinesesimp>
-			<Chinese>被擊殺的我方步兵：</Chinese>
-			<Turkish>BLUFOR kayıpları:</Turkish>
-			<Portuguese>Baixas aliadas em combate:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_4">
-			<Original>Civilians killed:</Original>
-			<French>Civils tués :</French>
-			<German>Zivilisten getötet:</German>
-			<Spanish>Civiles asesinados:</Spanish>
-			<Russian>Гражданских убито:</Russian>
-			<Italian>Civile ha ucciso:</Italian>
-			<Chinesesimp>被击杀的平民：</Chinesesimp>
-			<Chinese>被擊殺的平民：</Chinese>
-			<Turkish>Öldürülen siviller:</Turkish>
-			<Portuguese>Civis mortos:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_5">
-			<Original>Civilians killed by players:</Original>
-			<French>Civils tués par les joueurs :</French>
-			<German>Zivilisten von Spielern getötet:</German>
-			<Spanish>Civiles asesinados por jugadores:</Spanish>
-			<Russian>Гражданских убито игроками:</Russian>
-			<Italian>Civile ucciso da:</Italian>
-			<Chinesesimp>被玩家击杀的平民：</Chinesesimp>
-			<Chinese>被玩家擊殺的平民：</Chinese>
-			<Turkish>Öldürülen siviller (oyuncular tarafından):</Turkish>
-			<Portuguese>Civis mortos por jogadores:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_6">
-			<Original>BLUFOR friendly fire incidents:</Original>
-			<French>Tirs fratricides BLUFOR :</French>
-			<German>BLUFOR Eigenbeschuss:</German>
-			<Spanish>Incidentes de fuego amigo en BLUFOR:</Spanish>
-			<Russian>BLUFOR дружественный огонь:</Russian>
-			<Italian>Fuoco amico tra i BLUFOR:</Italian>
-			<Chinesesimp>我军友军误击事件：</Chinesesimp>
-			<Chinese>友軍誤擊事件：</Chinese>
-			<Turkish>BLUFOR dost ateşi:</Turkish>
-			<Portuguese>Incidentes de fogo amigo:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_7">
-			<Original>OPFOR vehicles destroyed:</Original>
-			<French>Vehicules OPFOR détruits :</French>
-			<German>OPFOR Fahrzeuge zerstört:</German>
-			<Spanish>Vehículos OPFOR destruídos:</Spanish>
-			<Russian>OPFOR техники уничтожено:</Russian>
-			<Italian>Veicolo OPFOR distrutto:</Italian>
-			<Chinesesimp>敌军被摧毁的载具：</Chinesesimp>
-			<Chinese>敵軍被摧毀的載具：</Chinese>
-			<Turkish>OPFOR yokedilen araçları:</Turkish>
-			<Portuguese>Veículos inimigos destruídos:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_8">
-			<Original>OPFOR vehicles destroyed by players:</Original>
-			<French>Vehicules OPFOR détruits par les joueurs :</French>
-			<German>OPFOR Fahrzeuge von Spielern zerstört:</German>
-			<Spanish>Vehículos OPFOR destruídos por jugadores:</Spanish>
-			<Russian>OPFOR техники уничтожено игроками:</Russian>
-			<Italian>Veicolo OPFOR distrutto da:</Italian>
-			<Chinesesimp>被玩家摧毁的敌军载具：</Chinesesimp>
-			<Chinese>被玩家摧毀的敵軍載具：</Chinese>
-			<Turkish>OPFOR yokedilen araçları (oyuncular tarafından):</Turkish>
-			<Portuguese>Veículos inimigos destruídos por jogadores:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_9">
-			<Original>BLUFOR vehicles destroyed:</Original>
-			<French>Vehicules BLUFOR détruits :</French>
-			<German>BLUFOR Fahrzeuge zerstört:</German>
-			<Spanish>Vehículos BLUFOR destruídos:</Spanish>
-			<Russian>BLUFOR техники уничтожено:</Russian>
-			<Italian>Veicolo BLUFOR distrutto:</Italian>
-			<Chinesesimp>被摧毁的我军载具：</Chinesesimp>
-			<Chinese>被摧毀的我方載具：</Chinese>
-			<Turkish>BLUFOR yokedilen araçları:</Turkish>
-			<Portuguese>Veículos aliados destruídos:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_10">
-			<Original>BLUFOR vehicles built:</Original>
-			<French>Vehicules BLUFOR construits :</French>
-			<German>BLUFOR Fahrzeuge gebaut:</German>
-			<Spanish>Vehículos BLUFOR construidos:</Spanish>
-			<Russian>BLUFOR техники построено:</Russian>
-			<Italian>Veicolo BLUFOR creato:</Italian>
-			<Chinesesimp>我军建造的载具：</Chinesesimp>
-			<Chinese>我軍建造的載具：</Chinese>
-			<Turkish>BLUFOR yaratılan araçları:</Turkish>
-			<Portuguese>Veículos aliados construídos:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_11">
-			<Original>Vehicles recycled:</Original>
-			<French>Vehicules recyclés :</French>
-			<German>Fahrzeuge wiederaufbereitet:</German>
-			<Spanish>Vehículos reciclados:</Spanish>
-			<Russian>Техники утилизировано:</Russian>
-			<Italian>Veicolo riciclato:</Italian>
-			<Chinesesimp>回收的载具：</Chinesesimp>
-			<Chinese>回收的載具：</Chinese>
-			<Turkish>Geri dönüşüm olan araçlar:</Turkish>
-			<Portuguese>Veículos reciclados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_12">
-			<Original>Ammunition units spent:</Original>
-			<French>Unités de munitions dépensées :</French>
-			<German>Munitionseinheiten verbraucht:</German>
-			<Spanish>Unidades de munición gastadas:</Spanish>
-			<Russian>Единиц боеприпасов потрачено:</Russian>
-			<Italian>Punti munizione spesi:</Italian>
-			<Chinesesimp>消耗的弹药量：</Chinesesimp>
-			<Chinese>消耗的彈藥量：</Chinese>
-			<Turkish>Mermi mühimmati kullanımı:</Turkish>
-			<Portuguese>Unidades de munição utilizadas:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_13">
-			<Original>Sectors liberated:</Original>
-			<French>Secteurs libérés, delivrés :</French>
-			<German>Sektoren befreit:</German>
-			<Spanish>Sectores liberados:</Spanish>
-			<Russian>Зон освобождено:</Russian>
-			<Italian>Settore liberato:</Italian>
-			<Chinesesimp>解放的战区：</Chinesesimp>
-			<Chinese>解放的戰區：</Chinese>
-			<Turkish>Ele geçirilen sektörler:</Turkish>
-			<Portuguese>Setores liberados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_14">
-			<Original>Sectors lost:</Original>
-			<French>Secteurs perdus :</French>
-			<German>Sektoren verloren:</German>
-			<Spanish>Sectores perdidos:</Spanish>
-			<Russian>Зон потеряно:</Russian>
-			<Italian>Settore perso:</Italian>
-			<Chinesesimp>丢失的战区：</Chinesesimp>
-			<Chinese>失去的戰區：</Chinese>
-			<Turkish>Kaybedilen sektörler:</Turkish>
-			<Portuguese>Setores perdidos:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_15">
-			<Original>FOBs built:</Original>
-			<French>FOBs construites :</French>
-			<German>FOBs gebaut:</German>
-			<Spanish>FOBs construídas:</Spanish>
-			<Russian>FOB построено:</Russian>
-			<Italian>FOB costruita:</Italian>
-			<Chinesesimp>建造的前哨：</Chinesesimp>
-			<Chinese>建造的前線基地：</Chinese>
-			<Turkish>Kurulan FOB'ler:</Turkish>
-			<Portuguese>FOBs construídas:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_16">
-			<Original>FOBs lost:</Original>
-			<French>FOBs perdues :</French>
-			<German>FOBs verloren:</German>
-			<Spanish>FOB perdidas:</Spanish>
-			<Russian>FOB потеряно:</Russian>
-			<Italian>FOB persa:</Italian>
-			<Chinesesimp>损失的前哨：</Chinesesimp>
-			<Chinese>損失的前線基地：</Chinese>
-			<Turkish>Kaybedilen FOB'ler:</Turkish>
-			<Portuguese>FOBs perdidas:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_17">
-			<Original>Secondary objectives accomplished:</Original>
-			<French>Objectifs secondaires accomplis :</French>
-			<German>Sekundärziele erreicht:</German>
-			<Spanish>Objetivos secundarios conseguidos:</Spanish>
-			<Russian>Вторичных заданий выполнено:</Russian>
-			<Italian>Obiettivo secondario completato:</Italian>
-			<Chinesesimp>完成的次要目标：</Chinesesimp>
-			<Chinese>完成的次要目標</Chinese>
-			<Turkish>Bitirilen ikinci görevler:</Turkish>
-			<Portuguese>Objetivos secundários alcançados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_18">
-			<Original>Prisonners captured:</Original>
-			<French>Prisonniers capturés :</French>
-			<German>Gefangene gefasst:</German>
-			<Spanish>Prisioneros capturados:</Spanish>
-			<Russian>Пленных захвачено:</Russian>
-			<Italian>Prigionieri catturati:</Italian>
-			<Chinesesimp>俘虏的战俘：</Chinesesimp>
-			<Chinese>俘虜的戰俘：</Chinese>
-			<Turkish>Ele geçirilen esirler:</Turkish>
-			<Portuguese>Prisioneiros capturados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_19">
-			<Original>Hostile battlegroups called:</Original>
-			<French>Battlegroups hostiles appelés :</French>
-			<German>Gegnerische Truppen gerufen:</German>
-			<Spanish>Grupos hostiles de combate llamados:</Spanish>
-			<Russian>Вражеских боевых групп вызвано:</Russian>
-			<Italian>Battaglione ostile contattato:</Italian>
-			<Chinesesimp>敌军战斗组增援次数：</Chinesesimp>
-			<Chinese>敵方戰鬥群增援次數：</Chinese>
-			<Turkish>Düşman savaş grupları:</Turkish>
-			<Portuguese>Grupos de combate hostis chamados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_20">
-			<Original>Hostile reinforcements called:</Original>
-			<French>Renforts hostiles appelés :</French>
-			<German>Gegnerischen Nachschub gerufen:</German>
-			<Spanish>Refuerzos hostiles llamados:</Spanish>
-			<Russian>Враждебных подкреплений вызвано:</Russian>
-			<Italian>Chiamati rinforzi ostili:</Italian>
-			<Chinesesimp>敌军增援次数：</Chinesesimp>
-			<Chinese>敵方增援次數：</Chinese>
-			<Turkish>Düşman takviye kuvvetleri:</Turkish>
-			<Portuguese>Reforços hostis requisitados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_21">
-			<Original>Total combat readiness raised:</Original>
-			<French>Augmentation totale du niveau d'alerte :</French>
-			<German>Gesamte Kampfbereitschaft erhöht:</German>
-			<Spanish>Disposición de combate total recaudada:</Spanish>
-			<Russian>Всего войск поднято по тревоге:</Russian>
-			<Italian>Disposizione al combattimento recuperata:</Italian>
-			<Chinesesimp>总备战比例：</Chinesesimp>
-			<Chinese>威脅度比例：</Chinese>
-			<Turkish>Hazırda olan asker sayısı:</Turkish>
-			<Portuguese>Disposição total de combatentes em alerta:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_22">
-			<Original>IEDs detonated:</Original>
-			<French>Explosions d'IED :</French>
-			<German>IEDs zur Explosion gebracht:</German>
-			<Spanish>IEDs detonados:</Spanish>
-			<Russian>Фугасов взорвано:</Russian>
-			<Italian>IED detonato:</Italian>
-			<Chinesesimp>被引爆的IED：</Chinesesimp>
-			<Chinese>被引爆的IED：</Chinese>
-			<Turkish>Patlatılan mayınlar:</Turkish>
-			<Portuguese>IEDs detonadas:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_23">
-			<Original>Number of Spartan 01 losses:</Original>
-			<French>Pertes de Spartan 01 :</French>
-			<German>Höhe der Spartan-01 Verluste:</German>
-			<Spanish>Número de pérdidas de Spartan 01:</Spanish>
-			<Russian>Количество потерянных Spartan 01:</Russian>
-			<Italian>Numero di Spartan 01 persi :</Italian>
-			<Chinesesimp>损失的斯巴达01号：</Chinesesimp>
-			<Turkish>Spartan 01 kayıpları:</Turkish>
-			<Portuguese>Número de baixas de Spartan 01:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_24">
-			<Original>Player deaths:</Original>
-			<French>Joueurs morts :</French>
-			<German>Spielertode:</German>
-			<Spanish>Muertes del jugador:</Spanish>
-			<Russian>Смертей игрока:</Russian>
-			<Italian>Giocatori Deceduti:</Italian>
-			<Chinesesimp>玩家死亡数：</Chinesesimp>
-			<Chinese>玩家死亡數：</Chinese>
-			<Turkish>Ölen oyuncular:</Turkish>
-			<Portuguese>Morte de jogadores:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_25">
-			<Original>Rabbits killed:</Original>
-			<French>Lapins tués :</French>
-			<German>Hasen getötet:</German>
-			<Spanish>Conejos asesinados:</Spanish>
-			<Russian>Кроликов убито:</Russian>
-			<Italian>Conigli uccisi:</Italian>
-			<Chinesesimp>兔子屠杀数：</Chinesesimp>
-			<Chinese>兔子屠殺數：</Chinese>
-			<Turkish>Öldürülen tavşanlar:</Turkish>
-			<Portuguese>Coelhos mortos:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_26">
-			<Original>Many thanks for playing LIBERATION!</Original>
-			<French>Merci beaucoup d'avoir joué à LIBERATION!</French>
-			<German>Vielen Dank fürs Spielen von LIBERATION!</German>
-			<Spanish>¡Muchas gracias por jugar LIBERATION!</Spanish>
-			<Russian>Большое спасибо за то что играли в LIBERATION!</Russian>
-			<Italian>Mille Grazie per aver giocato LIBERATION!:</Italian>
-			<Chinesesimp>感谢您游玩Liberation！</Chinesesimp>
-			<Chinese>感謝您遊玩 Liberation！</Chinese>
-			<Turkish>LIBERATION oynadığınız için çok teşekkürler!</Turkish>
-			<Portuguese>Muito obrigado por jogar LIBERATION!</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_27">
-			<Original>BLUFOR soldiers recruited:</Original>
-			<French>Soldats BLUFOR recrutés :</French>
-			<German>BLUFOR Soldaten rekrutiert:</German>
-			<Spanish>Soldados BLUFOR reclutados:</Spanish>
-			<Russian>BLUFOR солдат призвано:</Russian>
-			<Italian>Soldato BLUFOR reclutato:</Italian>
-			<Chinesesimp>我军招募的士兵：</Chinesesimp>
-			<Chinese>我軍招募的士兵：</Chinese>
-			<Turkish>Çağrılan BLUFOR askerleri:</Turkish>
-			<Portuguese>Soldados aliados recrutados:</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_28">
-			<Original>We hope you enjoyed playing it, as much as we enjoyed making it.</Original>
-			<French>Nous espérons que vous avez pris autant de plaisir à y jouer, que nous à la créer.</French>
-			<German>Wir hoffen du hattest so viel Spaß am Spielen, wie wir dabei, es zu entwickeln.</German>
-			<Spanish>Esperamos que hayas disfrutado tanto jugándola, como nosotros creándola.</Spanish>
-			<Russian>Мы надеемся, что вы насладились игрой в эту миссию так же, как и мы, когда создавали её.</Russian>
-			<Italian>Speriamo che ti sia divertito giocare, qunato noi a creare questa missione:</Italian>
-			<Chinesesimp>一如我们如此热爱制作这个任务，也希望您能喜欢它。</Chinesesimp>
-			<Chinese>就像我們如此熱愛於製作這個任務，我們也希望你能喜歡它。</Chinese>
-			<Turkish>Umarım oynarken eğlenmişsinizdir, biz yaparken eğlendiğimiz kadar.</Turkish>
-			<Portuguese>Esperamos que tenham gostado de jogar, da mesma forma que gostamos de desenvolver esta missão.</Portuguese>
-		</Key>
-		<Key ID="STR_STATS_29">
-			<Original>(Press ESC to exit)</Original>
-			<French>(Appuyez sur Echap pour quitter)</French>
-			<German>(Drücke ESC zum Abbrechen)</German>
-			<Spanish>(Pulsa ESC para salir)</Spanish>
-			<Russian>(Нажмите клавишу ESC, чтобы выйти)</Russian>
-			<Italian>(Premi ESC per uscire)</Italian>
-			<Chinesesimp>（按ESC退出）</Chinesesimp>
-			<Chinese>（按 ESC 退出）</Chinese>
-			<Turkish>(ESC'ye basıp çıkabilirsiniz.)</Turkish>
-			<Portuguese>(Aperte ESC para sair)</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_MISSIONOPTIONS">
-			<Original>== MISSION OPTIONS ==</Original>
-			<French>== OPTIONS DE MISSION ==</French>
-			<German>== MISSIONSEINSTELLUNGEN ==</German>
-			<Spanish>== OPCIONES DE MISIÓN ==</Spanish>
-			<Russian>== ОПЦИИ МИССИИ ==</Russian>
-			<Italian>== OPZIONI MISSIONE ==</Italian>
-			<Chinesesimp>== 任务选项 ==</Chinesesimp>
-			<Chinese>== 任務選項 ==</Chinese>
-			<Turkish>== BÖLÜM AYARLARI ==</Turkish>
-			<Portuguese>== OPÇÕES DA MISSÃO ==</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_GAMEPLAYOPTIONS">
-			<Original>== GAMEPLAY OPTIONS ==</Original>
-			<German>== SPIELEINSTELLUNGEN ==</German>
-			<Spanish>== OPCIONES DE JUEGO</Spanish>
-			<Italian>==OPZIONI DI GIOCO ==</Italian>
-			<Chinesesimp>== 游戏选项 ==</Chinesesimp>
-			<Chinese>== 遊戲選項 ==</Chinese>
-			<Turkish>== OYUN AYARLARI ==</Turkish>
-			<Portuguese>== OPÇÕES DE JOGO ==</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_TECHNICALOPTIONS">
-			<Original>== TECHNICAL OPTIONS ==</Original>
-			<French>== OPTIONS TECHNIQUES ==</French>
-			<German>== TECHNISCHE EINSTELLUNGEN ==</German>
-			<Spanish>== OPCIONES TÉCNICAS ==</Spanish>
-			<Russian>== ТЕХНИЧЕСКИЕ ОПЦИИ ==</Russian>
-			<Italian>==OPZIONI TECNICHE ==</Italian>
-			<Chinesesimp>== 技术选项 ==</Chinesesimp>
-			<Chinese>== 技術選項 ==</Chinese>
-			<Turkish>== TEKNIK AYARLAR ==</Turkish>
-			<Portuguese>== OPÇÕES TÉCNICAS ==</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DAYDURATION">
-			<Original>Day duration (hours)</Original>
-			<French>Durée du jour (heures)</French>
-			<German>Länge eines Tages (Stunden)</German>
-			<Spanish>Duración del día (horas)</Spanish>
-			<Russian>Продолжительность дня (часов)</Russian>
-			<Italian>Durata del giorno (In ore)</Italian>
-			<Chinesesimp>每日时长（小时）</Chinesesimp>
-			<Chinese>美日時長（單位：小時）</Chinese>
-			<Turkish>Gün uzunluğu (saat)</Turkish>
-			<Portuguese>Duração do dia (horas)</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY">
-			<Original>Difficulty</Original>
-			<French>Difficulté</French>
-			<German>Schwierigkeit</German>
-			<Spanish>Dificultad</Spanish>
-			<Russian>Сложность</Russian>
-			<Italian>Difficoltà:</Italian>
-			<Chinesesimp>难度</Chinesesimp>
-			<Chinese>困難度</Chinese>
-			<Turkish>Zorluk:</Turkish>
-			<Portuguese>Dificuldade:</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY1">
-			<Original>Tourist</Original>
-			<French>Touriste</French>
-			<German>Tourist</German>
-			<Spanish>Turista</Spanish>
-			<Russian>Турист</Russian>
-			<Italian>Turista</Italian>
-			<Chinesesimp>观光</Chinesesimp>
-			<Chinese>觀光客</Chinese>
-			<Turkish>Turist</Turkish>
-			<Portuguese>Turista</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY2">
-			<Original>Easy</Original>
-			<French>Facile</French>
-			<German>Einfach</German>
-			<Spanish>Fácil</Spanish>
-			<Russian>Легко</Russian>
-			<Italian>Facile</Italian>
-			<Chinesesimp>简单</Chinesesimp>
-			<Chinese>簡單</Chinese>
-			<Turkish>Kolay</Turkish>
-			<Portuguese>Fácil</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY3">
-			<Original>Normal</Original>
-			<French>Normal</French>
-			<German>Normal</German>
-			<Spanish>Normal</Spanish>
-			<Russian>Нормально</Russian>
-			<Italian>Normale</Italian>
-			<Chinesesimp>正常</Chinesesimp>
-			<Chinese>正常</Chinese>
-			<Turkish>Normal</Turkish>
-			<Portuguese>Normal</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY4">
-			<Original>Moderate</Original>
-			<French>Modérée</French>
-			<German>Moderat</German>
-			<Spanish>Moderado</Spanish>
-			<Russian>Посложнее</Russian>
-			<Italian>Moderato</Italian>
-			<Chinesesimp>适中</Chinesesimp>
-			<Chinese>適中</Chinese>
-			<Turkish>Orta</Turkish>
-			<Portuguese>Moderada</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY5">
-			<Original>Hard</Original>
-			<French>Difficile</French>
-			<German>Schwer</German>
-			<Spanish>Difícil</Spanish>
-			<Russian>Сложно</Russian>
-			<Italian>Difficile</Italian>
-			<Chinesesimp>困难</Chinesesimp>
-			<Chinese>困難</Chinese>
-			<Turkish>Zor</Turkish>
-			<Portuguese>Difícil</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY6">
-			<Original>Extreme</Original>
-			<French>Extrême</French>
-			<German>Extrem</German>
-			<Spanish>Extremo</Spanish>
-			<Russian>Экстремально</Russian>
-			<Italian>Estremo</Italian>
-			<Chinesesimp>极难</Chinesesimp>
-			<Chinese>極難</Chinese>
-			<Turkish>Extreme</Turkish>
-			<Portuguese>Extrema</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY7">
-			<Original>Ludicrous</Original>
-			<French>Affolante</French>
-			<German>Wahnsinnig</German>
-			<Spanish>Ridículo</Spanish>
-			<Russian>Весело</Russian>
-			<Italian>Ridicolo</Italian>
-			<Chinesesimp>荒谬</Chinesesimp>
-			<Chinese>荒謬</Chinese>
-			<Turkish>Çılgınca</Turkish>
-			<Portuguese>Absurda</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DIFFICULTY8">
-			<Original>Oh god oh god we're all gonna die</Original>
-			<French>Oh mon dieu on va tous mourir</French>
-			<German>Oh mein Gott, wir werden alle sterben!</German>
-			<Spanish>Oh dios mío, vamos a morir!</Spanish>
-			<Russian>Боже мой, мы все умрём!</Russian>
-			<Italian>Oh dio, stiamo per morire!</Italian>
-			<Chinesesimp>天啦噜作死啦</Chinesesimp>
-			<Chinese>菩薩救救我！</Chinese>
-			<Turkish>Aman tanrım yok olacağız!</Turkish>
-			<Portuguese>Ah meu Deus, vamos morrer!</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_AI_SKILL_MANAGEMENT">
-			<Original>Manage AI Skill</Original>
-			<Chinesesimp>管理AI能力</Chinesesimp>
-			<Chinese>管理 AI 能力</Chinese>
-			<Italian>Livello Difficoltà AI</Italian>
-			<Turkish>AI Yeteneklerii düzenle</Turkish>
-			<Portuguese>Gerir nível de habilidade da IA</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_RESOURCESMULTIPLIER">
-			<Original>Resources multiplier</Original>
-			<French>Multiplicateur de resources</French>
-			<German>Ressourcenmultiplikator</German>
-			<Spanish>Multiplicador de recursos</Spanish>
-			<Russian>Множитель ресурсов</Russian>
-			<Italian>Moltiplicatore di risorse</Italian>
-			<Chinesesimp>资源乘数</Chinesesimp>
-			<Chinese>資源乘數</Chinese>
-			<Turkish>Kaynak Geliri Çarpanı</Turkish>
-			<Portuguese>Multiplicador de recursos</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_FATIGUE">
-			<Original>Stamina</Original>
-			<French>Stamina</French>
-			<German>Ausdauer</German>
-			<Spanish>Estamina</Spanish>
-			<Russian>Усталость</Russian>
-			<Italian>Stamina</Italian>
-			<Chinesesimp>体力</Chinesesimp>
-			<Chinese>體力</Chinese>
-			<Turkish>Stamina</Turkish>
-			<Portuguese>Vigor (stamina)</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_INTRO">
-			<Original>Introduction</Original>
-			<French>Introduction</French>
-			<German>Einführung</German>
-			<Spanish>Introducción</Spanish>
-			<Russian>Введение</Russian>
-			<Italian>Introduzione</Italian>
-			<Chinesesimp>开场动画</Chinesesimp>
-			<Chinese>開場動畫</Chinese>
-			<Turkish>Tanıtım</Turkish>
-			<Portuguese>Introdução</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEPLOYMENTCAMERA">
-			<Original>Deployment cinematic</Original>
-			<French>Cinématique de déploiement</French>
-			<German>Zwischensequenz bei Einsatz</German>
-			<Spanish>Cinemática de comienzo</Spanish>
-			<Russian>Кино во время размещения</Russian>
-			<Italian>Filmato di Schieramento</Italian>
-			<Chinesesimp>部署动画</Chinesesimp>
-			<Chinese>佈署動畫</Chinese>
-			<Turkish>Doğma Sinematiği</Turkish>
-			<Portuguese>Introdução cinemática de mobilização</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_ENABLED">
-			<Original>Enabled</Original>
-			<French>Activé</French>
-			<German>Aktiviert</German>
-			<Spanish>Activado</Spanish>
-			<Russian>Вкл</Russian>
-			<Italian>Attivo</Italian>
-			<Chinesesimp>开启</Chinesesimp>
-			<Chinese>開啟</Chinese>
-			<Turkish>Aktif</Turkish>
-			<Portuguese>Ativado</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DISABLED">
-			<Original>Disabled</Original>
-			<French>Désactivé</French>
-			<German>Deaktiviert</German>
-			<Spanish>Desactivado</Spanish>
-			<Russian>Выкл</Russian>
-			<Italian>Disattivato</Italian>
-			<Chinesesimp>关闭</Chinesesimp>
-			<Chinese>關閉</Chinese>
-			<Turkish>Kapalı</Turkish>
-			<Portuguese>Desativado</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_FIRSTFOB">
-			<Original>Start the campaign with the first FOB already built</Original>
-			<French>Commencer la campagne avec une première FOB déjà construite</French>
-			<German>Starte die Kampagne mit einer bereits gebauten FOB</German>
-			<Spanish>Comenzar la campaña con la primera FOB ya construída</Spanish>
-			<Russian>Начать кампанию, когда первая FOB размещена</Russian>
-			<Italian>Comincia la campagna costruendo la prima FOB</Italian>
-			<Chinesesimp>部署起始前哨</Chinesesimp>
-			<Chinese>佈署起始前線基地</Chinese>
-			<Turkish>Oyuna ilk FOB kurulu olarak başla</Turkish>
-			<Portuguese>Iniciar a campanha com a primeira FOB já construída</Portuguese>
-		</Key>
-		<Key ID="STR_YES">
-			<Original>Yes</Original>
-			<French>Oui</French>
-			<German>Ja</German>
-			<Spanish>Si</Spanish>
-			<Russian>Да</Russian>
-			<Italian>Si</Italian>
-			<Chinesesimp>是</Chinesesimp>
-			<Chinese>是</Chinese>
-			<Turkish>Evet</Turkish>
-			<Portuguese>Sim</Portuguese>
-		</Key>
-		<Key ID="STR_NO">
-			<Original>No</Original>
-			<French>Non</French>
-			<German>Nein</German>
-			<Spanish>No</Spanish>
-			<Russian>Нет</Russian>
-			<Italian>NO</Italian>
-			<Chinesesimp>否</Chinesesimp>
-			<Chinese>否</Chinese>
-			<Turkish>Hayır</Turkish>
-			<Portuguese>Não</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP">
-			<Original>Maximum amount of AI units</Original>
-			<French>Quantité maximum d'unités IA</French>
-			<German>Maximale Anzahl KI-Einheiten</German>
-			<Spanish>Cantidad máxima de unidades de IA</Spanish>
-			<Russian>Максимальное количество единиц AI</Russian>
-			<Italian>Numero massimo di unità AI</Italian>
-			<Chinesesimp>AI单位最大数量</Chinesesimp>
-			<Chinese>AI 單位最大數量</Chinese>
-			<Turkish>AI birlik sınırı</Turkish>
-			<Portuguese>Quantidade máxima de unidades IA</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP1">
-			<Original>50% - Recommended for local hosting</Original>
-			<French>50% - Recommandé pour un hébergement local</French>
-			<German>50 % - Empfohlen für lokal gehostete Spiele</German>
-			<Spanish>50% - Recomendado para host local</Spanish>
-			<Russian>50% - Рекомендуется для локального хостинга</Russian>
-			<Italian>50% - Raccomandato per host locali</Italian>
-			<Chinesesimp>50% - 适用于本地主机</Chinesesimp>
-			<Chinese>50% - 適合本地 HOST 遊戲使用</Chinese>
-			<Turkish>50% - Yerel sunucu için uygun</Turkish>
-			<Portuguese>50% - Recomendado para hospedagem local</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP2">
-			<Original>75% - Dedicated server recommended</Original>
-			<French>75% - Serveur dédié recommandé</French>
-			<German>75 % - Dezidierter Server empfohlen</German>
-			<Spanish>75% - Recomendado para servidor dedicado</Spanish>
-			<Russian>75% - Выделенный сервер рекомендуется</Russian>
-			<Italian>75% - Raccomandato per server dedicati</Italian>
-			<Chinesesimp>75% - 适用于服务器</Chinesesimp>
-			<Chinese>75% - 適合伺服器使用</Chinese>
-			<Turkish>75% - Yerel sunucu için uygun</Turkish>
-			<Portuguese>75% - Recomendado para servidor dedicado</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP3">
-			<Original>100% - Dedicated server recommended</Original>
-			<French>100% - Serveur dédié recommandé</French>
-			<German>100 % - Dezidierter Server empfohlen</German>
-			<Spanish>100% - Recomendado para servidor dedicado</Spanish>
-			<Russian>100% - Выделенный сервер рекомендуется</Russian>
-			<Italian>100% - Raccomandato per server dedicati</Italian>
-			<Chinesesimp>100% - 适用于服务器</Chinesesimp>
-			<Chinese>100% - 適合伺服器使用</Chinese>
-			<Turkish>100% - Dedicated server için uygun</Turkish>
-			<Portuguese>100% - Recomendado para servidor dedicado</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP4">
-			<Original>125% - Dedicated server with headless client recommended</Original>
-			<French>125% - Serveur dédié avec headless client recommandé</French>
-			<German>125 % - Dezidierter Server mit Headless Client empfohlen</German>
-			<Spanish>125% - Recomendado para servidor dedicado con cliente descabezado</Spanish>
-			<Russian>125% - Выделенный сервер вместе с headless client рекомендуется</Russian>
-			<Italian>125% - Raccomandato per server dedicati con headless client</Italian>
-			<Chinesesimp>125% - 适用于有Headless Client辅助的服务器</Chinesesimp>
-			<Chinese>125% - 適合有無頭客戶端的伺服器使用</Chinese>
-			<Turkish>125% - Headless client'e sahip dedicated server için uygun</Turkish>
-			<Portuguese>125% - Recomendado para servidor com headless client</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP5">
-			<Original>150% - Dedicated server with multiple headless clients recommended</Original>
-			<French>150% - Serveur dédié avec clients headless multiples recommandé</French>
-			<German>150 % - Dezidierter Server mit mehreren Headless Clients empfohlen</German>
-			<Spanish>150% - Recomendado para servidor dedicado con múltiples clientes descabezados</Spanish>
-			<Russian>150% - Выделенный сервер вместе с несколькими headless client рекомендуется</Russian>
-			<Italian>150% - Raccomandato per server dedicati con molti headless client</Italian>
-			<Chinesesimp>150% - 适用于有多个Headless Client辅助的服务器</Chinesesimp>
-			<Chinese>150% - 適合有多個無頭客戶端的伺服器使用</Chinese>
-			<Turkish>150% - Çoklu headless client'e sahip dedicated server için uygun</Turkish>
-			<Portuguese>150% - Recomendado para servidor com mútiplos headless clients</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_UNITCAP6">
-			<Original>200% - Dedicated server with multiple headless clients recommended</Original>
-			<French>200% - Serveur dédié avec clients headless multiples recommandés</French>
-			<German>200 % - Dezidierter Server mit mehreren Headless Clients empfohlen</German>
-			<Spanish>200% - Recomendado para servidor dedicado con múltiples clientes descabezados</Spanish>
-			<Russian>200% - Выделенный сервер вместе с несколькими headless client рекомендуется</Russian>
-			<Italian>200% - Raccomandato per server dedicati con tanti headless client</Italian>
-			<Chinesesimp>200% - 适用于有多个Headless Client辅助的服务器</Chinesesimp>
-			<Chinese>200% - 適合有多個無頭客戶端的伺服器使用</Chinese>
-			<Turkish>200% - Çoklu headless client'e sahip dedicated server için uygun</Turkish>
-			<Portuguese>150% - Recomendado para servidor com mútiplos headless clients</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_CIVILIANS">
-			<Original>Civilian activity</Original>
-			<French>Activité civile</French>
-			<German>Zivile Aktivität</German>
-			<Spanish>Actividad civil</Spanish>
-			<Russian>Гражданская активность</Russian>
-			<Italian>Attività dei civili</Italian>
-			<Chinesesimp>平民存在感</Chinesesimp>
-			<Chinese>平民活動程度</Chinese>
-			<Turkish>Sivil aktivitesi</Turkish>
-			<Portuguese>Atividade Civil</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_CIVILIANS1">
-			<Original>None</Original>
-			<French>Aucune</French>
-			<German>Keine</German>
-			<Spanish>Ninguna</Spanish>
-			<Russian>Нету</Russian>
-			<Italian>Nessuna</Italian>
-			<Chinesesimp>无</Chinesesimp>
-			<Chinese>無(關閉平民活動)</Chinese>
-			<Turkish>Hiç</Turkish>
-			<Portuguese>Nenhuma</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_CIVILIANS2">
-			<Original>Reduced</Original>
-			<French>Réduite</French>
-			<German>Reduziert</German>
-			<Spanish>Reducida</Spanish>
-			<Russian>Снижена</Russian>
-			<Italian>Ridotta</Italian>
-			<Chinesesimp>较少</Chinesesimp>
-			<Chinese>較少</Chinese>
-			<Turkish>Düşük</Turkish>
-			<Portuguese>Reduzida</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_CIVILIANS3">
-			<Original>Normal</Original>
-			<French>Normale</French>
-			<German>Normal</German>
-			<Spanish>Normal</Spanish>
-			<Russian>Нормальная</Russian>
-			<Italian>Normale</Italian>
-			<Chinesesimp>正常</Chinesesimp>
-			<Chinese>正常</Chinese>
-			<Turkish>Normal</Turkish>
-			<Portuguese>Normal</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_CIVILIANS4">
-			<Original>Increased</Original>
-			<French>Augmentée</French>
-			<German>Erhöht</German>
-			<Spanish>Aumentada</Spanish>
-			<Russian>Увеличенная</Russian>
-			<Italian>Aumentata</Italian>
-			<Chinesesimp>较多</Chinesesimp>
-			<Chinese>較多</Chinese>
-			<Turkish>Arttırılmış</Turkish>
-			<Portuguese>Aumentada</Portuguese>
-		</Key>
-		<Key ID="STR_FRIENDLY_FIRE">
-			<Original>Warning: friendly fire</Original>
-			<French>Attention: tirs alliés</French>
-			<German>Achtung: Eigenbeschuss</German>
-			<Spanish>Atención: fuego amigo</Spanish>
-			<Russian>Предупреждение: дружественный огонь</Russian>
-			<Italian>Attenzione: fuoco amico</Italian>
-			<Chinesesimp>警告：误击友军</Chinesesimp>
-			<Chinese>警告：誤擊友軍</Chinese>
-			<Turkish>Dikkat: dost ateşi</Turkish>
-			<Portuguese>Atenção: Fogo amigo</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_TEAMKILL_PENALTY">
-			<Original>Teamkill penalty</Original>
-			<French>Pénalité pour tirs alliés</French>
-			<German>Strafe für das Töten von Verbündeten</German>
-			<Spanish>Penalización por fuego amigo</Spanish>
-			<Russian>Штраф за убийство своего</Russian>
-			<Italian>Penalità se si uccide un compagno di squadra</Italian>
-			<Chinesesimp>友军击杀惩罚</Chinesesimp>
-			<Chinese>友軍擊殺懲罰</Chinese>
-			<Turkish>Dost ateşi cezası</Turkish>
-			<Portuguese>Penalidade por fogo amigo</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_ADAPT_TO_PLAYERCOUNT">
-			<Original>Hostile presence adapts to player count</Original>
-			<French>La présence hostile s'adapte au nombre de joueurs</French>
-			<German>Feindpräsenz passt sich der Spielerzahl an</German>
-			<Spanish>Adaptar presencia hostil según la cantidad de jugadores</Spanish>
-			<Russian>Вражеские силы адаптируются к количеству игроков</Russian>
-			<Italian>presenza ostile adattata al numero dei giocatori</Italian>
-			<Chinesesimp>随玩家数量调整敌军活动</Chinesesimp>
-			<Chinese>隨玩家數量調整敵人活動程度</Chinese>
-			<Turkish>Düşman birlikleri oyuncu sayısına göre adapte olur</Turkish>
-			<Portuguese>Adaptar presença hostil de acordo com a quantidade de jogadores</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD1">
-			<Original>Infantry units</Original>
-			<French>Unités d'infanterie</French>
-			<German>Infanterie</German>
-			<Spanish>Unidades de infantería</Spanish>
-			<Russian>Пехотинцы</Russian>
-			<Italian>Unità di fanteria</Italian>
-			<Chinesesimp>步兵单位</Chinesesimp>
-			<Chinese>步兵單位</Chinese>
-			<Turkish>Birlik ünitleri</Turkish>
-			<Portuguese>Unidades de infantaria</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD2">
-			<Original>Light vehicles</Original>
-			<French>Véhicules légers</French>
-			<German>Leichte Fahrzeuge</German>
-			<Spanish>Vehículos ligeros</Spanish>
-			<Russian>Легкая техника</Russian>
-			<Italian>Veicoli Leggeri</Italian>
-			<Chinesesimp>轻型载具</Chinesesimp>
-			<Chinese>輕型載具</Chinese>
-			<Turkish>Hafif araçlar</Turkish>
-			<Portuguese>Veículos leves</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD3">
-			<Original>Armored vehicles</Original>
-			<French>Vehicules blindés</French>
-			<German>Gepanzerte Fahrzeuge</German>
-			<Spanish>Vehículos blindados</Spanish>
-			<Russian>Бронетехника</Russian>
-			<Italian>Veicoli Blindati</Italian>
-			<Chinesesimp>装甲载具</Chinesesimp>
-			<Chinese>裝甲載具</Chinese>
-			<Turkish>Zırhlı araçlar</Turkish>
-			<Portuguese>Veículos blindados</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD4">
-			<Original>Air vehicles</Original>
-			<French>Véhicules aériens</French>
-			<German>Luftfahrzeuge</German>
-			<Spanish>Vehículos aéreos</Spanish>
-			<Russian>Авиационная техника</Russian>
-			<Italian>Veicoli Aerei</Italian>
-			<Chinesesimp>空中载具</Chinesesimp>
-			<Chinese>空中載具</Chinese>
-			<Turkish>Uçak ve helikopterler</Turkish>
-			<Portuguese>Veículos aéreos</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD5">
-			<Original>Static defenses</Original>
-			<French>Defenses statiques</French>
-			<German>Statische Verteidigung</German>
-			<Spanish>Defensas estáticas</Spanish>
-			<Russian>Стационары</Russian>
-			<Italian>Difese statiche</Italian>
-			<Chinesesimp>固定防御</Chinesesimp>
-			<Chinese>固定式防禦</Chinese>
-			<Turkish>Statik savunma aletleri</Turkish>
-			<Portuguese>Defesas estáticas</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD6">
-			<Original>Buildings</Original>
-			<French>Batiments</French>
-			<German>Gebäude</German>
-			<Spanish>Edificios</Spanish>
-			<Russian>Постройки</Russian>
-			<Italian>Edifici</Italian>
-			<Chinesesimp>建筑工事</Chinesesimp>
-			<Chinese>建築工事</Chinese>
-			<Turkish>Yapılar</Turkish>
-			<Portuguese>Construções</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD7">
-			<Original>Logistics</Original>
-			<French>Logistique</French>
-			<German>Logistik</German>
-			<Spanish>Logística</Spanish>
-			<Russian>Снабжение</Russian>
-			<Italian>Logistica</Italian>
-			<Chinesesimp>后勤</Chinesesimp>
-			<Chinese>後勤</Chinese>
-			<Turkish>Lojistikler</Turkish>
-			<Portuguese>Logística</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD8">
-			<Original>Infantry squads</Original>
-			<French>Escouades d'infanterie</French>
-			<German>Infanteriegruppen</German>
-			<Spanish>Escuadras de infantería</Spanish>
-			<Russian>Пехотные отделения</Russian>
-			<Italian>Squadra Fanteria</Italian>
-			<Chinesesimp>步兵班</Chinesesimp>
-			<Chinese>步兵班</Chinese>
-			<Turkish>Asker timleri</Turkish>
-			<Portuguese>Grupos de combate de infantaria</Portuguese>
-		</Key>
-		<Key ID="STR_ACTIVE_SECTORS">
-			<Original>Active Sectors:</Original>
-			<French>Secteurs Actifs :</French>
-			<German>Aktive Sektoren:</German>
-			<Spanish>Sectores activos:</Spanish>
-			<Russian>Активные Зоны:</Russian>
-			<Italian>Settori Attivi:</Italian>
-			<Chinesesimp>活动中的战区：</Chinesesimp>
-			<Chinese>觸發中的戰區：</Chinese>
-			<Turkish>Aktif Sektörler:</Turkish>
-			<Portuguese>Setores ativos:</Portuguese>
-		</Key>
-		<Key ID="STR_OVERLOAD_HINT">
-			<Original>The unitcap setting has been exceeded and further sector activation is temporarily halted. You can now see the list of currently active sectors where you shall concentrate your efforts.</Original>
-			<French>La limite d'unités actives a été dépassée et l'activation de nouveaux secteurs est temporairement stoppée. Vous pouvez maintenant voir la liste des sectors déjà actifs sur lesquels vous pouvez concentrer vos efforts.</French>
-			<German>Maximale Anzahl KI-Einheiten erreicht. Es können keine weitere Zonen aktiviert werden. Du kannst nun die Liste der aktiven Gebiete sehen, auf die du deine Kraft fokussieren solltest.</German>
-			<Spanish>El límite de unidades activas se ha excedido, por lo que la activación de sectores queda temporalmente paralizada. Ahora puedes ver la lista de sectores activos donde concentrar tus esfuerzos</Spanish>
-			<Russian>Превышено ограничение по количеству ботов в настройках миссии и активация зон временно приостановлена. Теперь вы можете увидеть список активных в данный момент зон, где вы должны сконцентрировать свои усилия.</Russian>
-			<Italian>L'impostazione unitcap è stata superata e l'attivazione di ulteriori settori è interrotta temporaneamente. Ora è possibile visualizzare l'elenco dei settori attualmente attivi in ​​cui si devono concentrare i vostri sforzi.</Italian>
-			<Chinesesimp>已达到单位上限，暂停其他战区的激活。你可以通过活动中的战区列表查看并确立主攻地区。</Chinesesimp>
-			<Chinese>敵人生成數量已達單位上限，系統將暫時停止其他戰區的敵軍觸發功能；你可以通過觸發中的戰區來查看並確定想主要進攻的戰區。</Chinese>
-			<Turkish>Unit sınırı aşıldır ve sektör aktivasyonu geçici olarak durduruldu. Şuan da ilgilenmeniz gereken aktif sektörler listesi görüntülenmekte.</Turkish>
-			<Portuguese>O limite de unidades foi excedido e a ativação de outros setores foi temporariamente pausada. Você pode ver a lista de setores ativos onde deverá concentrar seus esforços.</Portuguese>
-		</Key>
-		<Key ID="STR_VEHICLE_LOCKED">
-			<Original>LOCKED BY</Original>
-			<French>VEROUILLE PAR</French>
-			<German>VERSCHLOSSEN VON</German>
-			<Spanish>BLOQUEADO POR</Spanish>
-			<Russian>ЗАБЛОКИРОВАНО</Russian>
-			<Italian>BLOCCATO DA</Italian>
-			<Chinesesimp>锁定于</Chinesesimp>
-			<Chinese>鎖定於</Chinese>
-			<Turkish>TARAFINDAN KİLİTLİ</Turkish>
-			<Portuguese>BLOQUEADO POR</Portuguese>
-		</Key>
-		<Key ID="STR_VEHICLE_UNLOCKED">
-			<Original>UNLOCKED BY</Original>
-			<French>DEVEROUILLE PAR</French>
-			<German>GEÖFFNET VON</German>
-			<Spanish>DESBLOQUEADO POR</Spanish>
-			<Russian>РАЗБЛОКИРОВАНО</Russian>
-			<Italian>SBLOCCATO DA</Italian>
-			<Chinesesimp>解锁于</Chinesesimp>
-			<Chinese>解鎖於</Chinese>
-			<Turkish>TARAFINDAN KİLİDİ AÇILDI</Turkish>
-			<Portuguese>DESBLOQUEADO POR</Portuguese>
-		</Key>
-		<Key ID="STR_SQUAD_MANAGEMENT">
-			<Original>SQUAD MANAGEMENT</Original>
-			<French>GESTION D'ESCOUADE</French>
-			<German>GRUPPENVERWALTUNG</German>
-			<Spanish>GESTIÓN DE ESCUADRA</Spanish>
-			<Russian>УПРАВЛЕНИЕ СОСТАВОМ ГРУПП</Russian>
-			<Italian>GESTIONE SQUADRA</Italian>
-			<Chinesesimp>班组管理</Chinesesimp>
-			<Chinese>班級管理</Chinese>
-			<Turkish>TİM YÖNETİMİ</Turkish>
-			<Portuguese>GESTÃO DO GRUPO DE COMBATE</Portuguese>
-		</Key>
-		<Key ID="STR_SQUAD_MANAGEMENT_ACTION">
-			<Original>-- SQUAD MANAGEMENT</Original>
-			<French>-- GESTION D'ESCOUADE</French>
-			<German>-- GRUPPENVERWALTUNG</German>
-			<Spanish>-- GESTIÓN DE ESCUADRA</Spanish>
-			<Russian>-- УПРАВЛЕНИЕ СОСТАВОМ ГРУПП</Russian>
-			<Italian>-- GESTIONE SQUADRA</Italian>
-			<Chinesesimp>-- 班组管理</Chinesesimp>
-			<Chinese>-- 班級管理</Chinese>
-			<Turkish>-- TİM YÖNETİMİ</Turkish>
-			<Portuguese>-- GESTÃO DO GRUPO DE COMBATE</Portuguese>
-		</Key>
-		<Key ID="STR_DEPLOY_ON_MEMBER">
-			<Original>Replace</Original>
-			<French>Remplacer</French>
-			<German>Ersetzen</German>
-			<Spanish>Reemplazar</Spanish>
-			<Russian>Заменить</Russian>
-			<Italian>Sostituisci</Italian>
-			<Chinesesimp>附身</Chinesesimp>
-			<Chinese>取代</Chinese>
-			<Turkish>Değiş</Turkish>
-			<Portuguese>Substituir</Portuguese>
-		</Key>
-		<Key ID="STR_DEPLOY_ON_MEMBER_TOOLTIP">
-			<Original>You will deploy on the selected squad member and replace them while keeping your current loadout.</Original>
-			<French>Vous allez vous déployer à la place du member d'escouade selectionné tout en conservant votre équipement actuel.</French>
-			<German>Du wirst das ausgewählte Gruppenmitglied ersetzen, während du deine Ausrüstung behältst.</German>
-			<Spanish>Reaparecerás en el miembro de la escuadra seleccionado, manteniendo tu equipación actual</Spanish>
-			<Russian>Вы будете развёрнуты на выбранном AI-солдате группы, и замените его, сохранив текущее снаряжение.</Russian>
-			<Italian>Verrai schierato sul membro della squadra selezionata e lo rimpiazzerai mantenendo il loadout corrente.</Italian>
-			<Chinesesimp>你将附身到所选班组成员身上并保留你当前的装备</Chinesesimp>
-			<Chinese>你將使用你目前的身上裝備並取代選定的班級成員。</Chinese>
-			<Turkish>Seçilen şahış ile değişeceksin ve üstündeki herşey ona aktarılacak.</Turkish>
-			<Portuguese>Você irá reaparecer no membro selecionado e o substituir enquanto mantém seu equipamento atual.</Portuguese>
-		</Key>
-		<Key ID="STR_REMOVE_MEMBER">
-			<Original>Remove</Original>
-			<French>Supprimer</French>
-			<German>Entfernen</German>
-			<Spanish>Suprimir</Spanish>
-			<Russian>Удалить</Russian>
-			<Italian>Rimuovi</Italian>
-			<Chinesesimp>移除</Chinesesimp>
-			<Chinese>移除</Chinese>
-			<Turkish>Kaldır</Turkish>
-			<Portuguese>Remover</Portuguese>
-		</Key>
-		<Key ID="STR_REMOVE_MEMBER_TOOLTIP">
-			<Original>The selected squad member will be deleted.</Original>
-			<French>Le membre d'escouade sélectionné sera supprimé.</French>
-			<German>Das ausgewählte Gruppenmitglied löschen.</German>
-			<Spanish>El miembro de la escuadra seleccionado será eliminado</Spanish>
-			<Russian>Выбранный член группы будет удалён.</Russian>
-			<Italian>Il soldato attualmente selezionato è stato rimosso</Italian>
-			<Chinesesimp>所选班组成员将会被移除。</Chinesesimp>
-			<Chinese>所選的班級成員將被移除</Chinese>
-			<Turkish>Bu tim üyesi silinecektir.</Turkish>
-			<Portuguese>O membro selecionado será deletado</Portuguese>
-		</Key>
-		<Key ID="STR_RESUPPLY">
-			<Original>Resupply</Original>
-			<French>Réapprovisionner</French>
-			<German>Versorgen</German>
-			<Spanish>Reabastecer</Spanish>
-			<Russian>Переснарядить</Russian>
-			<Italian>Riapprovvigionamento</Italian>
-			<Chinesesimp>补给</Chinesesimp>
-			<Chinese>補給</Chinese>
-			<Turkish>Tazele</Turkish>
-			<Portuguese>Reabastecer</Portuguese>
-		</Key>
-		<Key ID="STR_RESUPPLY_TOOLTIP">
-			<Original>If the selected squad member is close enough from a resupply point (mobile spawn or FOB) they will get a brand new, full loadout.</Original>
-			<French>Si le membre d'escouade sélectionné est assez près d'un point d'approvisionnement (spawn mobile ou FOB) il recevra un nouvel équipement complet.</French>
-			<German>Wenn das gewählte Gruppenmitglied nahe genug bei einem Versorgungspunkt (mobiler Spawn oder FOB) ist, erhält es eine brandneue, vollständige Ausrüstung</German>
-			<Spanish>Si el miembro de la escuadra se encuentra cerca de un punto de abastecimiento (spawn móvil o FOB) obtendrá el equipamiento completo nuevo</Spanish>
-			<Russian>Если выбранный член группы находится достаточно близко от точки пополнения запасов (мобильный КШМ или FOB), он будет заменён новым, полностью снаряжённым.</Russian>
-			<Italian>Se il membro di una squadra è nei pressi di una FOB o Respwan Mobile potrà ricaricare il suo loadout.</Italian>
-			<Chinesesimp>如果选择的班组成员距离补给点（机动复活点或前哨）够近时，他们将获得一套全新完整的装备。</Chinesesimp>
-			<Chinese>如果選定的班級乘員距離補給點（機動重生點或前線基地）夠近時，他們將獲得一套全新的完整裝備。</Chinese>
-			<Turkish>Seçilen tim üyesi bir mühimmat tazeleme noktasına yakın ise (mobil respawn veya FOB) üstündeki herşey doldurulup, yenilenecektir.</Turkish>
-			<Portuguese>Se o membro selecionado estiver próximo o suficiente de um ponto de reabastecimento (respawn móvel ou FOB), irá adquirir um novo loadout.</Portuguese>
-		</Key>
-		<Key ID="STR_CONFIRM">
-			<Original>Confirm</Original>
-			<French>Confirmer</French>
-			<German>Bestätigen</German>
-			<Spanish>Confirmar</Spanish>
-			<Russian>Подтвердить</Russian>
-			<Italian>Conferma</Italian>
-			<Chinesesimp>确认</Chinesesimp>
-			<Chinese>確認</Chinese>
-			<Turkish>Onayla</Turkish>
-			<Portuguese>Confirmar</Portuguese>
-		</Key>
-		<Key ID="STR_HEALTH">
-			<Original>Health:</Original>
-			<French>Santé :</French>
-			<German>Leben:</German>
-			<Spanish>Salud:</Spanish>
-			<Russian>Здоровье:</Russian>
-			<Italian>Salute:</Italian>
-			<Chinesesimp>血量：</Chinesesimp>
-			<Chinese>血量：</Chinese>
-			<Turkish>Sağlık:</Turkish>
-			<Portuguese>Saúde:</Portuguese>
-		</Key>
-		<Key ID="STR_DISTANCE">
-			<Original>Distance:</Original>
-			<French>Distance :</French>
-			<German>Distanz:</German>
-			<Spanish>Distancia:</Spanish>
-			<Russian>Дистанция:</Russian>
-			<Italian>Distanza:</Italian>
-			<Chinesesimp>距离：</Chinesesimp>
-			<Chinese>距離：</Chinese>
-			<Turkish>Uzaklık:</Turkish>
-			<Portuguese>Distância:</Portuguese>
-		</Key>
-		<Key ID="STR_PRIMARY_WEAPON">
-			<Original>Primary</Original>
-			<French>Principale</French>
-			<German>Primär</German>
-			<Spanish>Principal</Spanish>
-			<Russian>Главный</Russian>
-			<Italian>Primaria</Italian>
-			<Chinesesimp>主要</Chinesesimp>
-			<Chinese>主要</Chinese>
-			<Turkish>Birincil</Turkish>
-			<Portuguese>Primária</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_WEAPON">
-			<Original>Secondary</Original>
-			<French>Secondaire</French>
-			<German>Sekundär</German>
-			<Spanish>Secundaria</Spanish>
-			<Russian>Подчинённый</Russian>
-			<Italian>Secondaria</Italian>
-			<Chinesesimp>次要</Chinesesimp>
-			<Chinese>次要</Chinese>
-			<Turkish>İkincil</Turkish>
-			<Portuguese>Secundária</Portuguese>
-		</Key>
-		<Key ID="STR_NONE">
-			<Original>None</Original>
-			<French>Aucune</French>
-			<German>Keine</German>
-			<Spanish>Ninguno</Spanish>
-			<Russian>Никто</Russian>
-			<Italian>Nessuno</Italian>
-			<Chinesesimp>无</Chinesesimp>
-			<Chinese>無</Chinese>
-			<Turkish>Hiçbiri</Turkish>
-			<Portuguese>Nenhum</Portuguese>
-		</Key>
-		<Key ID="STR_DRIVER">
-			<Original>Driver</Original>
-			<French>Conducteur</French>
-			<German>Fahrer</German>
-			<Spanish>Conductor</Spanish>
-			<Russian>Водитель</Russian>
-			<Italian>Guidatore</Italian>
-			<Chinesesimp>驾驶员</Chinesesimp>
-			<Chinese>駕駛</Chinese>
-			<Turkish>Sürücü</Turkish>
-			<Portuguese>Motorista</Portuguese>
-		</Key>
-		<Key ID="STR_GUNNER">
-			<Original>Gunner</Original>
-			<French>Tireur</French>
-			<German>Schütze</German>
-			<Spanish>Artillero</Spanish>
-			<Russian>Стрелок</Russian>
-			<Italian>Artigliere</Italian>
-			<Chinesesimp>炮手</Chinesesimp>
-			<Chinese>砲手</Chinese>
-			<Turkish>Silahçı</Turkish>
-			<Portuguese>Atirador</Portuguese>
-		</Key>
-		<Key ID="STR_COMMANDER">
-			<Original>Commander</Original>
-			<French>Commandant</French>
-			<German>Kommandant</German>
-			<Spanish>Comandante</Spanish>
-			<Russian>Командир</Russian>
-			<Italian>Comandante</Italian>
-			<Chinesesimp>车长</Chinesesimp>
-			<Chinese>車長</Chinese>
-			<Turkish>Komutan</Turkish>
-			<Portuguese>Comandante</Portuguese>
-		</Key>
-		<Key ID="STR_PASSENGER">
-			<Original>Passenger</Original>
-			<French>Passager</French>
-			<German>Passagier</German>
-			<Spanish>Pasajero</Spanish>
-			<Russian>Пассажир</Russian>
-			<Italian>Passeggero</Italian>
-			<Chinesesimp>乘客</Chinesesimp>
-			<Chinese>乘客</Chinese>
-			<Turkish>Yolcu</Turkish>
-			<Portuguese>Passageiro</Portuguese>
-		</Key>
-		<Key ID="STR_SQUAD_DEPLOY">
-			<Original>Squad deploy</Original>
-			<French>Déploiement d'escouade</French>
-			<German>Gruppeneinsatz</German>
-			<Spanish>Despliegue de escuadra</Spanish>
-			<Russian>Мобилизовать отряд</Russian>
-			<Italian>Schieramento Squadra</Italian>
-			<Chinesesimp>班组部署</Chinesesimp>
-			<Chinese>班級佈署</Chinese>
-			<Turkish>Tim çıkar</Turkish>
-			<Portuguese>Mobilizar Grupo de Combate</Portuguese>
-		</Key>
-		<Key ID="STR_REMOVE_OK">
-			<Original>You have deleted the selected squad member.</Original>
-			<French>Vous avez supprimé le membre de l'escouade sélectionné.</French>
-			<German>Du hast das ausgewählte Gruppenmitglied gelöscht.</German>
-			<Spanish>Has eliminado al miebro de la escuadra.</Spanish>
-			<Russian>Вы демобилизовали выбранного члена группы.</Russian>
-			<Italian>Hai eliminato il membro della squadra selezionato.</Italian>
-			<Chinesesimp>所选班组成员已移除。</Chinesesimp>
-			<Chinese>所選的班級乘員已移除。</Chinese>
-			<Turkish>Seçilen tim üyesini sildiniz.</Turkish>
-			<Portuguese>Você deletou o membro selecionado.</Portuguese>
-		</Key>
-		<Key ID="STR_RESUPPLY_OK">
-			<Original>The selected squad member has been resupplied.</Original>
-			<French>Le membre de l'escouade sélectionné a été réapprovisionné.</French>
-			<German>Das ausgewählte Gruppenmitglied wurde versorgt.</German>
-			<Spanish>El miembro seleccionado de la escuadra ha sido reamunicionado</Spanish>
-			<Russian>Выбранный член группы был переснаряжён</Russian>
-			<Italian>Il membro della squadra selezionato è stato rifornito</Italian>
-			<Chinesesimp>所选班组成员已补给。</Chinesesimp>
-			<Chinese>所選的班級成員以補給。</Chinese>
-			<Turkish>Seçilen tim üyesi mühimmatı tazelendi.</Turkish>
-			<Portuguese>O membro selecionado do grupo se remuniciou.</Portuguese>
-		</Key>
-		<Key ID="STR_RESUPPLY_KO">
-			<Original>The selected squad member isn't close enough from a FOB or mobile spawn.</Original>
-			<French>Le membre de l'escouade sélectionné n'est pas assez proche d'une FOB ou d'un spawn mobile.</French>
-			<German>Das ausgewählte Gruppenmitglied ist nicht nahe genug an einer FOB oder an einem mobilen Spawn.</German>
-			<Spanish>El miembro seleccionado de la escuadra no está suficientemente cerca de una FOB o spawn móvil.</Spanish>
-			<Russian>Выбранный член группы находится далеко от КШМ и FOB</Russian>
-			<Italian>Il membro della squadra non è sufficentemente vicino alla FOB o Respawn Mobile.</Italian>
-			<Chinesesimp>所选班组成员距离前哨或机动复活点太远。</Chinesesimp>
-			<Chinese>所選的班級成員距離前線基地或機動重生點太遠。</Chinese>
-			<Turkish>Seçilen tim üyesi FOB veya mobil spawn noktasına yakın değil.</Turkish>
-			<Portuguese>O membro selecionado do grupo não está próximo o suficiente de uma FOB ou respawn móvel.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TITLE">
-			<Original>PERMISSIONS MANAGEMENT</Original>
-			<French>GESTION DES PERMISSIONS</French>
-			<German>Rechteverwaltung</German>
-			<Spanish>GESTIÓN DE PERMISOS</Spanish>
-			<Russian>УПРАВЛЕНИЕ РАЗРЕШЕНИЯМИ</Russian>
-			<Italian>GESTIONE PERMESSI</Italian>
-			<Chinesesimp>权限管理</Chinesesimp>
-			<Chinese>權限管理</Chinese>
-			<Turkish>YETKİLERİ YÖNET</Turkish>
-			<Portuguese>GESTÃO DE PERMISSÕES</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_LIGHT">
-			<Original>Light vehicles</Original>
-			<French>Véhicules légers</French>
-			<German>Leichte Fahrzeuge</German>
-			<Spanish>Vehículos ligeros</Spanish>
-			<Russian>Лёгкая техника</Russian>
-			<Italian>Veicoli Leggeri</Italian>
-			<Chinesesimp>轻型载具</Chinesesimp>
-			<Chinese>輕型載具</Chinese>
-			<Turkish>Hafif araçlar</Turkish>
-			<Portuguese>Veículos leves</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_ARMORED">
-			<Original>Armored vehicles</Original>
-			<French>Véhicules blindés</French>
-			<German>Gepanzerte Fahrzeuge</German>
-			<Spanish>Vehículos blindados</Spanish>
-			<Russian>Бронированная техника</Russian>
-			<Italian>veicoli Blindati</Italian>
-			<Chinesesimp>装甲载具</Chinesesimp>
-			<Chinese>裝甲載具</Chinese>
-			<Turkish>Zırhlı araçlar</Turkish>
-			<Portuguese>Veículos blindados</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_AIR">
-			<Original>Air vehicles</Original>
-			<French>Véhicules aériens</French>
-			<German>Luftfahrzeuge</German>
-			<Spanish>Vehículos aéreos</Spanish>
-			<Russian>Авиация</Russian>
-			<Italian>Aerei</Italian>
-			<Chinesesimp>空中载具</Chinesesimp>
-			<Chinese>空中載具</Chinese>
-			<Turkish>Hava araçları</Turkish>
-			<Portuguese>Veículos aéreos</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_CONSTRUCTION">
-			<Original>Construction</Original>
-			<French>Construction</French>
-			<German>Konstruktionen</German>
-			<Spanish>Construcción</Spanish>
-			<Russian>Постройка</Russian>
-			<Italian>Costruzione</Italian>
-			<Chinesesimp>建造</Chinesesimp>
-			<Chinese>建造</Chinese>
-			<Turkish>İnşaat</Turkish>
-			<Portuguese>Construção</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_RECYCLING">
-			<Original>Recycling</Original>
-			<French>Recyclage</French>
-			<German>Wiederverwerten</German>
-			<Spanish>Reciclar</Spanish>
-			<Russian>Утилизация</Russian>
-			<Italian>Riciclaggio</Italian>
-			<Chinesesimp>回收</Chinesesimp>
-			<Chinese>回收</Chinese>
-			<Turkish>Geri dönüşüm</Turkish>
-			<Portuguese>Reciclando</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_MISC">
-			<Original>Others</Original>
-			<French>Autres</French>
-			<German>Andere</German>
-			<Spanish>Otros</Spanish>
-			<Russian>Остальное</Russian>
-			<Italian>Altro</Italian>
-			<Chinesesimp>其它</Chinesesimp>
-			<Chinese>其他</Chinese>
-			<Turkish>Diğerleri</Turkish>
-			<Portuguese>Outros</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_ALL">
-			<Original>All</Original>
-			<French>Toutes</French>
-			<German>Alle</German>
-			<Spanish>Todos</Spanish>
-			<Russian>Всё</Russian>
-			<Italian>Tutto</Italian>
-			<Chinesesimp>全部</Chinesesimp>
-			<Chinese>全部</Chinese>
-			<Turkish>Hepsi</Turkish>
-			<Portuguese>Todos</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_NONE">
-			<Original>None</Original>
-			<French>Aucune</French>
-			<German>Keine</German>
-			<Spanish>Ninguno</Spanish>
-			<Russian>Ничего</Russian>
-			<Italian>Nessuno</Italian>
-			<Chinesesimp>无</Chinesesimp>
-			<Chinese>無</Chinese>
-			<Turkish>Hiçbiri</Turkish>
-			<Portuguese>Nenhum</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_LIGHT">
-			<Original>Allows the player to operate light vehicles as driver and gunner.</Original>
-			<French>Autorise le joueur à utiliser les véhicules légers en tant que conducteur ou tireur.</French>
-			<German>Erlaubt es dem Spieler, leichte Fahrzeuge als Fahrer und Schütze zu bedienen.</German>
-			<Spanish>Permite al jugador utilizar vehículos ligeros como conductor y artillero</Spanish>
-			<Russian>Позволить игроку быть водителем и стрелком лёгкой техники.</Russian>
-			<Italian>Permetti al giocatore di entrare nei veicoli leggeri come guidatore e artigliere</Italian>
-			<Chinesesimp>允许玩家进入轻型载具的驾驶和炮手位。</Chinesesimp>
-			<Chinese>允許玩家進入輕型載具的駕駛與砲手位置。</Chinese>
-			<Turkish>Oyuncunun hafif araçları sürücü veya silahçı olarak kullanmasını sağlar</Turkish>
-			<Portuguese>Permite ao jogador operar veículos leves como condutor e atirador.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_ARMORED">
-			<Original>Allows the player to operate armored vehicles as driver, gunner and commander.</Original>
-			<French>Autorise le joueur à utiliser les véhicules blindés en tant que conducteur, tireur ou commandant.</French>
-			<German>Erlaubt es dem Spieler, gepanzerte Fahrzeuge als Fahrer, Schütze und Kommandant zu bedienen.</German>
-			<Spanish>Permite al jugador utilizar vehículos blindados como conductor, artillero y comandante</Spanish>
-			<Russian>Позволить игроку быть командиром, водителем и стрелком бронированной техники.</Russian>
-			<Italian>Permetti al giocatore di entrare nei veicoli blindati come guidatore e artigliere e comandante</Italian>
-			<Chinesesimp>允许玩家进入装甲载具的驾驶、炮手和车长位。</Chinesesimp>
-			<Chinese>允許玩家進入裝甲載具的駕駛、砲手、車長位置。</Chinese>
-			<Turkish>Oyuncunun zırhlı araçları sürücü, komutan veya silahçı olarak kullanmasını sağlar</Turkish>
-			<Portuguese>Permite ao jogador operar veículos blindados como condutor, atirador e comandante.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_AIR">
-			<Original>Allows the player to operate air vehicles as driver and gunner.</Original>
-			<French>Autorise le joueur à utiliser les véhicules aériens en tant que conducteur ou tireur.</French>
-			<German>Erlaubt es dem Spieler, Luftfahrzeuge als Pilot und Schütze zu bedienen.</German>
-			<Spanish>Permite al jugador utilizar vehículos aéreos como conductor y artillero</Spanish>
-			<Russian>Позволить игроку быть пилотом и стрелком авиации.</Russian>
-			<Italian>Permetti al giocatore di entrare negli aerei come guidatore e artigliere</Italian>
-			<Chinesesimp>允许玩家进入空中载具的驾驶和炮手位。</Chinesesimp>
-			<Chinese>允許玩家進入空中載具的駕駛和砲手位置。</Chinese>
-			<Turkish>Oyuncunun bütün hava araçlarını sürücü veya silahçı olarak kullanmasını sağlar</Turkish>
-			<Portuguese>Permite ao jogador operar veículos aéreos como piloto e atirador.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_CONSTRUCTION">
-			<Original>Allows the player to use the BUILD menu.</Original>
-			<French>Autorise le joueur à utiliser le menu CONSTRUCTION.</French>
-			<German>Erlaubt es dem Spieler, das Baumenü zu benutzen.</German>
-			<Spanish>Permite al jugador utilizar el menú de CONSTRUCCIÓN</Spanish>
-			<Russian>Позволить игроку использовать меню постройки.</Russian>
-			<Italian>Permetti al giocatore di Costruire</Italian>
-			<Chinesesimp>允许玩家使用建造菜单</Chinesesimp>
-			<Chinese>允許玩家使用建造選單。</Chinese>
-			<Turkish>Oyuncunun İNŞA menüsünü kullanmasını sağlar</Turkish>
-			<Portuguese>Permite ao jogador utilizar o menu de CONTRUÇÃO.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_RECYCLING">
-			<Original>Allows the player to use the RECYCLE action.</Original>
-			<French>Autorise le joueur à utiliser l'action RECYCLER.</French>
-			<German>Erlaubt es dem Spieler, die "WIEDERVERWERTEN"-Aktion zu benutzen.</German>
-			<Spanish>Permite al jugador utilizar la acción de RECICLAR</Spanish>
-			<Russian>Позволить игроку утилизировать постройки и технику.</Russian>
-			<Italian>Permetti al giocatore di Riciclare</Italian>
-			<Chinesesimp>允许玩家使用回收功能。</Chinesesimp>
-			<Chinese>允許玩家使用回收功能。</Chinese>
-			<Turkish>Oyuncunun GERİ DÖNÜŞTÜR butonunu kullanmasını sağlar</Turkish>
-			<Portuguese>Permite ao jogador utilizar a ação "RECICLAR".</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_MISC">
-			<Original>Allows the player to use other actions: unflip, resource box manipulation, prisoner capture, etc.</Original>
-			<French>Autorise le joueur à utiliser les autres actions : retournement de véhicule, manipulation des boites de munition, capture de prisoniers, etc.</French>
-			<German>Erlaubt es dem Spieler, andere Aktionen durchzuführen: Umdrehen, Interaktion mit Munitionskisten, Gefangennahme, usw.</German>
-			<Spanish>Permite al jugador usar otras acciones: Recolocar vehículo, manipulación de cajas de munición, captura de prisioneros, etc.</Spanish>
-			<Russian>Позволить игроку остальные действия: перевернуть, манипуляции с ящиками боеприпасов, захват пленных, итп.</Russian>
-			<Italian>Permetti al giocatore di usare le altre funzioni come , catturare prigionieri,raddrizzare veicoli ecc.</Italian>
-			<Chinesesimp>允许玩家使用其他功能：翻正、货箱控制、俘虏战俘，等等。</Chinesesimp>
-			<Chinese>允許玩家使用其他功能，如：翻正、貨物控制（裝載、卸載、倉儲等）、俘虜戰俘，等等。</Chinese>
-			<Turkish>Oyuncunun şunları yapmasını sağlar: ters döndürme, kutuların yönetimi, esir yakalama, vb.</Turkish>
-			<Portuguese>Permite ao jogador executar outras ações: Desvirar veículo, manipular caixas de recursos, captura de prisioneiros, etc.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_ALL">
-			<Original>Gives all permissions to the player.</Original>
-			<French>Donne toutes les permissions au joueur.</French>
-			<German>Gibt dem Spieler alle Rechte</German>
-			<Spanish>Darle todos los permisos al jugador</Spanish>
-			<Russian>Разрешить всё игроку.</Russian>
-			<Italian>Permetti tutto al giocatore.</Italian>
-			<Chinesesimp>给予玩家所有权限。</Chinesesimp>
-			<Chinese>給予玩家所有權限。</Chinese>
-			<Turkish>Bütün yetkileri verir.</Turkish>
-			<Portuguese>Libera todas as permissões para o jogador.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_TOOLTIP_NONE">
-			<Original>Removes all permissions from the player.</Original>
-			<French>Supprime toutes les permissions du joueur.</French>
-			<German>Nimmt dem Spieler alle Rechte weg.</German>
-			<Spanish>Quitar todos los permisos al jugador</Spanish>
-			<Russian>Запретить всё игроку.</Russian>
-			<Italian>Rimuovi tutti i permessi al giocatore.</Italian>
-			<Chinesesimp>移除玩家所有权限。</Chinesesimp>
-			<Chinese>移除玩家所有權限。</Chinese>
-			<Turkish>Hiçbir yetkisi olmaz.</Turkish>
-			<Portuguese>Remove todas as permissões do jogador.</Portuguese>
-		</Key>
-		<Key ID="STR_COMMANDER_ACTION">
-			<Original>-- PERMISSIONS</Original>
-			<French>-- PERMISSIONS</French>
-			<German>-- RECHTE</German>
-			<Spanish>-- PERMISOS</Spanish>
-			<Russian>-- РАЗРЕШЕНИЯ</Russian>
-			<Italian>-- PERMESSI</Italian>
-			<Chinesesimp>-- 权限</Chinesesimp>
-			<Chinese>-- 權限</Chinese>
-			<Turkish>-- YETKİLER</Turkish>
-			<Portuguese>-- PERMISSÕES</Portuguese>
-		</Key>
-		<Key ID="STR_SAVE_CHANGES">
-			<Original>Save Changes</Original>
-			<French>Sauvegarder</French>
-			<German>Änderungen speichern</German>
-			<Spanish>Guardar cambios</Spanish>
-			<Russian>Сохранить Изменения</Russian>
-			<Italian>Salva Modifiche</Italian>
-			<Chinesesimp>保存更改</Chinesesimp>
-			<Chinese>儲存變更</Chinese>
-			<Turkish>Değişiklikleri kaydet</Turkish>
-			<Portuguese>Salvar alterações</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSIONS_PARAM">
-			<Original>Permissions Management</Original>
-			<French>Gestion des Permissions</French>
-			<German>Rechteverwaltung</German>
-			<Spanish>Gestión de permisos</Spanish>
-			<Russian>Управление Разрешениями</Russian>
-			<Italian>Permessi Gestione</Italian>
-			<Chinesesimp>权限管理</Chinesesimp>
-			<Chinese>權限管理</Chinese>
-			<Turkish>Yetkileri Yönet</Turkish>
-			<Portuguese>Gestão de Permissões</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSION_NO_LIGHT">
-			<Original>You don't have permission from the commander to use light vehicles.</Original>
-			<French>Vous n'avez pas la permission du commandant pour utiliser les véhicules légers.</French>
-			<German>Du hast keine Rechte zur Nutzung leichter Fahrzeuge.</German>
-			<Spanish>No tienes permiso del comandante para usar vehículos ligeros</Spanish>
-			<Russian>У тебя нет разрешения от командира использовать легкую технику.</Russian>
-			<Italian>Non hai il permesso di usare veicoli leggeri</Italian>
-			<Chinesesimp>指挥官没有给你使用轻型载具的权限。</Chinesesimp>
-			<Chinese>指揮官並沒有提供你輕型載具機組員權限。</Chinese>
-			<Turkish>Hafif araçları kullanmak için yetkiniz yok.</Turkish>
-			<Portuguese>Você não tem permissão do comandante para utilizar veículos leves.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSION_NO_ARMOR">
-			<Original>You don't have permission from the commander to use armored vehicles.</Original>
-			<French>Vous n'avez pas la permission du commandant pour utiliser les véhicules blindés.</French>
-			<German>Du hast keine Rechte zur Nutzung gepanzerter Fahrzeuge</German>
-			<Spanish>No tienes permiso del comandante para usar vehículos blindados</Spanish>
-			<Russian>У тебя нет разрешения от командира использовать бронированную технику.</Russian>
-			<Italian>Non hai il permesso di usare veicoli pesanti</Italian>
-			<Chinesesimp>指挥官没有给你使用装甲载具的权限。</Chinesesimp>
-			<Chinese>指揮官並沒有提供你裝甲載具機組員權限。</Chinese>
-			<Turkish>Zırhlı araçları kullanmanız için yetkiniz yok.</Turkish>
-			<Portuguese>Você não tem permissão do comandante para utilizar veículos blindados.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSION_NO_AIR">
-			<Original>You don't have permission from the commander to use air vehicles.</Original>
-			<French>Vous n'avez pas la permission du commandant pour utiliser les véhicules aériens.</French>
-			<German>Du hast keine Rechte zur Nutzung von Luftfahrzeugen</German>
-			<Spanish>No tienes permiso del comandante para usar vehículos aéreos</Spanish>
-			<Russian>У тебя нет разрешения от командира использовать авиацию.</Russian>
-			<Italian>Non hai il permesso di usare veivoli</Italian>
-			<Chinesesimp>指挥官没有给你使用空中载具的权限。</Chinesesimp>
-			<Chinese>指揮官並沒有提供你空中載具機組員權限。</Chinese>
-			<Turkish>Hava araçlarını kullanmanız için yetkiniz yok.</Turkish>
-			<Portuguese>Você não tem permissão do comandante para utilizar veículos aéreos.</Portuguese>
-		</Key>
-		<Key ID="STR_PERMISSION_WARNING">
-			<Original>No permissions have been set. The commander must setup the permissions to allow player actions and vehicle usage. Alternatively, the permission system can be disabled from the mission options.</Original>
-			<French>Aucune permission n'a été définie. Le commandant doit configurer les permissions pour permettre aux joueurs d'effectuer des actions et d'utiliser les véhicules. Sinon, le système de permissions peut être désactivé dans les options de mission.</French>
-			<German>Keine Rechte wurden vergeben. Der Kommandant muss die Rechte verwalten, um Spielern Aktionen und die Nutzung von Fahrzeugen zu erlaubne. Alternativ kann das Rechtesystem in den Missionsoptionen deaktiviert werden.</German>
-			<Spanish>No hay permisos definidos. El comandante debe asignar los permisos para permitir a los jugadores el uso de los vehículos y acciones. Alternativamente, puede desactivarse el sistema de permisos desde las opciones de misión</Spanish>
-			<Russian>Разрешения не были даны. Командир должен настроить разрешения, чтобы позволить игроку действия и использование техники. Кроме того, система разрешений может быть отключена в настройках миссии.</Russian>
-			<Italian>I permessi non sono settati.Il comandante deve entrare nel menu e attribuire i permessi ai giocatori.</Italian>
-			<Chinesesimp>没有设定任何权限。指挥官必须为玩家设定可用功能和载具。另外，权限系统可以在任务选项中关闭。</Chinesesimp>
-			<Chinese>沒有設定任何權限。指揮官必須為玩家指定可使用的功能與載具類型。另外，權限系統可以在任務選項中關閉。</Chinese>
-			<Turkish>Yetkiler ayarlanmadı. Komutan oyuncuların yapabilecekleri yetkileri ayarlamalı. Alternatif olarak, yetki sistemi görev ayarlarından kapatılabilir.</Turkish>
-			<Portuguese>Nenhuma permissão foi liberada. O comandante precisa alterar as permissões para permitir que o jogador execute ações e utiliza veículos. Alternativamente, o sistema de permissão pode ser desabilitado no menu de opções da missão.</Portuguese>
-		</Key>
-		<Key ID="STR_ARSENAL_TITLE">
-			<Original>ARSENAL</Original>
-			<French>ARSENAL</French>
-			<German>ARSENAL</German>
-			<Spanish>ARSENAL</Spanish>
-			<Russian>АРСЕНАЛ</Russian>
-			<Italian>ARSENALE</Italian>
-			<Chinesesimp>军火库</Chinesesimp>
-			<Chinese>軍火庫</Chinese>
-			<Turkish>ARSENAL</Turkish>
-			<Portuguese>ARSENAL</Portuguese>
-		</Key>
-		<Key ID="STR_EDIT_LOADOUT">
-			<Original>Edit loadout</Original>
-			<French>Modifier équipement</French>
-			<German>Ausrüstung bearbeiten</German>
-			<Spanish>Modificar equipamiento</Spanish>
-			<Russian>Редактировать</Russian>
-			<Italian>Modifica Equipaggiamneto</Italian>
-			<Chinesesimp>编辑装备</Chinesesimp>
-			<Chinese>編輯裝備</Chinese>
-			<Turkish>Ekipmanı düzenle</Turkish>
-			<Portuguese>Modificar equipamento</Portuguese>
-		</Key>
-		<Key ID="STR_LOAD_LOADOUT">
-			<Original>Take loadout</Original>
-			<French>Charger l'équipement</French>
-			<German>Ausrüstung laden</German>
-			<Spanish>Coger equipamiento</Spanish>
-			<Russian>Загрузить</Russian>
-			<Italian>Prendi Equipaggiamento</Italian>
-			<Chinesesimp>拿取装备</Chinesesimp>
-			<Chinese>領取裝備</Chinese>
-			<Turkish>Ekipman al</Turkish>
-			<Portuguese>Aceitar equipamento</Portuguese>
-		</Key>
-		<Key ID="STR_DEFAULT">
-			<Original>Default</Original>
-			<French>Par défaut</French>
-			<German>Standard</German>
-			<Spanish>Por defecto</Spanish>
-			<Russian>Стандартно</Russian>
-			<Italian>Default</Italian>
-			<Chinesesimp>默认</Chinesesimp>
-			<Chinese>預設</Chinese>
-			<Turkish>Varsayılan</Turkish>
-			<Portuguese>Padrão</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_REPACKAGE">
-			<Original>-- REPACKAGE FOB --</Original>
-			<French>-- REPLIER FOB --</French>
-			<German>-- FOB EINPACKEN --</German>
-			<Spanish>-- EMPAQUETAR FOB --</Spanish>
-			<Russian>-- СВЕРНУТЬ FOB --</Russian>
-			<Italian>-- SMONTA FOB --</Italian>
-			<Chinesesimp>-- 收起前哨 --</Chinesesimp>
-			<Chinese>-- 收起前線基地 --</Chinese>
-			<Turkish>-- FOB YENIDEN PAKETLE --</Turkish>
-			<Portuguese>-- MOBILIZAR FOB --</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_REPACKAGE_TITLE">
-			<Original>REPACKAGE FOB</Original>
-			<French>REPLIER FOB</French>
-			<German>FOB EINPACKEN</German>
-			<Spanish>EMPAQUETAR FOB</Spanish>
-			<Russian>СВЕРНУТЬ FOB</Russian>
-			<Italian>SMONTA FOB</Italian>
-			<Chinesesimp>收起前哨</Chinesesimp>
-			<Chinese>收起前線基地</Chinese>
-			<Turkish>FOB YENIDEN PAKETLE</Turkish>
-			<Portuguese>MOBILIZAR FOB</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_REPACKAGE_CONFIRM">
-			<Original>Are you sure you want to repackage this FOB?</Original>
-			<French>Etes-vous sur de vouloir replier cette fob?</French>
-			<German>Bist du dir sicher, dass du deine FOB einpacken willst?</German>
-			<Spanish>¿Estas seguro de querer reempaquetar esta FOB?</Spanish>
-			<Russian>Ты уверен что хочешь свернуть эту FOB?</Russian>
-			<Italian>Sei sicuro di voler smontare la FOB?</Italian>
-			<Chinesesimp>你确定要收起这个前哨？</Chinesesimp>
-			<Chinese>你確定要收起這個前線基地？</Chinese>
-			<Turkish>Bu FOB'yi yeniden paketlemek istediğinize emin misiniz?</Turkish>
-			<Portuguese>Você tem certeza que quer mobilizar esta FOB?</Portuguese>
-		</Key>
-		<Key ID="STR_FOB_REPACKAGE_HINT">
-			<Original>FOB repackaged.</Original>
-			<French>FOB repliée.</French>
-			<German>FOB eingepackt.</German>
-			<Spanish>FOB reempaquetada</Spanish>
-			<Russian>FOB свёрнута</Russian>
-			<Italian>FOB smontata.</Italian>
-			<Chinesesimp>前哨已收起。</Chinesesimp>
-			<Chinese>前線基地已收起。</Chinese>
-			<Turkish>FOB yeniden paketlendi.</Turkish>
-			<Portuguese>FOB mobilizada.</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM">
-			<Original>HALO jump</Original>
-			<French>Saut HALO</French>
-			<German>HALO-Sprung</German>
-			<Spanish>Salto HALO</Spanish>
-			<Russian>HALO прыжок</Russian>
-			<Italian>PARACADUTARSI</Italian>
-			<Chinesesimp>伞降</Chinesesimp>
-			<Chinese>跳傘</Chinese>
-			<Turkish>HALO atlayışı</Turkish>
-			<Portuguese>Salto em queda livre</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM1">
-			<Original>Enabled - No cooldown</Original>
-			<French>Activé - Pas de cooldown</French>
-			<German>Aktiviert - Keine Abklingzeit</German>
-			<Spanish>Activado - Sin tiempo de espera</Spanish>
-			<Russian>Вкл - без перерыва</Russian>
-			<Italian>Attivato - Senza attesa</Italian>
-			<Chinesesimp>开启 - 无冷却</Chinesesimp>
-			<Chinese>開啟 - 無冷卻</Chinese>
-			<Turkish>Açık - Süre yok</Turkish>
-			<Portuguese>Ativado - Sem tempo de espera</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM2">
-			<Original>Enabled - 5 minutes cooldown</Original>
-			<French>Activé - Cooldown de 5 minutes</French>
-			<German>Aktiviert - 5 Minuten Abklingzeit</German>
-			<Spanish>Activado - 5 minutos de espera</Spanish>
-			<Russian>Вкл - 5 минут перерыв</Russian>
-			<Italian>Attivato - 5 minuti di attesa</Italian>
-			<Chinesesimp>开启 - 5分钟冷却</Chinesesimp>
-			<Chinese>開啟 - 5 分鐘冷卻</Chinese>
-			<Turkish>Açık - 5 dakika bekleme süresi</Turkish>
-			<Portuguese>Ativado - Espera de 5 minutos</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM3">
-			<Original>Enabled - 10 minutes cooldown</Original>
-			<French>Activé - Cooldown de 10 minutes</French>
-			<German>Aktiviert - 10 Minuten Abklingzeit</German>
-			<Spanish>Activado - 10 minutos de espera</Spanish>
-			<Russian>Вкл - 10 минут перерыв</Russian>
-			<Italian>Attivato - 10 minuti di attesa</Italian>
-			<Chinesesimp>开启 - 10分钟冷却</Chinesesimp>
-			<Chinese>開啟 - 10 分鐘冷卻</Chinese>
-			<Turkish>Açık - 10 dakika bekleme süresi</Turkish>
-			<Portuguese>Ativado - Espera de 10 minutos</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM4">
-			<Original>Enabled - 15 minutes cooldown</Original>
-			<French>Activé - Cooldown de 15 minutes</French>
-			<German>Aktiviert - 15 Minuten Abklingzeit</German>
-			<Spanish>Activado - 15 minutos de espera</Spanish>
-			<Russian>Вкл - 15 минут перерыв</Russian>
-			<Italian>Attivato - 15 minuti di attesa</Italian>
-			<Chinesesimp>开启 - 15分钟冷却</Chinesesimp>
-			<Chinese>開啟 - 15 分鐘冷卻</Chinese>
-			<Turkish>Açık - 15 dakika bekleme süresi</Turkish>
-			<Portuguese>Ativado - Espera de 15 minutos</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM5">
-			<Original>Enabled - 20 minutes cooldown</Original>
-			<French>Activé - Cooldown de 20 minutes</French>
-			<German>Aktiviert - 20 Minuten Abklingzeit</German>
-			<Spanish>Activado - 20 minutos de espera</Spanish>
-			<Russian>Вкл - 20 минут перерыв</Russian>
-			<Italian>Attivato - 20 minuti di attesa</Italian>
-			<Chinesesimp>开启 - 20分钟冷却</Chinesesimp>
-			<Chinese>開啟 - 20 分鐘冷卻</Chinese>
-			<Turkish>Açık - 20 dakika bekleme süresi</Turkish>
-			<Portuguese>Ativado - Espera de 20 minutos</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_PARAM6">
-			<Original>Enabled - 30 minutes cooldown</Original>
-			<French>Activé - Cooldown de 30 minutes</French>
-			<German>Aktiviert - 30 Minuten Abklingzeut</German>
-			<Spanish>Activado - 30 minutos de espera</Spanish>
-			<Russian>Вкл - 30 минут перерыв</Russian>
-			<Italian>Attivato - 30 minuti di attesa</Italian>
-			<Chinesesimp>开启 - 30分钟冷却</Chinesesimp>
-			<Chinese>開啟 - 30 分鐘冷卻</Chinese>
-			<Turkish>Açık - 30 dakika bekleme süresi</Turkish>
-			<Portuguese>Ativado - Espera de 30 minutos</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_DENIED_COOLDOWN">
-			<Original>Can't perform HALO jump, you are on cooldown for %1 more minute(s).</Original>
-			<French>Impossible d'effectuer un suat HALO, vous êtes en cooldown pour encore %1 minute(s).</French>
-			<German>HALO Sprung noch nicht möglich. Verbleibende Abklingzeit von %1 Minuten.</German>
-			<Spanish>No puedes saltar en HALO, te quedan %1 minuto(s) de espera.</Spanish>
-			<Russian>HALO прыжок недоступен, подождите %1 минут</Russian>
-			<Italian>Non puoi paracadutarti, hai un attesa di %1 minuti.</Italian>
-			<Chinesesimp>无法进行伞降，剩余冷却时间为%1分钟。</Chinesesimp>
-			<Chinese>無法進行跳傘，還需要 %1 分鐘的冷卻時間。</Chinese>
-			<Turkish>HALO jump yapılamıyor, %1 dakika beklemelisiniz.</Turkish>
-			<Portuguese>Não é possível executar o salto em queda livre, o tempo de espera é de %1 minuto(s).</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_ACTION">
-			<Original>-- HALO JUMP</Original>
-			<French>-- SAUT HALO</French>
-			<German>-- HALO-SPRUNG</German>
-			<Spanish>-- SALTO HALO</Spanish>
-			<Russian>-- HALO прыжок</Russian>
-			<Italian>-- PARACADUTARSI</Italian>
-			<Chinesesimp>-- 伞降</Chinesesimp>
-			<Chinese>-- 跳傘</Chinese>
-			<Turkish>-- HALO Atla</Turkish>
-			<Portuguese>-- Salto em queda livre</Portuguese>
-		</Key>
-		<Key ID="STR_HALO_TITLE">
-			<Original>HALO JUMP</Original>
-			<French>SAUT HALO</French>
-			<German>HALO-SPRUNG</German>
-			<Spanish>SALTO HALO</Spanish>
-			<Russian>HALO ПРЫЖОК</Russian>
-			<Italian>PARACADUTARSI</Italian>
-			<Chinesesimp>伞降</Chinesesimp>
-			<Chinese>跳傘</Chinese>
-			<Turkish>HALO ATLAYIŞI</Turkish>
-			<Portuguese>Salto em queda livre</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_CLEAR_CARGO">
-			<Original>Clear spawned vehicle cargo</Original>
-			<German>Inventar gespawnter Fahrzeuge leeren</German>
-			<Italian>Cancella il carico del veicolo creato</Italian>
-			<Portuguese>Remover carga do veículo requisitado</Portuguese>
-			<Chinese>移除載具上的物品</Chinese>
-		</Key>
-		<Key ID="STR_DEPLOY_IN_PROGRESS">
-			<Original>Deployment in progress...</Original>
-			<French>Déploiement en cours...</French>
-			<German>Verlegung im Gange</German>
-			<Spanish>Despliegue en curso...</Spanish>
-			<Russian>В процессе выполнения ...</Russian>
-			<Italian>In attesa del lancio ...</Italian>
-			<Chinesesimp>正在部署中...</Chinesesimp>
-			<Chinese>正在佈署中...</Chinese>
-			<Turkish>Atlanılıyor...</Turkish>
-			<Portuguese>Mobilização em andamento...</Portuguese>
-		</Key>
-		<Key ID="STR_WHITELIST_PARAM">
-			<Original>Use the commander whitelist</Original>
-			<French>Utiliser la whitelist pour le commandant</French>
-			<German>Nutze die Whitelist für den Kommandanten</German>
-			<Spanish>Utilizar la lista blanca para Comandantes</Spanish>
-			<Russian>Использование "белого" списка командиров</Russian>
-			<Italian>Usa la whitelist del comandante</Italian>
-			<Chinesesimp>使用指挥官白名单</Chinesesimp>
-			<Chinese>使用指揮官白名單</Chinese>
-			<Turkish>Komutanlar için beyaz liste kullan</Turkish>
-			<Portuguese>Use a lista de permissões de comandantes</Portuguese>
-		</Key>
-		<Key ID="STR_WHITELIST_ENABLED">
-			<Original>Enabled - Only use if you have modified your whitelist.sqf!</Original>
-			<German>Aktiviert - Nur benutzen, wenn du deine whitelist.sqf verändert hast!</German>
-			<French>Activé - A n'utiliser que si vous avez modifié votre whitelist.sqf !</French>
-			<Spanish>Activado - ¡Sólo utilizar si has modificado tu whitelist.sqf</Spanish>
-			<Russian>Вкл - Использовать только если вы редактировали файл whitelist.sqf!</Russian>
-			<Italian>Attiva - Solo se hai modificato la tua whitelist.sqf!</Italian>
-			<Chinesesimp>开启 - 只有在设立了whitelist.sqf时才能用这个选项！</Chinesesimp>
-			<Chinese>開啟 - 只有在設立了whitelist.sqf時才能使用這個選項！</Chinese>
-			<Turkish>Aktif - whitelist.sqf dosyası ayarlanmış olmalı.</Turkish>
-			<Portuguese>Ativado - Apenas use se tiver modificado o arquivo whitelist.sqf!</Portuguese>
-		</Key>
-		<Key ID="STR_BUILD_ENEMIES_NEARBY">
-			<Original>Cannot build: hostile forces nearby.</Original>
-			<French>Impossible de construire: forces hostiles à proximité.</French>
-			<German>Kann nicht gebaut werden: Feindkräfte in der Nähe</German>
-			<Spanish>No se puede construir: fuerzas hostiles cercanas</Spanish>
-			<Russian>Постройка невозможна: враги рядом.</Russian>
-			<Italian>Impossibile costruire: forze ostili nelle vicinanze</Italian>
-			<Chinesesimp>无法建造：附近有敌军部队。</Chinesesimp>
-			<Chinese>目前無法建造：附近有敵軍部隊。</Chinese>
-			<Turkish>Kurulamaz: Düşmanlar yakında.</Turkish>
-			<Portuguese>Não é possível construir: Forças hostis na proximidade.</Portuguese>
-		</Key>
-		<Key ID="STR_CLEANUP_PARAM">
-			<Original>Cleanup abandoned vehicles outside FOBs</Original>
-			<French>Nettoyer les véhicules abandonnés loin d'une FOB</French>
-			<German>Räumt verlassene Fahrzeuge auserhalb von FOBs weg</German>
-			<Spanish>Limpieza de vehículos abandonados fuera de FOBs</Spanish>
-			<Russian>Удаление брошенной техники вне FOB.</Russian>
-			<Italian>Eliminazione di veicoli abbandonati fuori le FOB</Italian>
-			<Chinesesimp>清理前哨外的废弃载具</Chinesesimp>
-			<Chinese>清理前線基地外的廢棄載具</Chinese>
-			<Turkish>FOB dışındaki araçların temizlenmesi</Turkish>
-			<Portuguese>Remover veículos abandonados fora das FOBs</Portuguese>
-		</Key>
-		<Key ID="STR_CLEANUP_PARAM1">
-			<Original>Enabled - 1 hour delay</Original>
-			<French>Activé - 1 heure de délai</French>
-			<German>Aktiv - 1 Stunde Verzögerung</German>
-			<Spanish>Activado- abandonados durante 1 hora</Spanish>
-			<Russian>Вкл - задержка 1 час</Russian>
-			<Italian>Attivato - eliminazione ogni ora</Italian>
-			<Chinesesimp>开启 - 1小时延迟</Chinesesimp>
-			<Chinese>開啟 - 延遲 1 小時</Chinese>
-			<Turkish>Açık - 1 saat gecikmeli</Turkish>
-			<Portuguese>Ativado - 1 hora para remoção</Portuguese>
-		</Key>
-		<Key ID="STR_CLEANUP_PARAM2">
-			<Original>Enabled - 2 hours delay</Original>
-			<French>Activé - 2 heures de délai</French>
-			<German>Aktiv - 2 Stunde Verzögerung</German>
-			<Spanish>Activado - abandonados durante 2 horas</Spanish>
-			<Russian>Вкл - задержка 2 часа</Russian>
-			<Italian>Attivato - eliminazione ogni 2 ore</Italian>
-			<Chinesesimp>开启 - 2小时延迟</Chinesesimp>
-			<Chinese>開啟 - 延遲 2 小時</Chinese>
-			<Turkish>Açık - 2 saat gecikmeli</Turkish>
-			<Portuguese>Ativado - 2 horas para remoção</Portuguese>
-		</Key>
-		<Key ID="STR_CLEANUP_PARAM3">
-			<Original>Enabled - 4 hours delay</Original>
-			<French>Activé - 4 heures de délai</French>
-			<German>Aktiv - 4 Stunden Verzögerung</German>
-			<Spanish>Activado - abandonados durante 4 horas</Spanish>
-			<Russian>Вкл - задержка 4 часа</Russian>
-			<Italian>Attivato - eliminazione ogni 4 ore</Italian>
-			<Chinesesimp>开启 - 4小时延迟</Chinesesimp>
-			<Chinese>開啟 - 延遲 4 小時</Chinese>
-			<Turkish>Açık - 4 saat gecikmeli</Turkish>
-			<Portuguese>Ativado - 4 horas para remoção</Portuguese>
-		</Key>
-		<Key ID="STR_SORRY">
-			<Original>Sorry!</Original>
-			<French>Désolé !</French>
-			<German>Entschuldigung!</German>
-			<Spanish>Lo siento!</Spanish>
-			<Russian>Извини!</Russian>
-			<Italian>Scusa!</Italian>
-			<Chinesesimp>抱歉！</Chinesesimp>
-			<Chinese>抱歉！</Chinese>
-			<Turkish>Özür dilerim!</Turkish>
-			<Portuguese>Desculpe!</Portuguese>
-		</Key>
-		<Key ID="STR_COMMANDER_NOT_AUTHORIZED">
-			<Original>You are not authorized to use the commander slot on this server.</Original>
-			<French>Vous n'êtes pas authorizé à utiliser la place de commandant sur ce serveur.</French>
-			<German>Du bist auf diesem Server nicht als Kommandant autorisiert.</German>
-			<Spanish>No estás autorizado para usar el slot de comandante en este servidor.</Spanish>
-			<Russian>Вы не авторизованы, чтобы использовать слот коммандира на этом сервере.</Russian>
-			<Italian>Non sei autorizzato ad usare lo slot comandante in questo server.</Italian>
-			<Chinesesimp>你没有使用这个服务器指挥官栏位的权限。</Chinesesimp>
-			<Chinese>你並沒有使用這個伺服器指揮官欄位的權限。</Chinese>
-			<Turkish>Komutan slotunu kullanmak için seçilmemişsiniz.</Turkish>
-			<Portuguese>Você não está autorizado a usar o slot de comandante neste servidor.</Portuguese>
-		</Key>
-		<Key ID="STR_MAKE_RESPAWN_LOADOUT">
-			<Original>Save respawn loadout</Original>
-			<French>Equipement de respawn</French>
-			<German>Ausrüstung bei Respawn festlegen</German>
-			<Spanish>Guardar el equipamiento para respawn</Spanish>
-			<Russian>Всегда загружать</Russian>
-			<Italian>Salva Equipaggiamento </Italian>
-			<Chinesesimp>保存重生装备</Chinesesimp>
-			<Chinese>設定為重生裝備</Chinese>
-			<Turkish>Respawn ekipmanını kaydet.</Turkish>
-			<Portuguese>Salvar equipamento para respawn.</Portuguese>
-		</Key>
-		<Key ID="STR_MAKE_RESPAWN_LOADOUT_HINT">
-			<Original>Your current loadout will be restored on every respawn.</Original>
-			<French>Votre equipement actuel sera restauré à chaque respawn.</French>
-			<German>Deine Ausrüstung wird bei jedem Respwan wiederhergestellt.</German>
-			<Spanish>Tu actual equipamiento seá mantenido en cada respawn.</Spanish>
-			<Russian>Ваше текущее снаряжение будет загружаться после каждого возраждения</Russian>
-			<Italian>Il tuo equipaggiamneto sarà ricaricato ad ogni respawn</Italian>
-			<Chinesesimp>你的装备将在重生时恢复到现有状态。</Chinesesimp>
-			<Chinese>重生後，你的裝備將恢復到現有狀態。</Chinese>
-			<Turkish>Şuanki ekipmanınız her doğduğunuzda yeniden verilecek.</Turkish>
-			<Portuguese>Seu equipamento atual será restaurado em cada respawn.</Portuguese>
-		</Key>
-		<Key ID="STR_LOAD_PLAYER_LOADOUT">
-			<Original>Load from player</Original>
-			<French>Charger depuis joueur</French>
-			<German>Von Spieler laden</German>
-			<Spanish>Cargar desde jugador</Spanish>
-			<Russian>Из игрока</Russian>
-			<Italian>Carica da giocatore</Italian>
-			<Chinesesimp>读取其他玩家装备</Chinesesimp>
-			<Chinese>複製其他玩家裝備</Chinese>
-			<Turkish>Diğer oyuncudan al</Turkish>
-			<Portuguese>Copiar do jogador</Portuguese>
-		</Key>
-		<Key ID="STR_LOAD_PLAYER_LOADOUT_HINT">
-			<Original>Successful loadout transfer from %1.</Original>
-			<French>Transfer d'équipement réussi depuis %1.</French>
-			<German>Erfolgreich Ausrüstung von %1 übertragen.</German>
-			<Spanish>Transferencia de equipamiento de %1 terminada.</Spanish>
-			<Russian>Успешная загрузка снаряжения игрока %1</Russian>
-			<Italian>Equipaggiamento traferito correttamente da %1</Italian>
-			<Chinesesimp>成功从%1读取了装备</Chinesesimp>
-			<Chinese>成功複製了 %1 的裝備</Chinese>
-			<Turkish>%1 den ekipman alındı.</Turkish>
-			<Portuguese>Transferência de loadout de %1 realizada.</Portuguese>
-		</Key>
-		<Key ID="STR_LOADOUT">
-			<Original>Loadout:</Original>
-			<French>Equipement :</French>
-			<German>Ausrüstung:</German>
-			<Spanish>Equipamiento:</Spanish>
-			<Russian>Снаряжение:</Russian>
-			<Italian>Equipaggiamento:</Italian>
-			<Chinesesimp>装备：</Chinesesimp>
-			<Chinese>裝備</Chinese>
-			<Turkish>Ekipman:</Turkish>
-			<Portuguese>Equipamento:</Portuguese>
-		</Key>
-		<Key ID="STR_SPAWN_POINT">
-			<Original>Deployment location:</Original>
-			<French>Lieu de déploiement :</French>
-			<German>Einsatzposition:</German>
-			<Spanish>Lugar para el despliegue:</Spanish>
-			<Russian>Позиция размешения:</Russian>
-			<Italian>Luogo di Schieramento:</Italian>
-			<Chinesesimp>部署地点：</Chinesesimp>
-			<Chinese>佈署地點：</Chinese>
-			<Turkish>Doğma noktası:</Turkish>
-			<Portuguese>Local para mobilização:</Portuguese>
-		</Key>
-		<Key ID="STR_AGGRESSIVITY_PARAM">
-			<Original>OPFOR aggressivity</Original>
-			<French>Aggressivité de l'OPFOR</French>
-			<German>OPFOR Aggressivität</German>
-			<Spanish>Agresividad del OPFOR</Spanish>
-			<Russian>Уровень обеспокоенности OPFOR</Russian>
-			<Italian>Aggressività OPFOR</Italian>
-			<Chinesesimp>敌军进攻性</Chinesesimp>
-			<Chinese>敵軍侵略度</Chinese>
-			<Turkish>OPFOR agresifliği</Turkish>
-			<Portuguese>Agressividade inimiga</Portuguese>
-		</Key>
-		<Key ID="STR_AGGRESSIVITY_PARAM0">
-			<Original>Anemic</Original>
-			<French>Anémique</French>
-			<German>Mutlos</German>
-			<Spanish>Anémica</Spanish>
-			<Russian>Вяло</Russian>
-			<Italian>Anemico</Italian>
-			<Chinesesimp>可悲</Chinesesimp>
-			<Chinese>可悲</Chinese>
-			<Turkish>Pasif</Turkish>
-			<Portuguese>Anêmica</Portuguese>
-		</Key>
-		<Key ID="STR_AGGRESSIVITY_PARAM1">
-			<Original>Weak</Original>
-			<French>Faible</French>
-			<German>Schwach</German>
-			<Spanish>Floja</Spanish>
-			<Russian>Слабо</Russian>
-			<Italian>Debole</Italian>
-			<Chinesesimp>弱小</Chinesesimp>
-			<Chinese>弱小</Chinese>
-			<Turkish>Zayıf</Turkish>
-			<Portuguese>Fraca</Portuguese>
-		</Key>
-		<Key ID="STR_AGGRESSIVITY_PARAM2">
-			<Original>Normal</Original>
-			<French>Normale</French>
-			<German>Normal</German>
-			<Spanish>Normal</Spanish>
-			<Russian>Нормально</Russian>
-			<Italian>Normale</Italian>
-			<Chinesesimp>正常</Chinesesimp>
-			<Chinese>正常</Chinese>
-			<Turkish>Normal</Turkish>
-			<Portuguese>Normal</Portuguese>
-		</Key>
-		<Key ID="STR_AGGRESSIVITY_PARAM3">
-			<Original>Strong</Original>
-			<French>Forte</French>
-			<German>Stark</German>
-			<Spanish>Fuerte</Spanish>
-			<Russian>Сильно</Russian>
-			<Italian>Forte</Italian>
-			<Chinesesimp>强大</Chinesesimp>
-			<Chinese>強大</Chinese>
-			<Turkish>Güçlü</Turkish>
-			<Portuguese>Forte</Portuguese>
-		</Key>
-		<Key ID="STR_AGGRESSIVITY_PARAM4">
-			<Original>Extreme</Original>
-			<French>Extreme</French>
-			<German>Extrem</German>
-			<Spanish>Extrema</Spanish>
-			<Russian>Очень сильно</Russian>
-			<Italian>Estremo</Italian>
-			<Chinesesimp>噩梦</Chinesesimp>
-			<Chinese>惡夢</Chinese>
-			<Turkish>Extreme</Turkish>
-			<Portuguese>Extrema</Portuguese>
-		</Key>
-		<Key ID="STR_WEATHER_PARAM">
-			<Original>Weather</Original>
-			<French>Meteo</French>
-			<German>Wetter</German>
-			<Spanish>Clima</Spanish>
-			<Russian>Погода</Russian>
-			<Italian>Meteo</Italian>
-			<Chinesesimp>天气</Chinesesimp>
-			<Chinese>天氣</Chinese>
-			<Turkish>Hava</Turkish>
-			<Portuguese>Clima</Portuguese>
-		</Key>
-		<Key ID="STR_WEATHER_PARAM1">
-			<Original>Always sunny</Original>
-			<French>Soleil permanent</French>
-			<German>Immer sonnig</German>
-			<Spanish>Siempre soleado</Spanish>
-			<Russian>Всегда солнечно</Russian>
-			<Italian>Semopre Soleggiato</Italian>
-			<Chinesesimp>永远晴天</Chinesesimp>
-			<Chinese>永遠晴天</Chinese>
-			<Turkish>Hep güneşli</Turkish>
-			<Portuguese>Sempre ensolarado</Portuguese>
-		</Key>
-		<Key ID="STR_WEATHER_PARAM2">
-			<Original>Random without rain</Original>
-			<French>Aléatoire sans pluie</French>
-			<German>Zufällig ohne Regen</German>
-			<Spanish>Aleatorio sin lluvia</Spanish>
-			<Russian>Случайно, без дождя</Russian>
-			<Italian>Casuale senza pioggia</Italian>
-			<Chinesesimp>随机但无雨</Chinesesimp>
-			<Chinese>隨機但無雨</Chinese>
-			<Turkish>Rasgele ama yağmursuz</Turkish>
-			<Portuguese>Aleatório sem chuva</Portuguese>
-		</Key>
-		<Key ID="STR_WEATHER_PARAM3">
-			<Original>Random</Original>
-			<French>Aléatoire</French>
-			<German>Zufällig</German>
-			<Spanish>Aleatorio</Spanish>
-			<Russian>Случайно</Russian>
-			<Italian>Casuale</Italian>
-			<Chinesesimp>随机</Chinesesimp>
-			<Chinese>完全隨機</Chinese>
-			<Turkish>Rasgele</Turkish>
-			<Portuguese>Aleatório</Portuguese>
-		</Key>
-		<Key ID="STR_SHORTER_NIGHTS_PARAM">
-			<Original>Shorter nights</Original>
-			<French>Nuits plus courtes</French>
-			<German>Kürzere Nächte</German>
-			<Spanish>Noches más cortas</Spanish>
-			<Russian>Короткие ночи</Russian>
-			<Italian>Notte Breve</Italian>
-			<Chinesesimp>短暂夜晚</Chinesesimp>
-			<Chinese>短暫夜晚</Chinese>
-			<Turkish>Kısa geceler</Turkish>
-			<Portuguese>Noites curtas</Portuguese>
-		</Key>
-		<Key ID="STR_REPAIRING">
-			<Original>Repairing</Original>
-			<French>Réparation</French>
-			<German>Repariert</German>
-			<Spanish>Reparando</Spanish>
-			<Russian>Ремонт</Russian>
-			<Italian>Riparazione</Italian>
-			<Chinesesimp>修理中</Chinesesimp>
-			<Chinese>修理中</Chinese>
-			<Turkish>Tamir</Turkish>
-			<Portuguese>Reparando</Portuguese>
-		</Key>
-		<Key ID="STR_REARMING">
-			<Original>Rearming in %1s</Original>
-			<French>Réarmement dans %1s</French>
-			<German>Aufmunitioniert in %1s</German>
-			<Spanish>Rearmando en %1s</Spanish>
-			<Russian>Перезарядка за %1с</Russian>
-			<Italian>Riarmando 1%</Italian>
-			<Chinesesimp>%1后开始补充弹药</Chinesesimp>
-			<Chinese>%1 秒後開始補充彈藥</Chinese>
-			<Turkish>%1 saniye içinde yeniden dolduruluyor</Turkish>
-			<Portuguese>Remuniciando em %1s</Portuguese>
-		</Key>
-		<Key ID="STR_REFUELING">
-			<Original>Refueling</Original>
-			<French>Ravitaillement</French>
-			<German>Auftanken</German>
-			<Spanish>Repostando</Spanish>
-			<Russian>Заправка</Russian>
-			<Italian>Rifornendo</Italian>
-			<Chinesesimp>加油中</Chinesesimp>
-			<Chinese>加油中</Chinese>
-			<Turkish>Yakıt koyuluyor</Turkish>
-			<Portuguese>Reabastecendo</Portuguese>
-		</Key>
-		<Key ID="STR_INTEL">
-			<Original>-- TAKE INTEL</Original>
-			<French>-- PRENDRE INTEL</French>
-			<German>-- GEHEIMDIENSTINFORMATIONEN AUFNEHMEN</German>
-			<Spanish>-- COGER INTELIGENCIA</Spanish>
-			<Russian>-- ПОЛУЧИТЬ РАЗВЕДДАННЫЕ</Russian>
-			<Italian>-- PREDI INTEL</Italian>
-			<Chinesesimp>-- 拿取情报</Chinesesimp>
-			<Chinese>-- 拿取情報</Chinese>
-			<Turkish>-- İSTİHBAHRAT AL</Turkish>
-			<Portuguese>-- PEGAR INTELIGÊNCIA</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_OBJECTIVES">
-			<Original>-- SECONDARY OBJECTIVES</Original>
-			<French>-- OBJECTIFS SECONDAIRES</French>
-			<German>-- SEKUNDÄRE ZIELE</German>
-			<Spanish>-- OBJETIVOS SECUNDARIOS</Spanish>
-			<Russian>-- ДОПОЛНИТЕЛЬНЫЕ ЗАДАЧИ</Russian>
-			<Italian>-- OBIETTIVI SECONDARI</Italian>
-			<Chinesesimp>-- 次要目标</Chinesesimp>
-			<Chinese>-- 次要目標</Chinese>
-			<Turkish>-- İKİNCİ GÖREVLER</Turkish>
-			<Portuguese>-- OBJETIVOS SECUNDÁRIOS</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_OBJECTIVES_TITLE">
-			<Original>SECONDARY OBJECTIVES</Original>
-			<French>OBJECTIFS SECONDAIRES</French>
-			<German>SEKUNDÄRE ZIELE</German>
-			<Spanish>OBJETIVOS SECUNDARIOS</Spanish>
-			<Russian>ДОПОЛНИТЕЛЬНЫЕ ЗАДАЧИ</Russian>
-			<Italian>OBIETTIVI SECONDARI</Italian>
-			<Chinesesimp>次要目标</Chinesesimp>
-			<Chinese>次要目標</Chinese>
-			<Turkish>İKİNCİ GÖREVLER</Turkish>
-			<Portuguese>OBJETIVOS SECUNDÁRIOS</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_OBJECTIVES_START">
-			<Original>Start</Original>
-			<French>Commencer</French>
-			<German>Beginnen</German>
-			<Spanish>Empezar</Spanish>
-			<Russian>Старт</Russian>
-			<Italian>Inizia</Italian>
-			<Chinesesimp>开始</Chinesesimp>
-			<Chinese>開始</Chinese>
-			<Turkish>Başla</Turkish>
-			<Portuguese>Iniciar</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_INTEL">
-			<Original>Current intel: %1</Original>
-			<French>Intel actuelle : %1</French>
-			<German>Aktuelle Geheimdienstinformationen: %1</German>
-			<Spanish>Inteligencia actual: %1</Spanish>
-			<Russian>Разведданные: %1</Russian>
-			<Italian>Intel Attuale: %1</Italian>
-			<Chinesesimp>当前情报：%1</Chinesesimp>
-			<Chinese>目前情報：%1</Chinese>
-			<Turkish>Şuanki istihbahrat: %1</Turkish>
-			<Portuguese>Inteligência atual: %1</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_NOT_ENOUGH_INTEL">
-			<Original>Insufficient intel points</Original>
-			<French>Points d'intel insuffisants</French>
-			<German>Zu wenige Geheimdienstinformationen</German>
-			<Spanish>Puntos de inteligencia insuficientes</Spanish>
-			<Russian>Недостаточно информации</Russian>
-			<Italian>Punti intel insufficenti</Italian>
-			<Chinesesimp>情报点不足</Chinesesimp>
-			<Chinese>情報點不足</Chinese>
-			<Turkish>Yetersiz istihbahrat</Turkish>
-			<Portuguese>Pontos de inteligencia insuficientes</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_IN_PROGRESS">
-			<Original>Secondary mission already in progress</Original>
-			<French>Mission secondaire déjà en cours</French>
-			<German>Sekundäre Mission läuft bereits</German>
-			<Spanish>Misión secundaria ya en curso</Spanish>
-			<Russian>Дополнительная задача уже есть</Russian>
-			<Italian>Missione secondaria attualmente in progresso</Italian>
-			<Chinesesimp>次要任务正在进行中</Chinesesimp>
-			<Chinese>次要目標正在進行中</Chinese>
-			<Turkish>Başka bir görev zaten çalışıyor.</Turkish>
-			<Portuguese>A missão secundária já está em andamento</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_INCOMING_TEXT">
-			<Original>Hostile forces are heading towards %1.</Original>
-			<French>Les forces hostiles se dirigent vers %1.</French>
-			<German>Feindliche Streitkräfte bewegen sich auf %1 zu.</German>
-			<Spanish>Fuerzas hostiles acercándose a %1.</Spanish>
-			<Russian>Замечена вражеская группа рядом с %1</Russian>
-			<Italian>Forze ostili sono in avvicinamento su %1.</Italian>
-			<Chinesesimp>敌军部队正在前往%1</Chinesesimp>
-			<Chinese>敵軍正在前往 %1</Chinese>
-			<Turkish>Düşmanlar %1 'e gidiyor.'</Turkish>
-			<Portuguese>Forças hostis estão a caminho de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_CSAT_CONVOY">
-			<Original>OPFOR Convoy</Original>
-			<French>Convoi OPFOR</French>
-			<German>OPFOR Konvoi</German>
-			<Spanish>Convoy OPFOR</Spanish>
-			<Russian>Конвой OPFOR</Russian>
-			<Italian>Convoglio OPFOR</Italian>
-			<Chinesesimp>敌军车队</Chinesesimp>
-			<Chinese>敵方車隊</Chinese>
-			<Turkish>OPFOR Konvoyu</Turkish>
-			<Portuguese>Comboio inimigo</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_CSAT_CONVOY_WP">
-			<Original>Waypoint</Original>
-			<French>Point de passage</French>
-			<German>Wegpunkt</German>
-			<Spanish>Punto de ruta</Spanish>
-			<Russian>Путевая точка</Russian>
-			<Italian>Punto di Passaggio</Italian>
-			<Chinesesimp>路径点</Chinesesimp>
-			<Chinese>路徑點</Chinese>
-			<Turkish>Varış noktası</Turkish>
-			<Portuguese>Waypoint</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CONVOY_DESTROYED_TEXT">
-			<Original>OPFOR Convoy neutralized.</Original>
-			<French>Convoi OPFOR neutralisé.</French>
-			<German>OPFOR Konvoi neutralisiert.</German>
-			<Spanish>Convoy OPFOR neutralizado</Spanish>
-			<Russian>Конвой OPFOR нейтрализован.</Russian>
-			<Italian>Convoglio OPFOR neutralizzato.</Italian>
-			<Chinesesimp>敌军车队已被消灭</Chinesesimp>
-			<Chinese>敵方車隊已被殲滅</Chinese>
-			<Turkish>OPFOR Konvoyu etkisizleştirildi.</Turkish>
-			<Portuguese>Comboio inimigo neutralizado.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CONVOY_SPOTTED_TEXT">
-			<Original>OPFOR Convoy near %1.</Original>
-			<French>Convoi OPFOR près de %1.</French>
-			<German>OPFOR Konvoi nahe %1.</German>
-			<Spanish>Convoy OPFOR cerca de 1%</Spanish>
-			<Russian>Конвой OPFOR рядом с %1.</Russian>
-			<Italian>Convoglio OPFOR vicino %1.</Italian>
-			<Chinesesimp>敌军车队接近%1</Chinesesimp>
-			<Chinese>敵方車隊接近 %1</Chinese>
-			<Turkish>OPFOR Konvoyu %1 tarafında.</Turkish>
-			<Portuguese>Comboio inimigo nas proximidades de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_GOTIT">
-			<Original>Got it!</Original>
-			<French>J'ai pigé!</French>
-			<German>Verstanden!</German>
-			<Spanish>Lo tengo!</Spanish>
-			<Russian>Вас понял!</Russian>
-			<Italian>Ricevuto!</Italian>
-			<Chinesesimp>明白了！</Chinesesimp>
-			<Chinese>收到！</Chinese>
-			<Turkish>Anlaşıldı!</Turkish>
-			<Portuguese>Entendido!</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_ACTION">
-			<Original>-- TUTORIAL</Original>
-			<French>-- TUTORIAL</French>
-			<German>-- TUTORIAL</German>
-			<Italian>-- TUTORIAL</Italian>
-			<Spanish>-- TUTORIAL</Spanish>
-			<Russian>-- РУКОВОДСТВО</Russian>
-			<Chinesesimp>-- 教程</Chinesesimp>
-			<Chinese>-- 教學</Chinese>
-			<Turkish>-- EĞİTİM</Turkish>
-			<Portuguese>-- TUTORIAL</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE">
-			<Original>TUTORIAL</Original>
-			<French>TUTORIAL</French>
-			<German>TUTORIAL</German>
-			<Italian>TUTORIAL</Italian>
-			<Spanish>TUTORIAL</Spanish>
-			<Russian>РУКОВОДСТВО</Russian>
-			<Chinesesimp>教程</Chinesesimp>
-			<Chinese>教學</Chinese>
-			<Turkish>EĞİTİM</Turkish>
-			<Portuguese>TUTORIAL</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_MISSION0">
-			<Original>FOB Hunting</Original>
-			<French>Chasse à la FOB</French>
-			<German>FOB Jagd</German>
-			<Spanish>Caza de FOB</Spanish>
-			<Russian>Охота за вражескими FOB</Russian>
-			<Italian>Caccia alla FOB</Italian>
-			<Chinesesimp>狩猎前哨</Chinesesimp>
-			<Chinese>獵殺前線基地</Chinese>
-			<Turkish>FOB Avı</Turkish>
-			<Portuguese>Caça à FOB</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_BRIEFING0">
-			<Original>
-			&lt;t size='1.3' color='#ffa000'&gt;FOB HUNTING&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			OPFOR forces use an array of small logistic bases situated behind the front lines. Destroying those assets would greatly disrupt the OPFOR supply lines and impair their capacity to react to our actions.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Your mission is to destroy all supply assets (trucks, containers) at the objective by any means at your disposal. Unfortunately our intelligence is not able to provide you with a precise position for the base, you will have to locate the objective in the red zone on your map.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Reward: OPFOR alert level reduced by 40%&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Original>
-			<French>
-			&lt;t size='1.3' color='#ffa000'&gt;CHASSE A LA FOB&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Les forces de l'OPFOR utilisent des bases logistiques situées derrière la ligne de front. Détruire ces objectifs pertubera les lignes d'approvisionnement de l'OPFOR et les empêchera de réagir efficacement à nos actions.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Votre mission est de détruire tous les équipements logistiques (camions, containers) présents sur l'objectif. Malheureusement nos renseignements ne permettent pas de vous donner la position précise de la base, vous devrez la chercher dans la zone rouge visible sur votre carte.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Coût: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Récompense: niveau d'alerte de l'OPFOR réduit de 40%&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</French>
-			<German>
-			&lt;t size='1.3' color='#ffa000'&gt;FOB JAGD&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Die OPFOR Streitkräfte benutzen ein Netzwerk von kleineren Nachschubbasen hinter den Frontlinien. Diese zu zerstören würden die OPFOR Nachschublinien und ihre Reaktionsmöglichkeiten stark einschränken.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Ihr Auftrag ist es alle Nachschubkapazitäten (Container und Trucks) zu zerstören. Leider ist unser Geheimdienst nicht in der Lage, Ihnen die genaue Position des Ortes mitzuteilen. Sie werden das Ziel innerhalb der makierten roten Zone auf der Karte suchen müssen.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Kosten: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Belohnung: OPFOR Alarmstatus wird um 40% reduziert&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</German>
-			<Spanish>
-			&lt;t size='1.3' color='#ffa000'&gt;CAZA DE FOB&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Las fuerzas del OPFOR utilizan una red de bases logísticas situadas tras las líneas enemigas. Destruir estos recursos interrunpira las líneas de abastecimiento del enemigo y entorpecerán su capacidad para responder a tus acciones.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Tu misión consiste en destruir todos los recursos (camiones, containers) en el objetivo por cualquier medio que esté en tus manos. Desafortunadamente nuestra inteligencia no permite obtener una localización precisa de la base, deberás encontrarla dentro de la zona marcada en rojo en el mapa.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa: nivel de alerta del OPFOR reducido en un 40%&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Spanish>
-			<Russian>
-			&lt;t size='1.3' color='#ffa000'&gt;ОХОТА ЗА FOB&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;&lt;t size='1'&gt;Силы OPFOR используют небольшие базы снабжения, расположенные за линией фронта. Уничтожение материальных средств этих баз значительно нарушит связи снабжения OPFOR и ухудшит их способность реагировать на ваши действия.&lt;/t&gt;&lt;br/&gt;	&lt;t size='1'&gt;
-			Ваша миссия состоит в том, чтобы уничтожить на базах все средства снабжения (грузовики, контейнеры) любыми средствами, находящимися в вашем распоряжении. К сожалению, наша разведка не в состоянии предоставить вам точное положение этих баз, вам придется найти их самостоятельно. Ищите базы снабжения в районе красной зоны, отмеченной на вашей карте.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Требуется: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Награда: уровень тревоги OPFOR уменьшится на 40%&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Russian>
-			<Italian>
-			&lt;t size='1.3' color='#ffa000'&gt;CACCIA ALLA FOB&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Le forze OPFOR utilizzano una serie di piccole basi logistiche situate dietro il fronte. Distruggere tali basi serve ad interrompere le linee di alimentazione OPFOR e mettere in pericolo la loro capacità di reagire alle nostre azioni.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			La vostra missione è di distruggere tutte le attività di approvvigionamento (camion, contenitori) presso l 'obiettivo con ogni mezzo a vostra disposizione. Purtroppo la nostra intelligence non è in grado di fornire una posizione precisa della base, si dovrà individuare l'obiettivo all'interno della zona rossa sulla mappa.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Ricompensa: livello di allerta OPFOR ridotto del 40%&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Italian>
-			<Chinesesimp>
-			&lt;t size='1.3' color='#ffa000'&gt;狩猎前哨&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			敌军部队在阵地后方建有一组小型后勤基地。摧毁这些设施将会极大的打击敌军的补给线，并拖慢他们的反应速度。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			你的任务是不惜一切代价摧毁目标区域所有补给物资（卡车、集装箱）。遗憾的是我们的情报部门无法为你提供这些基地的准确位置，你必须在地图的红色区域中自行搜索目标。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;花费：15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;奖励：敌军警戒等级降低40%&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;t size='1.3' color='#ffa000'&gt;獵殺前線基地&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			敵方在陣地後建立了一組小型前線基地作為後勤用，一旦成功摧毀他們將能給予敵軍補給線致命性的打擊、並使他們對我們的進攻感到措手不及。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			遺憾的是我們的情報單位並沒有辦法掌握確切位置，你的任務是在地圖上的紅色區域中尋找到敵方前線基地並摧毀所有基地內的補給物資（卡車、貨櫃）。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;花費：15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;獎勵：敵方警戒度降低 40 %&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Chinese>
-			<Turkish>
-			&lt;t size='1.3' color='#ffa000'&gt;FOB AVI&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			OPFOR kuvvetleri küçük çaplı bir işlemler yönetiyor. Bunları yoketmek onlara zarar verirken bir yandanda bizim yararımıza olacak.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Sizin göreviniz oradaki varlıkları ve eşyaları yoketmek olacak(kamyonet ve mühimmatlar). Malesef istihbaharatımız tam bölge yerini verememekte. Yakın alanlara gidip kendiniz bulmalısınız.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Maliyet: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Ödül: OPFOR uyarı seviyesi %40 a düşecek.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-		</Turkish>
-		<Portuguese>
-			&lt;t size='1.3' color='#ffa000'&gt;CAÇA À FOB&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			As forças de oposição (FOROP) utilizam um conjunto de pequenas bases de logística situadas além do fronte de batalha. Destruindo tais recursos desestabilizaria consideravelmente suas linhas de suprimento e afetaria sua capacidade de reagir às nossas ações.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Sua missão é destruir todas as fontes de recurso (caminhões, contêineres) que estão no objetivo, a qualquer custo. Infelizmente, nossa inteligência não foi capaz de fornecer dados da localização precisa da base. Dessa forma, você deverá localizar o objetivo dentro da zona vermelha identificada em seu mapa.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa: Alerta das forças de oposição reduzidos em 40%.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-		</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_MISSION1">
-			<Original>Convoy Hijack</Original>
-			<French>Interception de convoi</French>
-			<German>Konvoi Hinterhalt</German>
-			<Spanish>Interceptar el Convoy</Spanish>
-			<Russian>Налёт на конвой врага</Russian>
-			<Italian>Intercetta il Convoglio</Italian>
-			<Chinesesimp>劫掠车队</Chinesesimp>
-			<Chinese>攔截車隊</Chinese>
-			<Turkish>Konvoy baskını</Turkish>
-			<Portuguese>Interceptação de comboio</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_BRIEFING1">
-			<Original>
-			&lt;t size='1.3' color='#ffa000'&gt;CONVOY HIJACK&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			OPFOR forces use road convoys to resupply their defensive positions. Intercepting one of these convoys would effectively disrupt their supply lines, and we could use the occasion to retrieve an hefty amount of ammunition.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Your mission is to stop the OPFOR convoy by any means necessary. You can destroy it, or hijack it to retrieve all the ammunition you can grab. The target will be spotted on your map.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Reward: OPFOR alert level reduced by 15%&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Side reward: All the ammunition you can retrieve.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-			</Original>
-			<French>
-			&lt;t size='1.3' color='#ffa000'&gt;INTERCEPTION DE CONVOI&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Les forces de l'OPFOR utilisent des convois routiers pour réaprovisionner leurs positions. Intercepter un de ces convois pertuberait leurs lignes d'approvisionnement, et nous pourrions utiliser l'occasion pour récupérer une grande quantité de munitions.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Votre mission est de stopper le convoi de l'OPFOR par tous les moyens nécessaires. Vous pouvez le détruire, ou le stopper pour récupérer un maximum de munitions. La cible sera marquée sur votre carte.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Coût: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Récompense: niveau d'alerte de l'OPFOR réduit de 15%&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Récompense secondaire: toutes les munitions que vous pourrez récupérer.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-			</French>
-			<German>
-			&lt;t size='1.3' color='#ffa000'&gt;KONVOI HINTERHALT&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Die OPFOR Streitkräfte benutzen Straßenkonvois um ihre Verteidigungspositionen zu versorgen. Diese Konvois abzufangen würden ihre Nachschublinien effektiv unterbrechen und außerdem könnten wir die Möglichkeit nutzen, um selbst eine große Menge an Munition zu erbeuten.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Ihr Auftrag ist es, den OPFOR Konvoi auf jede erdenkliche Weise zu stoppen. Sie können ihn zerstören oder übernehmen, um soviel Munition wie möglich zu erbeuten. Das Ziel wird auf Ihrer Karte aufgeklärt.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Kosten: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Belohnung: OPFOR Alarmstatus wird um 15% reduziert&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Weitere Belohnung: Soviel Munition wie Sie erbeuten können.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-			</German>
-			<Spanish>
-			&lt;t size='1.3' color='#ffa000'&gt;INTERCEPTAR EL CONVOY&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Las fuerzas OPFOR utilizan convoys de carretera para reabastecer sus posiciones defensivas. Interceptar uno de estos convoy rompería de forma efectiva sus líneas de suministro, y podríamos aprovechar la ocasión para obtener una buena cantidad de munición.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Tu misión consiste en parar ese convoy por cualquier medio. Puedes destruirlo o capturarlo para capturar toda la munición que sea posible. El objetivo aparecerá marcado en el mapa.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Coste: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa: Nivel de alerta OPFOR reducido 15%&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa secundaria: Toda la munición que puedas traer.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-			</Spanish>
-			<Russian>&lt;t size='1.3' color='#ffa000'&gt;НАЛЁТ НА КОНВОЙ&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Силы OPFOR используют автоколонны для снабжения своих оборонительных позиций. Перехват одного из этих конвоев эффективно нарушил бы их связи снабжения, и мы могли бы использовать эту возможность для получения большого количество вооружения.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Ваша задача состоит в том, чтобы остановить конвой OPFOR любой ценой. Вы можете уничтожить его, или захватить его для получения ресурса вооружения. Цель будет отмечена на вашей карте.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Стоимость: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Награда: уровень тревоги OPFOR уменьшится на 15%&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Вторичная награда: Всё вооружение, которое можно получить за утилизацию груза конвоя.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-			</Russian>
-			<Italian>
-			&lt;t size='1.3' color='#ffa000'&gt;INTERCETTA IL CONVOGLIO&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Le forze OPFOR utilizzano convogli stradali per rifornire le loro posizioni difensive. Intercettare uno di questi convogli potrebbe effettivamente distruggere le loro linee di rifornimento, e potete sfruttare l'occasione per recuperare una notevole quantità di munizioni.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			La tua missione è quella di fermare il convoglio OPFOR con ogni mezzo necessario. Si può distruggerlo, o dirottarlo e recuperare tutte le munizioni. L'obiettivo sarà evidenziato sulla mappa.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Ricompensa: livello di allerta OPFOR ridotto del 15%&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Seconda ricompensa: è possibile recuperare tutte le munizioni.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-		</Italian>
-		<Chinesesimp>
-			&lt;t size='1.3' color='#ffa000'&gt;劫掠车队&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			敌军部队的防御位置通过地面车队进行补给。拦截这种车队可以有效打击他们的补给线，而这也是让我们截获弹药的大好机会。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			你的任务是不惜一切代价拦截敌军车队。由你决定是摧毁还是截获所有的弹药。目标将会标示在你的地图上。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;花费：10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;奖励：敌军警戒等级降低15%&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;次要奖励：你能截获的所有弹药。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-		</Chinesesimp>
-		<Chinese>
-			&lt;t size='1.3' color='#ffa000'&gt;攔截車隊&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			敵方正透過補給車隊來為他們的防禦陣線進行補給，攔截車隊將能有效打擊他們的補給線，而這也是我們從敵軍繳獲彈藥資源的大好機會。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			你的任務是攔截車隊，你可以自行決定要摧毀或是掠奪車隊上的所有彈藥，情報單位將會協助標示目標位置與目標可能前往的路徑點在你的地圖上。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;花費：10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;獎勵：敵軍警戒度降低 15 %&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;次要獎勵：所有你能從車隊上所繳獲的彈藥資源。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-		</Chinese>
-		<Turkish>
-			&lt;t size='1.3' color='#ffa000'&gt;CONVOY BASKINI&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			OPFOR kuvvetleri kendi bölgelerine konvoy ile mühimmat desteği yapıyor. Sizin göreviniz bu konvoyu durdurup kurtarabildiğiniz mühimmatı kendinize almaktır.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Göreviniz bu konvoyu ne pahasına olursa olsun durdurmak. Patlatmadığınız mühimmatı kendi bölgenize taşıyabilirsiniz. Konvoy haritada işaretlenecektir.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Maliyeti: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Ödül: OPFOR uyarı seviyesi %15 kadar düşecektir.&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Yan ödül: Kurtardığınız mühimmatlar.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-		</Turkish>
-		<Portuguese>
-			&lt;t size='1.3' color='#ffa000'&gt;INTERCEPTAÇÃO DE COMBOIO&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			As forças de oposição (FOROP) utilizam comboios terrestres para reabastecer suas posições defensivas. Interceptando um desses comboios afetaria efetivamente suas linhas de suprimento, e poderíamos usar a ocasião para recuperar uma grande quantidade de munições.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Sua missão é deter o comboio das forças de oposição utilizando qualquer meio possível. Você pode destruí-lo ou sequestrá-lo para recuperar toda a munição que conseguir transportar. O alvo será identificado em coordenadas específicas no seu mapa.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa: Nível de alerta das forças de oposição reduzido em 15%.&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa aliada: Toda a munição que conseguir.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
-			</Portuguese>
-		</Key>
+    <Package name="Liberation">
+        <!-- French localization made by zbug: https://github.com/GreuhZbug -->
+        <!-- German localization made by Wyqer: https://github.com/Wyqer -->
+        <!-- Italian localization made by k4s0: https://github.com/k4s0 -->
+        <!-- Spanish localization made by regiregi22: https://github.com/regiregi22 -->
+        <!-- Russion localization made by _KOC_: Constantin.rogozin@ya.ru -->
+        <!-- English corrections / proofreading by Applejakerie: https://github.com/Applejakerie -->
+        <!-- Chinese Simplified localization made by Nercon: https://github.com/nercon -->
+        <!-- Chinese Traditional localization made by John M. Rodriguez: https://github.com/KOEI5113 -->
+        <!-- (WIP) Turkish localization made by Carbneth: https://github.com/Carbneth -->
+        <!-- Portuguese localization made by NomadRomeo: https://github.com/NomadRomeo -->
+        <Key ID="STR_MISSION_TITLE">
+            <Original>KP Liberation v0.963a</Original>
+            <German>KP Liberation v0.963a</German>
+            <Spanish>KP Liberation v0.963a</Spanish>
+            <Italian>KP Liberation v0.963a</Italian>
+            <Chinesesimp>KP Liberation v0.963a</Chinesesimp>
+            <Chinese>KP Liberation v0.963a</Chinese>
+            <Turkish>KP Liberation v0.963a</Turkish>
+            <Portuguese>KP Liberation v0.963a</Portuguese>
+        </Key>
+        <Key ID="STR_MISSION_VERSION">
+            <Original>v0.963a</Original>
+            <German>v0.963a</German>
+            <Spanish>v0.963a</Spanish>
+            <Italian>v0.963a</Italian>
+            <Chinesesimp>v0.963a</Chinesesimp>
+            <Chinese>v0.963a</Chinese>
+            <Turkish>v0.963a</Turkish>
+            <Portuguese>v0.963a</Portuguese>
+        </Key>
+        <Key ID="STR_Deploy_OnPoint">
+            <Original>Deploy</Original>
+            <French>Déploiement</French>
+            <German>Bereitstellen</German>
+            <Spanish>Despliegue</Spanish>
+            <Russian>Развёртывание</Russian>
+            <Italian>Schierati</Italian>
+            <Chinesesimp>部署</Chinesesimp>
+            <Chinese>佈署</Chinese>
+            <Turkish>Atla</Turkish>
+            <Portuguese>Mobilizar</Portuguese>
+        </Key>
+        <Key ID="STR_Deploy_InProgress">
+            <Original>Deployment in progress ...</Original>
+            <French>Déploiement en cours ...</French>
+            <German>Bereitstellung in Arbeit</German>
+            <Spanish>Despliegue en curso ...</Spanish>
+            <Russian>Развёртывание в процессе ...</Russian>
+            <Italian>Schieramento in Corso ...</Italian>
+            <Chinesesimp>正在部署中...</Chinesesimp>
+            <Chinese>正在佈署中...</Chinese>
+            <Turkish>Atlama işlemi devam ediyor ...</Turkish>
+            <Portuguese>Mobilização em andamento...</Portuguese>
+        </Key>
+        <Key ID="STR_CLOSE">
+            <Original>Close</Original>
+            <French>Fermer</French>
+            <German>Schliessen</German>
+            <Spanish>Cerca</Spanish>
+            <Russian>Закрыть</Russian>
+            <Italian>Chiudi</Italian>
+            <Chinesesimp>关闭</Chinesesimp>
+            <Chinese>關閉</Chinese>
+            <Turkish>Kapat</Turkish>
+            <Portuguese>Fechar</Portuguese>
+        </Key>
+        <Key ID="STR_REVIVE_LABEL">
+            <Original>YOU ARE WOUNDED</Original>
+            <French>VOUS ETES BLESSE</French>
+            <German>DU BIST VERWUNDET</German>
+            <Spanish>ESTAS HERIDO</Spanish>
+            <Russian>ВЫ БЕЗ СОЗНАНИЯ</Russian>
+            <Italian>SEI STATO UCCISO</Italian>
+            <Chinesesimp>你受伤了</Chinesesimp>
+            <Chinese>你受傷了</Chinese>
+            <Turkish>Ağır yaralandın!</Turkish>
+            <Portuguese>VOCÊ ESTÁ FERIDO!</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_ACTION">
+            <Original>-- BUILD --</Original>
+            <French>-- CONSTRUIRE --</French>
+            <German>-- BAUEN --</German>
+            <Spanish>-- CONSTRUIR --</Spanish>
+            <Russian>-- ОБЕСПЕЧЕНИЕ --</Russian>
+            <Italian>-- COSTRUISCI --</Italian>
+            <Chinesesimp>-- 建造 --</Chinesesimp>
+            <Chinese>-- 建造 --</Chinese>
+            <Turkish>-- İnşa Et --</Turkish>
+            <Portuguese>-- CONSTRUIR --</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_TITLE">
+            <Original>BUILD MENU</Original>
+            <French>CONSTRUCTION</French>
+            <German>BAUMENÜ</German>
+            <Spanish>MENU DE CONSTRUCCIÓN</Spanish>
+            <Russian>ОБЕСПЕЧЕНИЕ</Russian>
+            <Italian>MENU COSTRUZIONI</Italian>
+            <Chinesesimp>建造菜单</Chinesesimp>
+            <Chinese>建造選單</Chinese>
+            <Turkish>İNŞA MENÜSÜ</Turkish>
+            <Portuguese>MENU DE CONSTRUÇÃO</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_BUTTON">
+            <Original>Build</Original>
+            <French>Construire</French>
+            <German>Bauen</German>
+            <Spanish>Construir</Spanish>
+            <Russian>Построить</Russian>
+            <Italian>Costruisci</Italian>
+            <Chinesesimp>建造</Chinesesimp>
+            <Chinese>建造</Chinese>
+            <Turkish>İnşa Et</Turkish>
+            <Portuguese>Construir</Portuguese>
+        </Key>
+        <Key ID="STR_MANPOWER">
+            <Original>Supplies</Original>
+            <French>Effectifs</French>
+            <German>Nachschub</German>
+            <Spanish>Efectivos</Spanish>
+            <Russian>Персонал</Russian>
+            <Italian>Personale</Italian>
+            <Chinesesimp>补给</Chinesesimp>
+            <Chinese>補給</Chinese>
+            <Turkish>Kaynaklar</Turkish>
+            <Portuguese>Suprimentos</Portuguese>
+        </Key>
+        <Key ID="STR_AMMO">
+            <Original>Ammunition</Original>
+            <French>Munitions</French>
+            <German>Munition</German>
+            <Spanish>Munición</Spanish>
+            <Russian>Вооружение</Russian>
+            <Italian>Munizioni</Italian>
+            <Chinesesimp>弹药</Chinesesimp>
+            <Chinese>彈藥</Chinese>
+            <Turkish>Muhimmatlar</Turkish>
+            <Portuguese>Munição</Portuguese>
+        </Key>
+        <Key ID="STR_FUEL">
+            <Original>Fuel</Original>
+            <French>Carburant</French>
+            <German>Kraftstoff</German>
+            <Spanish>Combustible</Spanish>
+            <Russian>Топливо</Russian>
+            <Italian>Carburante</Italian>
+            <Chinesesimp>燃料</Chinesesimp>
+            <Chinese>油料</Chinese>
+            <Turkish>Yakıt</Turkish>
+            <Portuguese>Combustível</Portuguese>
+        </Key>
+        <Key ID="STR_BLEEDOUT_MESSAGE">
+            <Original>Bleedout in %1 seconds</Original>
+            <French>Mort dans %1 secondes</French>
+            <German>Ausbluten in %1 Sekunden</German>
+            <Spanish>Desangrado en %1 segundos</Spanish>
+            <Russian>Вы умрёте через %1 секунд</Russian>
+            <Italian>Morte per dissanguamento fra %1 secondi</Italian>
+            <Chinesesimp>将于%1秒后失血阵亡</Chinesesimp>
+            <Chinese>將於 %1 秒後失血致死</Chinese>
+            <Turkish>%1 saniyedir kanıyorsun</Turkish>
+            <Portuguese>Morte por hemorragia em %1 segundos</Portuguese>
+        </Key>
+        <Key ID="STR_BLEEDOUT_STABILIZED">
+            <Original>Stabilized</Original>
+            <French>Stabilisé</French>
+            <German>Stabilisiert</German>
+            <Spanish>Estabilizado</Spanish>
+            <Russian>Стабильно</Russian>
+            <Italian>Stabilizzato</Italian>
+            <Chinesesimp>伤情稳定</Chinesesimp>
+            <Chinese>傷勢穩定</Chinese>
+            <Turkish>Stabilize</Turkish>
+            <Portuguese>Hemorragia estancada</Portuguese>
+        </Key>
+        <Key ID="STR_ROTATION">
+            <Original>-- Rotation</Original>
+            <French>-- Rotation</French>
+            <German>-- Rotieren</German>
+            <Spanish>-- Rotación</Spanish>
+            <Russian>-- Вращать</Russian>
+            <Italian>-- Ruota</Italian>
+            <Chinesesimp>-- 旋转</Chinesesimp>
+            <Chinese>-- 旋轉</Chinese>
+            <Turkish>-- Döndür</Turkish>
+            <Portuguese>-- Rotação</Portuguese>
+        </Key>
+        <Key ID="STR_PLACEMENT">
+            <Original>-- Build</Original>
+            <French>-- Construire</French>
+            <German>-- Bauen</German>
+            <Spanish>-- Construir</Spanish>
+            <Russian>-- Поставить</Russian>
+            <Italian>-- Costruisci</Italian>
+            <Chinesesimp>-- 建造</Chinesesimp>
+            <Chinese>-- 建造</Chinese>
+            <Turkish>-- Kur</Turkish>
+            <Portuguese>-- Construir</Portuguese>
+        </Key>
+        <Key ID="STR_PLACEMENT_BIS">
+            <Original>-- Build and Repeat</Original>
+            <French>-- Construire et Répéter</French>
+            <German>-- Bauen und Wiederholen</German>
+            <Spanish>-- Construir y repetir</Spanish>
+            <Russian>-- Поставить и повторить</Russian>
+            <Italian>-- Costruisci e Ripeti</Italian>
+            <Chinesesimp>-- 建造并重复</Chinesesimp>
+            <Chinese>-- 建造並重複</Chinese>
+            <Turkish>-- Kur ve tekrarla</Turkish>
+            <Portuguese>-- Construir e repetir</Portuguese>
+        </Key>
+        <Key ID="STR_CANCEL">
+            <Original>-- Cancel</Original>
+            <French>-- Annuler</French>
+            <German>-- Abbrechen</German>
+            <Spanish>-- Cancelar</Spanish>
+            <Russian>-- Отмена</Russian>
+            <Italian>-- Annulla</Italian>
+            <Chinesesimp>-- 取消</Chinesesimp>
+            <Chinese>-- 取消</Chinese>
+            <Turkish>-- İptal</Turkish>
+            <Portuguese>-- Cancelar</Portuguese>
+        </Key>
+        <Key ID="STR_CANCEL_HINT">
+            <Original>Building canceled.</Original>
+            <French>Construction annulée.</French>
+            <German>Bauen abgebrochen.</German>
+            <Spanish>Construcción cancelada</Spanish>
+            <Russian>Постройка отменена</Russian>
+            <Italian>Costruzione cancellata.</Italian>
+            <Chinesesimp>建造取消。</Chinesesimp>
+            <Chinese>建造取消。</Chinese>
+            <Turkish>İnşa iptal edildi.</Turkish>
+            <Portuguese>Construção cancelada.</Portuguese>
+        </Key>
+        <Key ID="STR_CONFIRM_HINT">
+            <Original>Building confirmed.</Original>
+            <French>Construction confirmée.</French>
+            <German>Bauen bestätigt.</German>
+            <Spanish>Construcción confirmada.</Spanish>
+            <Russian>Постройка подтверждена</Russian>
+            <Italian>Costruzione confermata.</Italian>
+            <Chinesesimp>建造完成。</Chinesesimp>
+            <Chinese>建造成功。</Chinese>
+            <Turkish>İnşa kuruldu.</Turkish>
+            <Portuguese>Construção confirmada.</Portuguese>
+        </Key>
+        <Key ID="STR_PLACEMENT_IMPOSSIBLE">
+            <Original>Can't place here: there are %1 object(s) within %2 meters of the object position.</Original>
+            <French>Impossible de placer ici : il y a %1 objet(s) dans les %2 mètres de la position voulue.</French>
+            <German>Kann hier nicht platziert werden: %1 Objekt(e) innerhalb von %2 Meter der Position</German>
+            <Spanish>Imposible de colocar aqui: hay 1% objeto(s) a %2 metros de la posición del objeto</Spanish>
+            <Russian>Нельзя разместить здесь: в %2 метрах есть 1% объект(а).</Russian>
+            <Italian>impossibile piazzare qui: ci sono %1 oggetti vicini %2 metri dalla posizione dell'oggetto in
+                costruzione
+            </Italian>
+            <Chinesesimp>无法安置在这里：当前位置%2米内有%1个物体阻挡。</Chinesesimp>
+            <Chinese>無法在此建造：目前 %2 公尺內有 %1 個物件存在。</Chinese>
+            <Turkish>Buraya kurulamaz: %2 metre içinde %1 obje bulunuyor.</Turkish>
+            <Portuguese>Impossível inserir aqui: Há %1 objeto(s) dentro de %2 metros da posição deste item.</Portuguese>
+        </Key>
+        <Key ID="STR_PLACEMENT_POSSIBLE">
+            <Original>This position is valid.</Original>
+            <French>Cette position est valide.</French>
+            <German>Diese Position ist gültig.</German>
+            <Spanish>Esta posición es válida</Spanish>
+            <Russian>Это место подходит.</Russian>
+            <Italian>Questa posizione è valida</Italian>
+            <Chinesesimp>可安置于此处。</Chinesesimp>
+            <Chinese>可在此建造。</Chinese>
+            <Turkish>Bu pozisyon uygun.</Turkish>
+            <Portuguese>Esta posição é válida.</Portuguese>
+        </Key>
+        <Key ID="STR_ARSENAL_ACTION">
+            <Original>-- ARSENAL --</Original>
+            <French>-- ARSENAL --</French>
+            <German>-- ARSENAL --</German>
+            <Spanish>-- ARSENAL --</Spanish>
+            <Russian>-- АРСЕНАЛ --</Russian>
+            <Italian>-- ARSENALE --</Italian>
+            <Chinesesimp>-- 军火库 --</Chinesesimp>
+            <Chinese>-- 軍火庫 --</Chinese>
+            <Turkish>-- CEPHANE --</Turkish>
+            <Portuguese>-- ARSENAL --</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_LOAD_BOX">
+            <Original>-- LOAD CRATE</Original>
+            <French>-- CHARGER MUNITIONS</French>
+            <German>-- KISTE AUFLADEN</German>
+            <Spanish>-- CARGAR CAJA DE MUNICIÓN</Spanish>
+            <Russian>-- ЗАГРУЗИТЬ ЯЩИК С БОЕПРИПАСАМИ</Russian>
+            <Italian>-- CARICA CASSA</Italian>
+            <Chinesesimp>-- 装载货箱</Chinesesimp>
+            <Chinese>-- 裝載貨物</Chinese>
+            <Turkish>-- KUTUYU YÜKLE</Turkish>
+            <Portuguese>-- CARREGAR CAIXA NO TRANSPORTE</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_UNLOAD_BOX">
+            <Original>-- UNLOAD CRATES</Original>
+            <French>-- DECHARGER MUNITIONS</French>
+            <German>-- KISTEN ABLADEN</German>
+            <Spanish>-- DESCARGAR CAJA DE MUNICIÓN</Spanish>
+            <Russian>-- ВЫГРУЗИТЬ ЯЩИК С БОЕПРИПАСАМИ</Russian>
+            <Italian>-- SCARICA CASSA</Italian>
+            <Chinesesimp>-- 卸载货箱</Chinesesimp>
+            <Chinese>-- 卸載貨物</Chinese>
+            <Turkish>-- KUTUYU İNDİR</Turkish>
+            <Portuguese>-- DESCARREGAR CAIXAS</Portuguese>
+        </Key>
+        <Key ID="STR_BOX_LOADED">
+            <Original>Ammo box successfully loaded on the transport vehicle.</Original>
+            <French>La caisse de munitions a été chargée sur le véhicule de transport.</French>
+            <German>Munitionskiste erfolgreich auf das Transportfahrzeug geladen.</German>
+            <Spanish>Caja de munición cargada correctamente en el vehículo de transporte</Spanish>
+            <Russian>Ящик с боеприпасами загружен в транспортное средство</Russian>
+            <Italian>Cassa munizioni correttamente caricata sul camion da trasporto</Italian>
+            <Chinesesimp>货箱已装载到运输载具中。</Chinesesimp>
+            <Chinese>貨物已上至運輸載具中。</Chinese>
+            <Turkish>Mermi kutusu başarıyla taşıma aracına yüklendi.</Turkish>
+            <Portuguese>Caixa de munição carregada com sucesso no veículo de transporte.</Portuguese>
+        </Key>
+        <Key ID="STR_BOX_UNLOADED">
+            <Original>Ammo box successfully unloaded from the transport vehicle.</Original>
+            <French>La caisse de munitions a été déchargée du véhicule de transport.</French>
+            <German>Munitionskiste erfolgreich vom Transportfahrzeug abgeladen.</German>
+            <Spanish>Caja de munición descargada correctamente del vehículo de transporte</Spanish>
+            <Russian>Ящик с боеприпасами выгружен из транспортного средства</Russian>
+            <Italian>Cassa munizioni correttamente scaricata dal camion da trasporto</Italian>
+            <Chinesesimp>货箱已从运输载具中卸载。</Chinesesimp>
+            <Chinese>貨物已從運輸載具中卸下。</Chinese>
+            <Turkish>Mermi kutusu başarıyla taşıma aracından indirildi.</Turkish>
+            <Portuguese>Caixa de munição descarregada com sucesso do veículo de transporte.</Portuguese>
+        </Key>
+        <Key ID="STR_BOX_CANTLOAD">
+            <Original>There is no nearby vehicle capable of carrying the ammo box.</Original>
+            <French>Aucun véhicule à proximité capable de charger la caisse de munitions.</French>
+            <German>Kein Fahrzeug in der Nähe, das die Munitionskiste aufnehmen kann.</German>
+            <Spanish>No hay ningún vehículo cercano capaz de cagar la caja de munición</Spanish>
+            <Russian>Рядом нет техники способной перевозить ящики с боеприпасами.</Russian>
+            <Italian>Non ci sono veicoli vicino alla cassa munizioni capaci di caricarla</Italian>
+            <Chinesesimp>附近没有能够装载货箱的载具。</Chinesesimp>
+            <Chinese>附近沒有具備足夠空間裝載貨物的載具。</Chinese>
+            <Turkish>Yakınlarda bu kutuyu taşıyabilecek araç yok.</Turkish>
+            <Portuguese>Não existe veículo nas proximidades capaz de carregar a caixa de munição.</Portuguese>
+        </Key>
+        <Key ID="STR_FOB_ACTION">
+            <Original>-- DEPLOY FOB --</Original>
+            <French>-- DEPLOYER FOB --</French>
+            <German>-- FOB BEREITSTELLEN --</German>
+            <Spanish>-- DESPLEGAR FOB --</Spanish>
+            <Russian>-- РАЗВЕРНУТЬ FOB --</Russian>
+            <Italian>-- COSTRUISCI FOB --</Italian>
+            <Chinesesimp>-- 部署前哨 --</Chinesesimp>
+            <Chinese>-- 佈署前線基地 --</Chinese>
+            <Turkish>-- FOB KUR --</Turkish>
+            <Portuguese>-- INSTALAR FOB --</Portuguese>
+        </Key>
+        <Key ID="STR_FOB_BUILDING_IMPOSSIBLE">
+            <Original>Can't deploy a new FOB here, you must be at least %1 meters away from every other FOB. Nearest FOB
+                is %2 meters away.
+            </Original>
+            <French>Impossible de déployer une nouvelle FOB ici, vous devez être à au moins %1 mètres de toutes les
+                autres FOB. La FOB la plus proche est à %2 mètres d'ici.
+            </French>
+            <German>Kann hier keine FOB platzieren, du musst min. %1 Meter von der anderen FOB entfernt sein. Die
+                nächste FOB ist %2 Meter entfernt.
+            </German>
+            <Spanish>Imposible desplegar una nueva FOB aquí, debes estar al menos a 1% metros de cualquier otra FOB. La
+                FOB más cercana está a %2 metros.
+            </Spanish>
+            <Russian>Нельзя развернуть FOB здесь, вы должны находится в %1 метрах от другой FOB. Ближайшая FOB в %2
+                метрах.
+            </Russian>
+            <Italian>Impossibile creare la nuova FOB qui, devi essere almeno %1 metri distante dalla FOB più vicina. La
+                FOB più vicina si trova a %2 metri.
+            </Italian>
+            <Chinesesimp>无法在此部署前哨，前哨之间的距离不得低于%1米。最近的前哨在%2米开外。</Chinesesimp>
+            <Chinese>無法在這裡佈署前線基地，前線基地之間的距離不得低於 %1 公尺，最近的前線基地離此 %2 公尺。</Chinese>
+            <Turkish>Buraya FOB koyamazsın. Diğer FOB'lerden %1 metre uzakta olmalısın. En yakındaki FOB %2 metre
+                uzaklıkta.
+            </Turkish>
+            <Portuguese>Não é possível instalar a FOB aqui, você precisa estar no mínimo a %1 metros de distância de
+                outra FOB. A FOB mais próxima está a %2 metros.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_FOB_BUILDING_IMPOSSIBLE_SECTOR">
+            <Original>Can't deploy a new FOB here, you must be at least %1 meters away from every capturable zone.
+                Nearest zone is %2 meters away.
+            </Original>
+            <French>Impossible de déployer une nouvelle FOB ici, vous devez être à au moins %1 mètres de toutes les
+                zones capturables. La zone la plus proche est à %2 mètres d'ici.
+            </French>
+            <German>Kann hier keine FOB platzieren, du musst min. %1 Meter von allen Sektoren entfernt sein. Der nächste
+                Sektor ist %2 Meter entfernt.
+            </German>
+            <Spanish>Imposible desplegar una nueva FOB aquí, debes estar al menos a %1 metros de cualquier zona
+                capturable. La zona más cercana está a %2 metros
+            </Spanish>
+            <Russian>Нельзя развернуть FOB здесь, вы должны находится в %1 метрах от захваченной зоны. Ближайшиая зона в
+                %2 метрах.
+            </Russian>
+            <Italian>Impossibile creare la nuova FOB qui, devi essere almeno %1 metri distante dalla Zona catturabile
+                più vicina. La Zona Catturabile più vicina si trova a %2 metri.
+            </Italian>
+            <Chinesesimp>无法在此部署前哨，前哨与战区之间的距离不得低于%1米。最近的战区在%2米开外。</Chinesesimp>
+            <Chinese>無法在此佈署前線基地，前線基地與戰區之間的距離不得低於 %1 公尺，最近的戰區離此 %2 公尺。</Chinese>
+            <Turkish>Buraya FOB açılamaz. Ele geçirilebilir bölgelerden en az %1 metre uzakta olmalısınız. En yakın
+                bölge %2 metre uzakta.
+            </Turkish>
+            <Portuguese>Não é possível instalar a FOB aqui, você precisa estar no mínimo a %1 metros de distância de
+                qualquer setor capturável. O setor mais próima está a %2 metros.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_ERROR_WATER">
+            <Original>Can't build on water.</Original>
+            <French>Impossible de construire sur l'eau.</French>
+            <German>Kann nicht auf Wasser gebaut werden.</German>
+            <Spanish>Imposible construir sobre el agua.</Spanish>
+            <Russian>Нельзя построить в воде.</Russian>
+            <Italian>Impossibile costruire sull'acqua.</Italian>
+            <Chinesesimp>无法在水面上建造。</Chinesesimp>
+            <Chinese>無法建造在水面上。</Chinese>
+            <Turkish>Su içine kurulamaz.</Turkish>
+            <Portuguese>Não é possível construir na água.</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_ERROR_DISTANCE">
+            <Original>Can't build further than %1 meters away from the FOB.</Original>
+            <French>Impossible de construire à plus de %1 mètres de la FOB.</French>
+            <German>Kann nicht weiter als %1 Meter von der FOB entfernt sein.</German>
+            <Spanish>Imposible construir más lejos de %1 metros de la FOB</Spanish>
+            <Russian>Нельзя построить дальше чем в %1 метрах от FOB.</Russian>
+            <Italian>Impossibile costruire a più di %1 metri dalla FOB.</Italian>
+            <Chinesesimp>无法在超出前哨%1米外的区域建造。</Chinesesimp>
+            <Chinese>無法在距離前線基地 %1 公尺外的區域建造</Chinese>
+            <Turkish>Diğer FOB'den %1 metre uzakta olmalısınız.</Turkish>
+            <Portuguese>Não é possível construir com mais de %1 metros de distância da FOB.</Portuguese>
+        </Key>
+        <Key ID="STR_FOBBOX">
+            <Original>FOB Container</Original>
+            <French>Container FOB</French>
+            <German>FOB Container</German>
+            <Spanish>Contenedor de FOB</Spanish>
+            <Russian>FOB контейнер</Russian>
+            <Chinesesimp>前哨部署柜</Chinesesimp>
+            <Chinese>前線基地貨櫃</Chinese>
+            <Turkish>FOB Konternırı</Turkish>
+            <Portuguese>FOB no Contêiner</Portuguese>
+        </Key>
+        <Key ID="STR_FOBTRUCK">
+            <Original>FOB Truck</Original>
+            <French>Camion FOB</French>
+            <German>FOB Lastwagen</German>
+            <Spanish>Camión de FOB</Spanish>
+            <Russian>FOB грузовик</Russian>
+            <Italian>Camion FOB</Italian>
+            <Chinesesimp>前哨部署车</Chinesesimp>
+            <Chinese>前線基地車</Chinese>
+            <Turkish>FOB Kamyoneti</Turkish>
+            <Portuguese>FOB transportável</Portuguese>
+        </Key>
+        <Key ID="STR_RESPAWN_TRUCK">
+            <Original>Mobile respawn</Original>
+            <French>Respawn mobile</French>
+            <German>Mobiler Respawn</German>
+            <Spanish>Respawn móvil</Spanish>
+            <Russian>Мобильная КШМ</Russian>
+            <Italian>Respawn Mobile</Italian>
+            <Chinesesimp>机动复活载具</Chinesesimp>
+            <Chinese>機動復活載具</Chinese>
+            <Turkish>Respawn Aracı</Turkish>
+            <Portuguese>Respawn móvel</Portuguese>
+        </Key>
+        <Key ID="STR_ARSENAL_BOX">
+            <Original>Arsenal box</Original>
+            <French>Caisse à arsenal</French>
+            <German>Arsenalkiste</German>
+            <Spanish>Caja de Arsenal</Spanish>
+            <Russian>Ящик с арсеналом</Russian>
+            <Italian>Cassa Arsenale</Italian>
+            <Chinesesimp>军火箱</Chinesesimp>
+            <Chinese>軍火箱</Chinese>
+            <Turkish>Arsenal Kutusu</Turkish>
+            <Portuguese>Caixa de Arsenal</Portuguese>
+        </Key>
+        <Key ID="STR_DEPLOY_TITLE">
+            <Original>DEPLOYMENT</Original>
+            <French>DEPLOIEMENT</French>
+            <German>EINSATZ</German>
+            <Spanish>DESPLIEGUE</Spanish>
+            <Russian>ДИСЛОКАЦИЯ</Russian>
+            <Italian>SCHIERAMENTO</Italian>
+            <Chinesesimp>部署</Chinesesimp>
+            <Chinese>佈署</Chinese>
+            <Turkish>CANLANMA</Turkish>
+            <Portuguese>MOBILIZAÇÃO</Portuguese>
+        </Key>
+        <Key ID="STR_DEPLOY_BUTTON">
+            <Original>Deploy</Original>
+            <French>Déploiment</French>
+            <German>Einsetzen</German>
+            <Spanish>Desplegar</Spanish>
+            <Russian>РАЗМЕСТИТЬ</Russian>
+            <Italian>Schierati</Italian>
+            <Chinesesimp>部署</Chinesesimp>
+            <Chinese>佈署</Chinese>
+            <Turkish>Canlan</Turkish>
+            <Portuguese>Mobilizar</Portuguese>
+        </Key>
+        <Key ID="STR_DEPLOY_ACTION">
+            <Original>-- REDEPLOY --</Original>
+            <French>-- REDEPLOIEMENT --</French>
+            <German>-- NEU EINSETZEN --</German>
+            <Spanish>-- REDESPLEGAR --</Spanish>
+            <Russian>-- ПЕРЕМЕСТИТЬСЯ --</Russian>
+            <Italian>-- RISCHIERAMENTO --</Italian>
+            <Chinesesimp>-- 重新部署 --</Chinesesimp>
+            <Chinese>-- 重新佈署 --</Chinese>
+            <Turkish>-- YENİDEN SEÇ --</Turkish>
+            <Portuguese>-- REMOBILIZAR --</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_CREW">
+            <Original>Build (Crew)</Original>
+            <French>Construire (Equipage)</French>
+            <German>Bauen (Besatzung)</German>
+            <Spanish>Construir (Equipo)</Spanish>
+            <Russian>Создать (Экипаж)</Russian>
+            <Italian>Crea Equipaggio</Italian>
+            <Chinesesimp>建造（含成员）</Chinesesimp>
+            <Chinese>建造（包含成員）</Chinese>
+            <Turkish>Ekip Yarat</Turkish>
+            <Portuguese>Construir (tripulado)</Portuguese>
+        </Key>
+        <Key ID="STR_LIGHT_RIFLE_SQUAD">
+            <Original>Light Rifle Squad</Original>
+            <French>Escouade Fusiliers Légère</French>
+            <German>Leichter Waffentrupp</German>
+            <Spanish>Escuadra de fusileros ligeros</Spanish>
+            <Russian>Легкий Стрелковый Отряд</Russian>
+            <Italian>Squadra Fucilieri Leggeri</Italian>
+            <Chinesesimp>轻装步枪班</Chinesesimp>
+            <Chinese>輕裝步槍班</Chinese>
+            <Turkish>Hafif Silah Timi</Turkish>
+            <Portuguese>Grupo de Combate de Infantaria Leve</Portuguese>
+        </Key>
+        <Key ID="STR_RIFLE_SQUAD">
+            <Original>Heavy Rifle Squad</Original>
+            <French>Escouade Fusiliers Lourde</French>
+            <German>Schwerer Waffentrupp</German>
+            <Spanish>Escuadra de fusileros pesados</Spanish>
+            <Russian>Тяжёлый Стрелковый Отряд</Russian>
+            <Italian>Squadra Fucilieri Pesanti</Italian>
+            <Chinesesimp>重装步枪班</Chinesesimp>
+            <Chinese>重裝步槍班</Chinese>
+            <Turkish>Ağır Silah Timi</Turkish>
+            <Portuguese>Grupo de Combate de Infantaria Pesada</Portuguese>
+        </Key>
+        <Key ID="STR_AT_SQUAD">
+            <Original>AT Squad</Original>
+            <French>Escouade AT</French>
+            <German>Panzerbekämpfungstrupp</German>
+            <Spanish>Escuadra Antitanque</Spanish>
+            <Russian>Отряд ПТ</Russian>
+            <Italian>Squadra Anticarro</Italian>
+            <Chinesesimp>反坦克班</Chinesesimp>
+            <Chinese>反坦班</Chinese>
+            <Turkish>Anti-Tank Timi</Turkish>
+            <Portuguese>Grupo de Combate Anti-Blindagem</Portuguese>
+        </Key>
+        <Key ID="STR_AA_SQUAD">
+            <Original>AA Squad</Original>
+            <French>Escouade AA</French>
+            <German>Luftabwehrtrupp</German>
+            <Spanish>Escuadra Antiaérea</Spanish>
+            <Russian>Отряд ПВО</Russian>
+            <Italian>Squadra Antiaerea</Italian>
+            <Chinesesimp>防空班</Chinesesimp>
+            <Chinese>防空班</Chinese>
+            <Turkish>Anti-Hava Timi</Turkish>
+            <Portuguese>Grupo de Combate Anti-Aéreo</Portuguese>
+        </Key>
+        <Key ID="STR_RECON_SQUAD">
+            <Original>Recon Squad</Original>
+            <French>Escouade Recon</French>
+            <German>Aufklärungstrupp</German>
+            <Spanish>Escuadra de reconocimiento</Spanish>
+            <Russian>Отряд Разведчиков</Russian>
+            <Italian>Squadra Ricognitori</Italian>
+            <Chinesesimp>侦察班</Chinesesimp>
+            <Chinese>偵查班</Chinese>
+            <Turkish>Gözcü Timi</Turkish>
+            <Portuguese>Grupo de Combate de Reconhecimento</Portuguese>
+        </Key>
+        <Key ID="STR_PARA_SQUAD">
+            <Original>Paratroopers Squad</Original>
+            <French>Escouade Parachutistes</French>
+            <German>Fallschirmjägertrupp</German>
+            <Spanish>Escuadra de paracaidistas</Spanish>
+            <Russian>Отряд Десантников</Russian>
+            <Italian>Squadra Paracadutisti</Italian>
+            <Chinesesimp>空降班</Chinesesimp>
+            <Chinese>傘兵班</Chinese>
+            <Turkish>Paraşütçü Asker Timi</Turkish>
+            <Portuguese>Grupo de Combate de Paraquedistas</Portuguese>
+        </Key>
+        <Key ID="STR_UNITCAP">
+            <Original>Unit cap</Original>
+            <French>Limite</French>
+            <German>Einheitenbegrenzung</German>
+            <Spanish>Límite de unidades</Spanish>
+            <Russian>Мобилизованных</Russian>
+            <Italian>Limite delle Unità</Italian>
+            <Chinesesimp>单位上限</Chinesesimp>
+            <Chinese>單位上限</Chinese>
+            <Turkish>Ünit Limiti</Turkish>
+            <Portuguese>Limite de unidades</Portuguese>
+        </Key>
+        <Key ID="STR_WIPE_TITLE">
+            <Original>Wipe savegame</Original>
+            <French>Effacer la sauvegarde</French>
+            <German>Spielstand löschen</German>
+            <Spanish>Borrar partida guardada</Spanish>
+            <Russian>Удалить сохранённый прогресс</Russian>
+            <Italian>Elimina Salvataggi</Italian>
+            <Chinesesimp>清空存档</Chinesesimp>
+            <Chinese>刪除存檔</Chinese>
+            <Turkish>Kayıtlı oyunu sil</Turkish>
+            <Portuguese>Apagar jogo salvo</Portuguese>
+        </Key>
+        <Key ID="STR_WIPE_TITLE_2">
+            <Original>Confirm : wipe savegame</Original>
+            <French>Confirmer : effacer la sauvegarde</French>
+            <German>Bestätige: Spielstand löschen</German>
+            <Spanish>Confirmar : Borrar partida guardada</Spanish>
+            <Russian>Подтвердить : Удалить сохранённый прогресс</Russian>
+            <Italian>Confermare : Elimina Salvataggi</Italian>
+            <Chinesesimp>确认 ： 清空存档</Chinesesimp>
+            <Chinese>確認：刪除存檔</Chinese>
+            <Turkish>Onayla : Kayıtlı oyunu sil</Turkish>
+            <Portuguese>Confirmar: Apagar jogo salvo</Portuguese>
+        </Key>
+        <Key ID="STR_WIPE_NO">
+            <Original>No</Original>
+            <French>Non</French>
+            <German>Nein</German>
+            <Spanish>No</Spanish>
+            <Russian>Нет</Russian>
+            <Italian>No</Italian>
+            <Chinesesimp>否</Chinesesimp>
+            <Chinese>否</Chinese>
+            <Turkish>Hayır</Turkish>
+            <Portuguese>Não</Portuguese>
+        </Key>
+        <Key ID="STR_WIPE_YES">
+            <Original>!! THE SAVEGAME WILL BE WIPED, NO RECOVERY POSSIBLE !!</Original>
+            <French>!! LA SAUVEGARDE SERA EFFACEE SANS RECUPERATION POSSIBLE !!</French>
+            <German>!! SPIELSTAND WIRD GELÖSCHT, KEIN WIEDERHERSTELLEN MÖGLICH !!</German>
+            <Spanish>!! LA PARTIDA GUARDADA SERÁ BORRADA, SIN RECUPERACIÓN POSIBLE !!</Spanish>
+            <Russian>!! СОХРАНЁННЫЙ ПРОГРЕСС БУДЕТ УДАЛЕН, ВОССТАНОВИТЬ БУДЕТ НЕВОЗМОЖНО !!</Russian>
+            <Italian>!! I SALVATAGGI SARANNO ELIMINATI, SENZA POSSIBILITA' DI RECUPERO !!</Italian>
+            <Chinesesimp>!!存档将被移除，且无法恢复!!</Chinesesimp>
+            <Chinese>！！警告，存檔將被刪除，且無法復原！！</Chinese>
+            <Turkish>!! KAYITLI OYUN SİLİNECEKTİR, GERİ GETİRELEMEZ !!</Turkish>
+            <Portuguese>!! O JOGO SALVO SERÁ APAGADO, NÃO SERÁ POSSÍVEL RECUPERÁ-LO !!</Portuguese>
+        </Key>
+        <Key ID="STR_UNFLIP">
+            <Original>-- UNFLIP</Original>
+            <French>-- UNFLIP</French>
+            <German>-- UMDREHEN</German>
+            <Spanish>-- RECOLOCAR VEHÍCULO</Spanish>
+            <Russian>-- ПЕРЕВЕРНУТЬ</Russian>
+            <Italian>-- RIADDRIZZA</Italian>
+            <Chinesesimp>-- 复位</Chinesesimp>
+            <Chinese>-- 翻正</Chinese>
+            <Turkish>-- TERS DÖNDÜR</Turkish>
+            <Portuguese>-- DESVIRAR</Portuguese>
+        </Key>
+        <Key ID="STR_GRID">
+            <Original>-- Grid mode</Original>
+            <French>-- Mode grille</French>
+            <German>-- Rastermodus</German>
+            <Spanish>-- Modo rejilla</Spanish>
+            <Russian>-- Режим сетки</Russian>
+            <Italian>-- Modalità Griglia</Italian>
+            <Chinesesimp>-- 网格模式</Chinesesimp>
+            <Chinese>-- 網格模式</Chinese>
+            <Turkish>-- Grid modu</Turkish>
+            <Portuguese>-- Modo "grid"</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_CAPTURE">
+            <Original>-- CAPTURE</Original>
+            <French>-- CAPTURER</French>
+            <German>-- GEFANGENNEHMEN</German>
+            <Spanish>-- CAPTURAR</Spanish>
+            <Russian>-- ЗАХВАТИТЬ</Russian>
+            <Italian>-- CATTURA</Italian>
+            <Chinesesimp>-- 俘虏</Chinesesimp>
+            <Chinese>-- 俘虜</Chinese>
+            <Turkish>-- YAKALA</Turkish>
+            <Portuguese>-- CAPTURAR</Portuguese>
+        </Key>
+        <Key ID="STR_SQUAD_MEMBER">
+            <Original>Squad member</Original>
+            <French>Membre d'escouade</French>
+            <German>Truppenmitglieder</German>
+            <Spanish>Miembro de escuadra</Spanish>
+            <Russian>Член отряда</Russian>
+            <Italian>Membri Squadra</Italian>
+            <Chinesesimp>班组成员</Chinesesimp>
+            <Chinese>班級成員</Chinese>
+            <Turkish>Tim üyesi</Turkish>
+            <Portuguese>Membro do Grupo</Portuguese>
+        </Key>
+        <Key ID="STR_SPAWN_NEAR">
+            <Original>Near</Original>
+            <French>Près de</French>
+            <German>Nah</German>
+            <Spanish>Cerca</Spanish>
+            <Russian>Рядом</Russian>
+            <Italian>Vicino</Italian>
+            <Chinesesimp>就近</Chinesesimp>
+            <Chinese>附近</Chinese>
+            <Turkish>Yakın</Turkish>
+            <Portuguese>Próximo de</Portuguese>
+        </Key>
+        <Key ID="STR_RECYCLE">
+            <Original>-- RECYCLE</Original>
+            <French>-- RECYCLER</French>
+            <German>-- WIEDERVERWERTEN</German>
+            <Spanish>-- RECICLAR</Spanish>
+            <Russian>-- УТИЛИЗИРОВАТЬ</Russian>
+            <Italian>-- RICICLA</Italian>
+            <Chinesesimp>-- 回收</Chinesesimp>
+            <Chinese>-- 回收</Chinese>
+            <Turkish>-- GERİ DÖNÜŞTÜR</Turkish>
+            <Portuguese>-- RECICLAR</Portuguese>
+        </Key>
+        <Key ID="STR_RECYCLING">
+            <Original>Recycling</Original>
+            <French>Recyclage</French>
+            <German>Wiederverwerten</German>
+            <Spanish>Reciclando</Spanish>
+            <Russian>Утилизация</Russian>
+            <Italian>Riciclando</Italian>
+            <Chinesesimp>正在回收</Chinesesimp>
+            <Chinese>回收中</Chinese>
+            <Turkish>Geri Dönüştürme</Turkish>
+            <Portuguese>Reciclando</Portuguese>
+        </Key>
+        <Key ID="STR_RECYCLING_YIELD">
+            <Original>Recycling this %1 will yield:</Original>
+            <French>Le recyclage de %1 rapportera :</French>
+            <German>Die Wiederverwertung von %1 erbringt:</German>
+            <Spanish>Reciclando este %1 obtienes:</Spanish>
+            <Russian>Утилизируя %1 получим</Russian>
+            <Italian>Riciclando questo %1 otterrai:</Italian>
+            <Chinesesimp>回收%1将会获得：</Chinesesimp>
+            <Chinese>回收%1將會獲得：</Chinese>
+            <Turkish>Geri dönüştürme %1 verecektir:</Turkish>
+            <Portuguese>Reciclando este %1, irá obter:</Portuguese>
+        </Key>
+        <Key ID="STR_RECYCLING_PROCEED">
+            <Original>Recycle</Original>
+            <French>Recycler</French>
+            <German>Wiederverwerten</German>
+            <Spanish>Reciclar</Spanish>
+            <Russian>Утилизировать</Russian>
+            <Italian>Riciclato</Italian>
+            <Chinesesimp>回收</Chinesesimp>
+            <Chinese>回收</Chinese>
+            <Turkish>Geri Dönüştür</Turkish>
+            <Portuguese>Reciclar</Portuguese>
+        </Key>
+        <Key ID="STR_RECYCLING_CANCEL">
+            <Original>Cancel</Original>
+            <French>Annuler</French>
+            <German>Abbrechen</German>
+            <Spanish>Cancelar</Spanish>
+            <Russian>Отмена</Russian>
+            <Italian>Annulla</Italian>
+            <Chinesesimp>取消</Chinesesimp>
+            <Chinese>取消</Chinese>
+            <Turkish>İptal</Turkish>
+            <Portuguese>Cancelar</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORCAPTURED_TITLE">
+            <Original>SECTOR CAPTURED</Original>
+            <French>SECTEUR CAPTURE</French>
+            <German>SEKTOR EINGENOMMEN</German>
+            <Spanish>SECTOR CAPTURADO</Spanish>
+            <Russian>ЗОНА ЗАХВАЧЕНА</Russian>
+            <Italian>SETTORE CATTURATO</Italian>
+            <Chinesesimp>战区已占领</Chinesesimp>
+            <Chinese>戰區已占領</Chinese>
+            <Turkish>SEKTÖR ELE GEÇİRİLDİ</Turkish>
+            <Portuguese>SETOR CAPTURADO</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORCAPTURED_TEXT">
+            <Original>Our forces have captured %1.</Original>
+            <French>Nos forces ont capturé %1.</French>
+            <German>Unsere Truppen haben %1 eingenommen.</German>
+            <Spanish>Nuestras fuerzas han capturado %1</Spanish>
+            <Russian>Наши войска захватили %1.</Russian>
+            <Italian>Le nostre unità hanno catturato %1</Italian>
+            <Chinesesimp>我军部队已占领%1。</Chinesesimp>
+            <Chinese>我軍已佔領 %1。</Chinese>
+            <Turkish>Birliklerimiz %1 'i almayı başardı</Turkish>
+            <Portuguese>Nossas forças capturaram %1.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORATTACKED_TITLE">
+            <Original>SECTOR ATTACKED</Original>
+            <French>SECTEUR ATTAQUE</French>
+            <German>SEKTOR ANGEGRIFFEN</German>
+            <Spanish>SECTOR ATACADO</Spanish>
+            <Russian>ЗОНА АТАКОВАНА</Russian>
+            <Italian>SETTORE SOTTO ATTACCO</Italian>
+            <Chinesesimp>战区遭到攻击</Chinesesimp>
+            <Chinese>戰區遭到襲擊</Chinese>
+            <Turkish>SEKTÖR SALDIRI ALTINDA</Turkish>
+            <Portuguese>SETOR ATACADO</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORATTACKED_TEXT">
+            <Original>Hostiles forces are attacking %1!</Original>
+            <French>Des forces hostiles attaquent %1!</French>
+            <German>Gegnerische Truppen greifen %1 an!</German>
+            <Spanish>Fuerzas hostiles están atacando %1</Spanish>
+            <Russian>Вражеские силы атакуют %1!</Russian>
+            <Italian>Forze ostili attaccano %1!</Italian>
+            <Chinesesimp>敌军部队正在进攻%1！</Chinesesimp>
+            <Chinese>敵軍正在進攻 %1！</Chinese>
+            <Turkish>Düşman birlikleri %1 'e saldırıyor'</Turkish>
+            <Portuguese>Forças hostis estão atacando %1!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORLOST_TITLE">
+            <Original>SECTOR LOST</Original>
+            <French>SECTEUR LOST</French>
+            <German>SEKTOR VERLOREN</German>
+            <Spanish>SECTOR PERDIDO</Spanish>
+            <Russian>ЗОНА ПОТЕРЯНА</Russian>
+            <Italian>SETTORE PERSO</Italian>
+            <Chinesesimp>战区已丢失</Chinesesimp>
+            <Chinese>已失去戰區</Chinese>
+            <Turkish>SEKTÖR KAYBEDİLDİ</Turkish>
+            <Portuguese>SETOR PERDIDO</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORLOST_TEXT">
+            <Original>We have lost control over %1!</Original>
+            <French>Nous avons perdu le contrôle de %1!</French>
+            <German>Wir haben die Kontrolle über %1 verloren!</German>
+            <Spanish>Hemos perdido el control sobre %1!</Spanish>
+            <Russian>Мы потеряли контроль над %1!</Russian>
+            <Italian>Abbiamo perso il controllo di %1!</Italian>
+            <Chinesesimp>我们失去了%1的控制权！</Chinesesimp>
+            <Chinese>我們失去了 %1 ！</Chinese>
+            <Turkish>%1 'deki hakimiyetimizi kaybettik!'</Turkish>
+            <Portuguese>Perdemos controle de %1!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORSAFE_TITLE">
+            <Original>SECTOR SAFE</Original>
+            <French>SECTEUR SECURISE</French>
+            <German>SEKTOR SICHER</German>
+            <Spanish>SECTOR SEGURO</Spanish>
+            <Russian>ЗОНА В БЕЗОПАСНОСТИ</Russian>
+            <Italian>SETTORE AL SICURO</Italian>
+            <Chinesesimp>战区已安全</Chinesesimp>
+            <Chinese>戰區已安全</Chinese>
+            <Turkish>SEKTÖR GÜVENDE</Turkish>
+            <Portuguese>SETOR SEGURO</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECTORSAFE_TEXT">
+            <Original>%1 is no longer under threat.</Original>
+            <French>%1 n'est plus menacé(e).</French>
+            <German>%1 ist außer Gefahr.</German>
+            <Spanish>%1 ya no está bajo amenaza.</Spanish>
+            <Russian>%1 больше не под угрозой.</Russian>
+            <Italian>%1 non è più sotto attacco.</Italian>
+            <Chinesesimp>%1脱离了危险。</Chinesesimp>
+            <Chinese>%1 脫離了危險。</Chinese>
+            <Turkish>%1 tehlike altında değil.</Turkish>
+            <Portuguese>%1 não está mais sob ameaça.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBBUILT_TITLE">
+            <Original>NEW FOB BUILT</Original>
+            <French>NOUVELLE FOB</French>
+            <German>NEUE FOB GEBAUT</German>
+            <Spanish>NUEVA FOB CONSTRUIDA</Spanish>
+            <Russian>НОВАЯ FOB ПОСТРОЕНА</Russian>
+            <Italian>NUOVA FOB COSTRUITA</Italian>
+            <Chinesesimp>新的前哨部署完成</Chinesesimp>
+            <Chinese>新的前線基地佈署完畢</Chinese>
+            <Turkish>YENİ FOB KURULDU</Turkish>
+            <Portuguese>NOVA FOB CONSTRUÍDA</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBBUILT_TEXT">
+            <Original>FOB %1 is now operational.</Original>
+            <French>La FOB %1 est opérationnelle.</French>
+            <German>FOB %1 nun funktionsfähig.</German>
+            <Spanish>La FOB %1 es operacional</Spanish>
+            <Russian>FOB %1 сейчас действует.</Russian>
+            <Italian>La FOB %1 è operativa.</Italian>
+            <Chinesesimp>%1前哨现已入役。</Chinesesimp>
+            <Chinese>前線基地 %1 已啟用。</Chinese>
+            <Turkish>FOB %1 şimdi yürürlükte.</Turkish>
+            <Portuguese>FOB %1 está operacional.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBSAFE_TITLE">
+            <Original>FOB SAFE</Original>
+            <French>FOB SECURISEE</French>
+            <German>FOB SICHER</German>
+            <Spanish>FOB SEGURA</Spanish>
+            <Russian>FOB В БЕЗОПАСНОСТИ</Russian>
+            <Italian>FOB AL SICURO</Italian>
+            <Chinesesimp>前哨已安全</Chinesesimp>
+            <Chinese>前線基地已安全</Chinese>
+            <Turkish>FOB GÜVENDE</Turkish>
+            <Portuguese>FOB SEGURA</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBSAFE_TEXT">
+            <Original>FOB %1 is no longer under threat.</Original>
+            <French>La FOB %1 n'est plus menacée.</French>
+            <German>FOB %1 ist außer Gefahr.</German>
+            <Spanish>FOB %1 ya no está bajo amenaza</Spanish>
+            <Russian>FOB %1 больше не находится под угрозой.</Russian>
+            <Italian>La FOB %1 non è più in pericolo.</Italian>
+            <Chinesesimp>%1前哨脱离了危险。</Chinesesimp>
+            <Chinese>前線基地 %1 已脫離危險。</Chinese>
+            <Turkish>FOB %1 artık güvende.</Turkish>
+            <Portuguese>FOB %1 não está mais sob ameaça.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBATTACKED_TITLE">
+            <Original>FOB ATTACKED</Original>
+            <French>FOB ATTAQUEE</French>
+            <German>FOB ANGEGRIFFEN</German>
+            <Spanish>FOB ATACADA</Spanish>
+            <Russian>FOB АТАКОВАНА</Russian>
+            <Italian>FOB SOTTO ATTACCO</Italian>
+            <Chinesesimp>前哨遭到攻击</Chinesesimp>
+            <Turkish>FOB SALDIRI ALTINDA</Turkish>
+            <Portuguese>FOB ATACADA</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBATTACKED_TEXT">
+            <Original>FOB %1 is under attack!</Original>
+            <French>La FOB %1 est attaquée !</French>
+            <German>FOB %1 wird angegriffen !</German>
+            <Spanish>FOB %1 está bajo ataque!</Spanish>
+            <Russian>FOB %1 атакована!</Russian>
+            <Italian>la FOB %1 è sotto attacco!</Italian>
+            <Chinesesimp>%1前哨受到了攻击！</Chinesesimp>
+            <Chinese>前線基地 %1 受到攻擊！</Chinese>
+            <Turkish>FOB %1 Saldırı altında</Turkish>
+            <Portuguese>FOB %1 está sob ataque!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBLOST_TITLE">
+            <Original>FOB DESTROYED</Original>
+            <French>FOB DETRUITE</French>
+            <German>FOB ZERSTÖRT</German>
+            <Spanish>FOB DESTRUIDA</Spanish>
+            <Russian>FOB УНИЧТОЖЕНА</Russian>
+            <Italian>FOB DISTRUTTA</Italian>
+            <Chinesesimp>前哨被摧毁</Chinesesimp>
+            <Chinese>前線基地被摧毀</Chinese>
+            <Turkish>FOB YOK EDİLDİ</Turkish>
+            <Portuguese>FOB DESTRUÍDA</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOBLOST_TEXT">
+            <Original>FOB %1 has been destroyed!</Original>
+            <French>La FOB %1 a été détruite !</French>
+            <German>FOB %1 wurde zerstört!</German>
+            <Spanish>La FOB %1 ha sido destruida!</Spanish>
+            <Russian>FOB %1 была уничтожена!</Russian>
+            <Italian>La FOB %1 è stata distrutta!</Italian>
+            <Chinesesimp>%1前哨被摧毁了！</Chinesesimp>
+            <Turkish>FOB %1 kaybedildi!</Turkish>
+            <Portuguese>FOB %1 foi destruída!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_BATTLEGROUP_TITLE">
+            <Original>HOSTILE FORCES INCOMING</Original>
+            <French>FORCES HOSTILES EN APPROCHE</French>
+            <German>GEGNERISCHE TRUPPEN TREFFEN EIN</German>
+            <Spanish>FUERZAS HOSTILES ACERCÁNDOSE</Spanish>
+            <Russian>ПОДХОДЯТ ВРАЖЕСКИЕ СИЛЫ</Russian>
+            <Italian>FORZE OSTILI IN ARRIVO</Italian>
+            <Chinesesimp>敌军部队接近中</Chinesesimp>
+            <Chinese>敵軍靠近中</Chinese>
+            <Turkish>DÜŞMAN BİRLİKLERİ GELİYOR</Turkish>
+            <Portuguese>FORÇAS HOSTIS A CAMINHO</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_BATTLEGROUP_TEXT">
+            <Original>Hostile forces spotted near %1.</Original>
+            <French>Forces hostiles repérées près de %1.</French>
+            <German>Gegnerische Truppen nahe %1 gesichtet.</German>
+            <Spanish>Fuerzas hosstiles avistadas cerca de %1</Spanish>
+            <Russian>Вражеские силы замечены рядом с %1.</Russian>
+            <Italian>Forze ostili avvistate vicino %1</Italian>
+            <Chinesesimp>%1附近发现了敌军部队。</Chinesesimp>
+            <Chinese>%1 附近發現了敵方的部隊</Chinese>
+            <Turkish>DÜŞMANLAR %1 yakınlarında göründü.</Turkish>
+            <Portuguese>Forças hostis identificadas nas proximidades de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_INTEL_TITLE">
+            <Original>NEW INTELLIGENCE</Original>
+            <French>NOUVEAUX RENSEIGNEMENTS</French>
+            <German>NEUE INFORMATIONEN</German>
+            <Spanish>NUEVA INTELIGENCIA</Spanish>
+            <Russian>НОВЫЕ РАЗВЕДДАННЫЕ</Russian>
+            <Italian>NUOVO INTEL</Italian>
+            <Chinesesimp>新情报</Chinesesimp>
+            <Chinese>新情報</Chinese>
+            <Turkish>YENİ İSTİHBAHRAT</Turkish>
+            <Portuguese>NOVA INTELIGÊNCIA</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_FOB_TEXT">
+            <Original>Hostile FOB near %1.</Original>
+            <French>FOB hostile près de %1.</French>
+            <German>Gegnerische FOB nahe %1.</German>
+            <Spanish>FOB hostil cerca de %1</Spanish>
+            <Russian>Вражеская FOB рядом %1.</Russian>
+            <Italian>FOB ostile vicino %1.</Italian>
+            <Chinesesimp>%1附近发现了敌军前哨。</Chinesesimp>
+            <Chinese>%1 附近發現了敵方的前線基地。</Chinese>
+            <Turkish>Düşman FOB'si %1 taraflarında.</Turkish>
+            <Portuguese>FOB hostil nas proximidades de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_PRISONER_TEXT">
+            <Original>We have interrogated a prisoner.</Original>
+            <French>Nous avons interroger un prisonnier.</French>
+            <German>Wir haben einen Gefangenen verhört.</German>
+            <Spanish>Hemos interrogado a un prisionero.</Spanish>
+            <Russian>Мы можем допросить пленного.</Russian>
+            <Italian>Abbiamo interrogato il prigioniero.</Italian>
+            <Chinesesimp>我们审讯了一名战犯。</Chinesesimp>
+            <Chinese>我們審問了一名俘虜。</Chinese>
+            <Turkish>Başarıyla bir tutsağı sorguladık.</Turkish>
+            <Portuguese>Interrogamos um prisioneiro.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_DOCUMENT_TEXT">
+            <Original>We have found secret documents.</Original>
+            <French>Nous avons trouvé des documents secrets</French>
+            <German>Wir haben geheime Dokumente gefunden.</German>
+            <Spanish>Hemos encontrado documentos secretos</Spanish>
+            <Russian>Мы нашли секретные документы.</Russian>
+            <Italian>Abbiamo trovato dei documenti segreti.</Italian>
+            <Chinesesimp>我们找到了机密文件。</Chinesesimp>
+            <Chinese>我們找到了機密文件。</Chinese>
+            <Turkish>Gizli istihbahrat dosyası bulduk.</Turkish>
+            <Portuguese>Localizamos documentos secretos.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECONDARY_TITLE">
+            <Original>SECONDARY OBJECTIVE</Original>
+            <French>OBJECTIF SECONDAIRE</French>
+            <German>SEKUNDÄRZIEL</German>
+            <Spanish>OBJETIVO SECUNDARIO</Spanish>
+            <Russian>ДОПОЛНИТЕЛЬНАЯ ЗАДАЧА</Russian>
+            <Italian>OBIETTIVI SECONDARI</Italian>
+            <Chinesesimp>次要目标</Chinesesimp>
+            <Chinese>次要任務</Chinese>
+            <Turkish>İKİNCİ GÖREV</Turkish>
+            <Portuguese>OBJETIVO SECUNDÁRIO</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SECONDARY_TEXT">
+            <Original>Hostile FOB destroyed</Original>
+            <French>FOB hostile détruite.</French>
+            <German>Gegnerische FOB zerstört.</German>
+            <Spanish>FOB hostil destruída</Spanish>
+            <Russian>Вражеская FOB уничтожена</Russian>
+            <Italian>FOB ostile distrutta.</Italian>
+            <Chinesesimp>敌军前哨已摧毁</Chinesesimp>
+            <Chinese>敵方前線基地已遭摧毀</Chinese>
+            <Turkish>Düşman FOB'si yok edildi.</Turkish>
+            <Portuguese>FOB hostil destruída</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_REINFORCEMENTS_TITLE">
+            <Original>HOSTILE REINFORCEMENTS</Original>
+            <French>RENFORTS HOSTILES</French>
+            <German>GEGNERISCHER NACHSCHUB</German>
+            <Spanish>REFUERZOS HOSTILES</Spanish>
+            <Russian>ВРАЖЕСКОЕ ПОДКРЕПЛЕНИЕ</Russian>
+            <Italian>RINFORZI OSTILI</Italian>
+            <Chinesesimp>敌军增援</Chinesesimp>
+            <Chinese>敵方增援</Chinese>
+            <Turkish>DÜŞMAN TAKVİYE KUVVETLERİ</Turkish>
+            <Portuguese>REFORÇOS HOSTIS</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_REINFORCEMENTS_TEXT">
+            <Original>Hostile forces reinforcing %1.</Original>
+            <French>Forces hostiles en renfort à %1.</French>
+            <German>Gegnerische Truppen verstärken %1.</German>
+            <Spanish>Fuerzas hostiles reforzando %1</Spanish>
+            <Russian>Вражеские подкрепления подходят в %1.</Russian>
+            <Italian>Forze ostili rinforzano le truppe su %1</Italian>
+            <Chinesesimp>敌军部队正在向%1增援。</Chinesesimp>
+            <Chinese>敵軍正在向 %1 增援。</Chinese>
+            <Turkish>Düşmanlar %1 'e takviye kuvvet yolladılar.'</Turkish>
+            <Portuguese>Forças hostis reforçando %1.</Portuguese>
+        </Key>
+        <Key ID="STR_VICTORY_TITLE">
+            <Original>BLUFOR VICTORY</Original>
+            <French>VICTOIRE BLUFOR</French>
+            <German>BLUFOR SIEGREICH</German>
+            <Spanish>VICTORIA DE BLUFOR</Spanish>
+            <Russian>СИНИЕ ПОБЕДИЛИ</Russian>
+            <Italian>VITTORIA PER I BLUFOR</Italian>
+            <Chinesesimp>我军胜利</Chinesesimp>
+            <Chinese>我軍勝利</Chinese>
+            <Turkish>BLUFOR ZAFERİ</Turkish>
+            <Portuguese>VITÓRIA DAS FORÇAS DA COALIZÃO (BLUFOR)</Portuguese>
+        </Key>
+        <Key ID="STR_VICTORY_TEXT">
+            <Original>You have liberated the island from the OPFOR oppression.</Original>
+            <French>Vous avez libéré Altis de l'oppression de l'OPFOR.</French>
+            <German>Du hast Altis von der OPFOR Besatzung befreit.</German>
+            <Spanish>Has liberado a Altis de la opresión del OPFOR</Spanish>
+            <Russian>Вы освободили Алтис от оккупации OPFOR.</Russian>
+            <Italian>Siete riusciti a liberare l'isola dall'oppressione degli OPFOR</Italian>
+            <Chinesesimp>你已将本岛从敌人的压迫中解救了出来。</Chinesesimp>
+            <Chinese>你已將從敵人的統治之中解放了此區域。</Chinese>
+            <Turkish>Bu adayı OPFOR işgalinden kurtardınız.</Turkish>
+            <Portuguese>Você libertou o território da opressão das tropas inimigas.</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_DAY">
+            <Original>days</Original>
+            <French>jours</French>
+            <German>Tage</German>
+            <Spanish>días</Spanish>
+            <Russian>дней</Russian>
+            <Italian>Giorni</Italian>
+            <Chinesesimp>日</Chinesesimp>
+            <Chinese>日</Chinese>
+            <Turkish>günler</Turkish>
+            <Portuguese>dias</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_HOURS">
+            <Original>hours</Original>
+            <French>heures</French>
+            <German>Stunden</German>
+            <Spanish>horas</Spanish>
+            <Russian>часов</Russian>
+            <Italian>Ore</Italian>
+            <Chinesesimp>时</Chinesesimp>
+            <Chinese>時</Chinese>
+            <Turkish>saatler</Turkish>
+            <Portuguese>horas</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_MINUTES">
+            <Original>minutes</Original>
+            <French>minutes</French>
+            <German>Minuten</German>
+            <Spanish>minutos</Spanish>
+            <Russian>минут</Russian>
+            <Italian>Minuti</Italian>
+            <Chinesesimp>分</Chinesesimp>
+            <Chinese>分</Chinese>
+            <Turkish>dakikalar</Turkish>
+            <Portuguese>minutos</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_SECONDS">
+            <Original>seconds</Original>
+            <French>secondes</French>
+            <German>Sekunden</German>
+            <Spanish>segundos</Spanish>
+            <Russian>секунд</Russian>
+            <Italian>Secondi</Italian>
+            <Chinesesimp>秒</Chinesesimp>
+            <Chinese>秒</Chinese>
+            <Turkish>saniyeler</Turkish>
+            <Portuguese>segundos</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_PLAYTIME">
+            <Original>Playtime:</Original>
+            <French>Temps de jeu :</French>
+            <German>Spielzeit:</German>
+            <Spanish>Tiempo de juego:</Spanish>
+            <Russian>Игрового времени:</Russian>
+            <Italian>tempo di Gioco:</Italian>
+            <Chinesesimp>游戏时间：</Chinesesimp>
+            <Chinese>遊戲時間：</Chinese>
+            <Turkish>Oynama süresi:</Turkish>
+            <Portuguese>Tempo de jogo:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_1">
+            <Original>OPFOR infantry killed:</Original>
+            <French>Infanterie OPFOR tuée :</French>
+            <German>OPFOR Infanterie getötet:</German>
+            <Spanish>Infantería OPFOR eliminada:</Spanish>
+            <Russian>OPFOR пехоты убито:</Russian>
+            <Italian>Fanteria OPFOR ha ucciso:</Italian>
+            <Chinesesimp>被击杀的敌军步兵：</Chinesesimp>
+            <Chinese>被擊殺的敵方步兵：</Chinese>
+            <Turkish>Öldürülen OPFOR:</Turkish>
+            <Portuguese>Baixas inimigas em combate:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_2">
+            <Original>OPFOR infantry killed by players:</Original>
+            <French>Infanterie OPFOR tuée par les joueurs :</French>
+            <German>OPFOR Infanterie von Spielern getötet:</German>
+            <Spanish>Infantería OPFOR eliminada por jugadores:</Spanish>
+            <Russian>OPFOR пехоты убито игроками:</Russian>
+            <Italian>Fanteria OPFOR uccisa da:</Italian>
+            <Chinesesimp>被玩家击杀的敌军步兵：</Chinesesimp>
+            <Chinese>被玩家擊殺的敵方步兵：</Chinese>
+            <Turkish>Oyuncular tarafından öldürülen OPFOR sayısı:</Turkish>
+            <Portuguese>Infantaria inimiga eliminada por jogadores:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_3">
+            <Original>BLUFOR infantry killed:</Original>
+            <French>Infanterie BLUFOR tuée :</French>
+            <German>BLUFOR Infanterie getötet:</German>
+            <Spanish>Infantería BLUFOR eliminada:</Spanish>
+            <Russian>BLUFOR пехоты убито:</Russian>
+            <Italian>Fanteria BLUFOR ha ucciso:</Italian>
+            <Chinesesimp>被击杀的我军步兵：</Chinesesimp>
+            <Chinese>被擊殺的我方步兵：</Chinese>
+            <Turkish>BLUFOR kayıpları:</Turkish>
+            <Portuguese>Baixas aliadas em combate:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_4">
+            <Original>Civilians killed:</Original>
+            <French>Civils tués :</French>
+            <German>Zivilisten getötet:</German>
+            <Spanish>Civiles asesinados:</Spanish>
+            <Russian>Гражданских убито:</Russian>
+            <Italian>Civile ha ucciso:</Italian>
+            <Chinesesimp>被击杀的平民：</Chinesesimp>
+            <Chinese>被擊殺的平民：</Chinese>
+            <Turkish>Öldürülen siviller:</Turkish>
+            <Portuguese>Civis mortos:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_5">
+            <Original>Civilians killed by players:</Original>
+            <French>Civils tués par les joueurs :</French>
+            <German>Zivilisten von Spielern getötet:</German>
+            <Spanish>Civiles asesinados por jugadores:</Spanish>
+            <Russian>Гражданских убито игроками:</Russian>
+            <Italian>Civile ucciso da:</Italian>
+            <Chinesesimp>被玩家击杀的平民：</Chinesesimp>
+            <Chinese>被玩家擊殺的平民：</Chinese>
+            <Turkish>Öldürülen siviller (oyuncular tarafından):</Turkish>
+            <Portuguese>Civis mortos por jogadores:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_6">
+            <Original>BLUFOR friendly fire incidents:</Original>
+            <French>Tirs fratricides BLUFOR :</French>
+            <German>BLUFOR Eigenbeschuss:</German>
+            <Spanish>Incidentes de fuego amigo en BLUFOR:</Spanish>
+            <Russian>BLUFOR дружественный огонь:</Russian>
+            <Italian>Fuoco amico tra i BLUFOR:</Italian>
+            <Chinesesimp>我军友军误击事件：</Chinesesimp>
+            <Chinese>友軍誤擊事件：</Chinese>
+            <Turkish>BLUFOR dost ateşi:</Turkish>
+            <Portuguese>Incidentes de fogo amigo:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_7">
+            <Original>OPFOR vehicles destroyed:</Original>
+            <French>Vehicules OPFOR détruits :</French>
+            <German>OPFOR Fahrzeuge zerstört:</German>
+            <Spanish>Vehículos OPFOR destruídos:</Spanish>
+            <Russian>OPFOR техники уничтожено:</Russian>
+            <Italian>Veicolo OPFOR distrutto:</Italian>
+            <Chinesesimp>敌军被摧毁的载具：</Chinesesimp>
+            <Chinese>敵軍被摧毀的載具：</Chinese>
+            <Turkish>OPFOR yokedilen araçları:</Turkish>
+            <Portuguese>Veículos inimigos destruídos:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_8">
+            <Original>OPFOR vehicles destroyed by players:</Original>
+            <French>Vehicules OPFOR détruits par les joueurs :</French>
+            <German>OPFOR Fahrzeuge von Spielern zerstört:</German>
+            <Spanish>Vehículos OPFOR destruídos por jugadores:</Spanish>
+            <Russian>OPFOR техники уничтожено игроками:</Russian>
+            <Italian>Veicolo OPFOR distrutto da:</Italian>
+            <Chinesesimp>被玩家摧毁的敌军载具：</Chinesesimp>
+            <Chinese>被玩家摧毀的敵軍載具：</Chinese>
+            <Turkish>OPFOR yokedilen araçları (oyuncular tarafından):</Turkish>
+            <Portuguese>Veículos inimigos destruídos por jogadores:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_9">
+            <Original>BLUFOR vehicles destroyed:</Original>
+            <French>Vehicules BLUFOR détruits :</French>
+            <German>BLUFOR Fahrzeuge zerstört:</German>
+            <Spanish>Vehículos BLUFOR destruídos:</Spanish>
+            <Russian>BLUFOR техники уничтожено:</Russian>
+            <Italian>Veicolo BLUFOR distrutto:</Italian>
+            <Chinesesimp>被摧毁的我军载具：</Chinesesimp>
+            <Chinese>被摧毀的我方載具：</Chinese>
+            <Turkish>BLUFOR yokedilen araçları:</Turkish>
+            <Portuguese>Veículos aliados destruídos:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_10">
+            <Original>BLUFOR vehicles built:</Original>
+            <French>Vehicules BLUFOR construits :</French>
+            <German>BLUFOR Fahrzeuge gebaut:</German>
+            <Spanish>Vehículos BLUFOR construidos:</Spanish>
+            <Russian>BLUFOR техники построено:</Russian>
+            <Italian>Veicolo BLUFOR creato:</Italian>
+            <Chinesesimp>我军建造的载具：</Chinesesimp>
+            <Chinese>我軍建造的載具：</Chinese>
+            <Turkish>BLUFOR yaratılan araçları:</Turkish>
+            <Portuguese>Veículos aliados construídos:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_11">
+            <Original>Vehicles recycled:</Original>
+            <French>Vehicules recyclés :</French>
+            <German>Fahrzeuge wiederaufbereitet:</German>
+            <Spanish>Vehículos reciclados:</Spanish>
+            <Russian>Техники утилизировано:</Russian>
+            <Italian>Veicolo riciclato:</Italian>
+            <Chinesesimp>回收的载具：</Chinesesimp>
+            <Chinese>回收的載具：</Chinese>
+            <Turkish>Geri dönüşüm olan araçlar:</Turkish>
+            <Portuguese>Veículos reciclados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_12">
+            <Original>Ammunition units spent:</Original>
+            <French>Unités de munitions dépensées :</French>
+            <German>Munitionseinheiten verbraucht:</German>
+            <Spanish>Unidades de munición gastadas:</Spanish>
+            <Russian>Единиц боеприпасов потрачено:</Russian>
+            <Italian>Punti munizione spesi:</Italian>
+            <Chinesesimp>消耗的弹药量：</Chinesesimp>
+            <Chinese>消耗的彈藥量：</Chinese>
+            <Turkish>Mermi mühimmati kullanımı:</Turkish>
+            <Portuguese>Unidades de munição utilizadas:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_13">
+            <Original>Sectors liberated:</Original>
+            <French>Secteurs libérés, delivrés :</French>
+            <German>Sektoren befreit:</German>
+            <Spanish>Sectores liberados:</Spanish>
+            <Russian>Зон освобождено:</Russian>
+            <Italian>Settore liberato:</Italian>
+            <Chinesesimp>解放的战区：</Chinesesimp>
+            <Chinese>解放的戰區：</Chinese>
+            <Turkish>Ele geçirilen sektörler:</Turkish>
+            <Portuguese>Setores liberados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_14">
+            <Original>Sectors lost:</Original>
+            <French>Secteurs perdus :</French>
+            <German>Sektoren verloren:</German>
+            <Spanish>Sectores perdidos:</Spanish>
+            <Russian>Зон потеряно:</Russian>
+            <Italian>Settore perso:</Italian>
+            <Chinesesimp>丢失的战区：</Chinesesimp>
+            <Chinese>失去的戰區：</Chinese>
+            <Turkish>Kaybedilen sektörler:</Turkish>
+            <Portuguese>Setores perdidos:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_15">
+            <Original>FOBs built:</Original>
+            <French>FOBs construites :</French>
+            <German>FOBs gebaut:</German>
+            <Spanish>FOBs construídas:</Spanish>
+            <Russian>FOB построено:</Russian>
+            <Italian>FOB costruita:</Italian>
+            <Chinesesimp>建造的前哨：</Chinesesimp>
+            <Chinese>建造的前線基地：</Chinese>
+            <Turkish>Kurulan FOB'ler:</Turkish>
+            <Portuguese>FOBs construídas:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_16">
+            <Original>FOBs lost:</Original>
+            <French>FOBs perdues :</French>
+            <German>FOBs verloren:</German>
+            <Spanish>FOB perdidas:</Spanish>
+            <Russian>FOB потеряно:</Russian>
+            <Italian>FOB persa:</Italian>
+            <Chinesesimp>损失的前哨：</Chinesesimp>
+            <Chinese>損失的前線基地：</Chinese>
+            <Turkish>Kaybedilen FOB'ler:</Turkish>
+            <Portuguese>FOBs perdidas:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_17">
+            <Original>Secondary objectives accomplished:</Original>
+            <French>Objectifs secondaires accomplis :</French>
+            <German>Sekundärziele erreicht:</German>
+            <Spanish>Objetivos secundarios conseguidos:</Spanish>
+            <Russian>Вторичных заданий выполнено:</Russian>
+            <Italian>Obiettivo secondario completato:</Italian>
+            <Chinesesimp>完成的次要目标：</Chinesesimp>
+            <Chinese>完成的次要目標</Chinese>
+            <Turkish>Bitirilen ikinci görevler:</Turkish>
+            <Portuguese>Objetivos secundários alcançados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_18">
+            <Original>Prisonners captured:</Original>
+            <French>Prisonniers capturés :</French>
+            <German>Gefangene gefasst:</German>
+            <Spanish>Prisioneros capturados:</Spanish>
+            <Russian>Пленных захвачено:</Russian>
+            <Italian>Prigionieri catturati:</Italian>
+            <Chinesesimp>俘虏的战俘：</Chinesesimp>
+            <Chinese>俘虜的戰俘：</Chinese>
+            <Turkish>Ele geçirilen esirler:</Turkish>
+            <Portuguese>Prisioneiros capturados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_19">
+            <Original>Hostile battlegroups called:</Original>
+            <French>Battlegroups hostiles appelés :</French>
+            <German>Gegnerische Truppen gerufen:</German>
+            <Spanish>Grupos hostiles de combate llamados:</Spanish>
+            <Russian>Вражеских боевых групп вызвано:</Russian>
+            <Italian>Battaglione ostile contattato:</Italian>
+            <Chinesesimp>敌军战斗组增援次数：</Chinesesimp>
+            <Chinese>敵方戰鬥群增援次數：</Chinese>
+            <Turkish>Düşman savaş grupları:</Turkish>
+            <Portuguese>Grupos de combate hostis chamados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_20">
+            <Original>Hostile reinforcements called:</Original>
+            <French>Renforts hostiles appelés :</French>
+            <German>Gegnerischen Nachschub gerufen:</German>
+            <Spanish>Refuerzos hostiles llamados:</Spanish>
+            <Russian>Враждебных подкреплений вызвано:</Russian>
+            <Italian>Chiamati rinforzi ostili:</Italian>
+            <Chinesesimp>敌军增援次数：</Chinesesimp>
+            <Chinese>敵方增援次數：</Chinese>
+            <Turkish>Düşman takviye kuvvetleri:</Turkish>
+            <Portuguese>Reforços hostis requisitados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_21">
+            <Original>Total combat readiness raised:</Original>
+            <French>Augmentation totale du niveau d'alerte :</French>
+            <German>Gesamte Kampfbereitschaft erhöht:</German>
+            <Spanish>Disposición de combate total recaudada:</Spanish>
+            <Russian>Всего войск поднято по тревоге:</Russian>
+            <Italian>Disposizione al combattimento recuperata:</Italian>
+            <Chinesesimp>总备战比例：</Chinesesimp>
+            <Chinese>威脅度比例：</Chinese>
+            <Turkish>Hazırda olan asker sayısı:</Turkish>
+            <Portuguese>Disposição total de combatentes em alerta:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_22">
+            <Original>IEDs detonated:</Original>
+            <French>Explosions d'IED :</French>
+            <German>IEDs zur Explosion gebracht:</German>
+            <Spanish>IEDs detonados:</Spanish>
+            <Russian>Фугасов взорвано:</Russian>
+            <Italian>IED detonato:</Italian>
+            <Chinesesimp>被引爆的IED：</Chinesesimp>
+            <Chinese>被引爆的IED：</Chinese>
+            <Turkish>Patlatılan mayınlar:</Turkish>
+            <Portuguese>IEDs detonadas:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_23">
+            <Original>Number of Spartan 01 losses:</Original>
+            <French>Pertes de Spartan 01 :</French>
+            <German>Höhe der Spartan-01 Verluste:</German>
+            <Spanish>Número de pérdidas de Spartan 01:</Spanish>
+            <Russian>Количество потерянных Spartan 01:</Russian>
+            <Italian>Numero di Spartan 01 persi :</Italian>
+            <Chinesesimp>损失的斯巴达01号：</Chinesesimp>
+            <Turkish>Spartan 01 kayıpları:</Turkish>
+            <Portuguese>Número de baixas de Spartan 01:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_24">
+            <Original>Player deaths:</Original>
+            <French>Joueurs morts :</French>
+            <German>Spielertode:</German>
+            <Spanish>Muertes del jugador:</Spanish>
+            <Russian>Смертей игрока:</Russian>
+            <Italian>Giocatori Deceduti:</Italian>
+            <Chinesesimp>玩家死亡数：</Chinesesimp>
+            <Chinese>玩家死亡數：</Chinese>
+            <Turkish>Ölen oyuncular:</Turkish>
+            <Portuguese>Morte de jogadores:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_25">
+            <Original>Rabbits killed:</Original>
+            <French>Lapins tués :</French>
+            <German>Hasen getötet:</German>
+            <Spanish>Conejos asesinados:</Spanish>
+            <Russian>Кроликов убито:</Russian>
+            <Italian>Conigli uccisi:</Italian>
+            <Chinesesimp>兔子屠杀数：</Chinesesimp>
+            <Chinese>兔子屠殺數：</Chinese>
+            <Turkish>Öldürülen tavşanlar:</Turkish>
+            <Portuguese>Coelhos mortos:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_26">
+            <Original>Many thanks for playing LIBERATION!</Original>
+            <French>Merci beaucoup d'avoir joué à LIBERATION!</French>
+            <German>Vielen Dank fürs Spielen von LIBERATION!</German>
+            <Spanish>¡Muchas gracias por jugar LIBERATION!</Spanish>
+            <Russian>Большое спасибо за то что играли в LIBERATION!</Russian>
+            <Italian>Mille Grazie per aver giocato LIBERATION!:</Italian>
+            <Chinesesimp>感谢您游玩Liberation！</Chinesesimp>
+            <Chinese>感謝您遊玩 Liberation！</Chinese>
+            <Turkish>LIBERATION oynadığınız için çok teşekkürler!</Turkish>
+            <Portuguese>Muito obrigado por jogar LIBERATION!</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_27">
+            <Original>BLUFOR soldiers recruited:</Original>
+            <French>Soldats BLUFOR recrutés :</French>
+            <German>BLUFOR Soldaten rekrutiert:</German>
+            <Spanish>Soldados BLUFOR reclutados:</Spanish>
+            <Russian>BLUFOR солдат призвано:</Russian>
+            <Italian>Soldato BLUFOR reclutato:</Italian>
+            <Chinesesimp>我军招募的士兵：</Chinesesimp>
+            <Chinese>我軍招募的士兵：</Chinese>
+            <Turkish>Çağrılan BLUFOR askerleri:</Turkish>
+            <Portuguese>Soldados aliados recrutados:</Portuguese>
+        </Key>
+        <Key ID="STR_STATS_28">
+            <Original>We hope you enjoyed playing it, as much as we enjoyed making it.</Original>
+            <French>Nous espérons que vous avez pris autant de plaisir à y jouer, que nous à la créer.</French>
+            <German>Wir hoffen du hattest so viel Spaß am Spielen, wie wir dabei, es zu entwickeln.</German>
+            <Spanish>Esperamos que hayas disfrutado tanto jugándola, como nosotros creándola.</Spanish>
+            <Russian>Мы надеемся, что вы насладились игрой в эту миссию так же, как и мы, когда создавали её.</Russian>
+            <Italian>Speriamo che ti sia divertito giocare, qunato noi a creare questa missione:</Italian>
+            <Chinesesimp>一如我们如此热爱制作这个任务，也希望您能喜欢它。</Chinesesimp>
+            <Chinese>就像我們如此熱愛於製作這個任務，我們也希望你能喜歡它。</Chinese>
+            <Turkish>Umarım oynarken eğlenmişsinizdir, biz yaparken eğlendiğimiz kadar.</Turkish>
+            <Portuguese>Esperamos que tenham gostado de jogar, da mesma forma que gostamos de desenvolver esta missão.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_STATS_29">
+            <Original>(Press ESC to exit)</Original>
+            <French>(Appuyez sur Echap pour quitter)</French>
+            <German>(Drücke ESC zum Abbrechen)</German>
+            <Spanish>(Pulsa ESC para salir)</Spanish>
+            <Russian>(Нажмите клавишу ESC, чтобы выйти)</Russian>
+            <Italian>(Premi ESC per uscire)</Italian>
+            <Chinesesimp>（按ESC退出）</Chinesesimp>
+            <Chinese>（按 ESC 退出）</Chinese>
+            <Turkish>(ESC'ye basıp çıkabilirsiniz.)</Turkish>
+            <Portuguese>(Aperte ESC para sair)</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_MISSIONOPTIONS">
+            <Original>== MISSION OPTIONS ==</Original>
+            <French>== OPTIONS DE MISSION ==</French>
+            <German>== MISSIONSEINSTELLUNGEN ==</German>
+            <Spanish>== OPCIONES DE MISIÓN ==</Spanish>
+            <Russian>== ОПЦИИ МИССИИ ==</Russian>
+            <Italian>== OPZIONI MISSIONE ==</Italian>
+            <Chinesesimp>== 任务选项 ==</Chinesesimp>
+            <Chinese>== 任務選項 ==</Chinese>
+            <Turkish>== BÖLÜM AYARLARI ==</Turkish>
+            <Portuguese>== OPÇÕES DA MISSÃO ==</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_GAMEPLAYOPTIONS">
+            <Original>== GAMEPLAY OPTIONS ==</Original>
+            <German>== SPIELEINSTELLUNGEN ==</German>
+            <Spanish>== OPCIONES DE JUEGO</Spanish>
+            <Italian>==OPZIONI DI GIOCO ==</Italian>
+            <Chinesesimp>== 游戏选项 ==</Chinesesimp>
+            <Chinese>== 遊戲選項 ==</Chinese>
+            <Turkish>== OYUN AYARLARI ==</Turkish>
+            <Portuguese>== OPÇÕES DE JOGO ==</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_TECHNICALOPTIONS">
+            <Original>== TECHNICAL OPTIONS ==</Original>
+            <French>== OPTIONS TECHNIQUES ==</French>
+            <German>== TECHNISCHE EINSTELLUNGEN ==</German>
+            <Spanish>== OPCIONES TÉCNICAS ==</Spanish>
+            <Russian>== ТЕХНИЧЕСКИЕ ОПЦИИ ==</Russian>
+            <Italian>==OPZIONI TECNICHE ==</Italian>
+            <Chinesesimp>== 技术选项 ==</Chinesesimp>
+            <Chinese>== 技術選項 ==</Chinese>
+            <Turkish>== TEKNIK AYARLAR ==</Turkish>
+            <Portuguese>== OPÇÕES TÉCNICAS ==</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DAYDURATION">
+            <Original>Day duration (hours)</Original>
+            <French>Durée du jour (heures)</French>
+            <German>Länge eines Tages (Stunden)</German>
+            <Spanish>Duración del día (horas)</Spanish>
+            <Russian>Продолжительность дня (часов)</Russian>
+            <Italian>Durata del giorno (In ore)</Italian>
+            <Chinesesimp>每日时长（小时）</Chinesesimp>
+            <Chinese>美日時長（單位：小時）</Chinese>
+            <Turkish>Gün uzunluğu (saat)</Turkish>
+            <Portuguese>Duração do dia (horas)</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY">
+            <Original>Difficulty</Original>
+            <French>Difficulté</French>
+            <German>Schwierigkeit</German>
+            <Spanish>Dificultad</Spanish>
+            <Russian>Сложность</Russian>
+            <Italian>Difficoltà:</Italian>
+            <Chinesesimp>难度</Chinesesimp>
+            <Chinese>困難度</Chinese>
+            <Turkish>Zorluk:</Turkish>
+            <Portuguese>Dificuldade:</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY1">
+            <Original>Tourist</Original>
+            <French>Touriste</French>
+            <German>Tourist</German>
+            <Spanish>Turista</Spanish>
+            <Russian>Турист</Russian>
+            <Italian>Turista</Italian>
+            <Chinesesimp>观光</Chinesesimp>
+            <Chinese>觀光客</Chinese>
+            <Turkish>Turist</Turkish>
+            <Portuguese>Turista</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY2">
+            <Original>Easy</Original>
+            <French>Facile</French>
+            <German>Einfach</German>
+            <Spanish>Fácil</Spanish>
+            <Russian>Легко</Russian>
+            <Italian>Facile</Italian>
+            <Chinesesimp>简单</Chinesesimp>
+            <Chinese>簡單</Chinese>
+            <Turkish>Kolay</Turkish>
+            <Portuguese>Fácil</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY3">
+            <Original>Normal</Original>
+            <French>Normal</French>
+            <German>Normal</German>
+            <Spanish>Normal</Spanish>
+            <Russian>Нормально</Russian>
+            <Italian>Normale</Italian>
+            <Chinesesimp>正常</Chinesesimp>
+            <Chinese>正常</Chinese>
+            <Turkish>Normal</Turkish>
+            <Portuguese>Normal</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY4">
+            <Original>Moderate</Original>
+            <French>Modérée</French>
+            <German>Moderat</German>
+            <Spanish>Moderado</Spanish>
+            <Russian>Посложнее</Russian>
+            <Italian>Moderato</Italian>
+            <Chinesesimp>适中</Chinesesimp>
+            <Chinese>適中</Chinese>
+            <Turkish>Orta</Turkish>
+            <Portuguese>Moderada</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY5">
+            <Original>Hard</Original>
+            <French>Difficile</French>
+            <German>Schwer</German>
+            <Spanish>Difícil</Spanish>
+            <Russian>Сложно</Russian>
+            <Italian>Difficile</Italian>
+            <Chinesesimp>困难</Chinesesimp>
+            <Chinese>困難</Chinese>
+            <Turkish>Zor</Turkish>
+            <Portuguese>Difícil</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY6">
+            <Original>Extreme</Original>
+            <French>Extrême</French>
+            <German>Extrem</German>
+            <Spanish>Extremo</Spanish>
+            <Russian>Экстремально</Russian>
+            <Italian>Estremo</Italian>
+            <Chinesesimp>极难</Chinesesimp>
+            <Chinese>極難</Chinese>
+            <Turkish>Extreme</Turkish>
+            <Portuguese>Extrema</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY7">
+            <Original>Ludicrous</Original>
+            <French>Affolante</French>
+            <German>Wahnsinnig</German>
+            <Spanish>Ridículo</Spanish>
+            <Russian>Весело</Russian>
+            <Italian>Ridicolo</Italian>
+            <Chinesesimp>荒谬</Chinesesimp>
+            <Chinese>荒謬</Chinese>
+            <Turkish>Çılgınca</Turkish>
+            <Portuguese>Absurda</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DIFFICULTY8">
+            <Original>Oh god oh god we're all gonna die</Original>
+            <French>Oh mon dieu on va tous mourir</French>
+            <German>Oh mein Gott, wir werden alle sterben!</German>
+            <Spanish>Oh dios mío, vamos a morir!</Spanish>
+            <Russian>Боже мой, мы все умрём!</Russian>
+            <Italian>Oh dio, stiamo per morire!</Italian>
+            <Chinesesimp>天啦噜作死啦</Chinesesimp>
+            <Chinese>菩薩救救我！</Chinese>
+            <Turkish>Aman tanrım yok olacağız!</Turkish>
+            <Portuguese>Ah meu Deus, vamos morrer!</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_AI_SKILL_MANAGEMENT">
+            <Original>Manage AI Skill</Original>
+            <Chinesesimp>管理AI能力</Chinesesimp>
+            <Chinese>管理 AI 能力</Chinese>
+            <Italian>Livello Difficoltà AI</Italian>
+            <Turkish>AI Yeteneklerii düzenle</Turkish>
+            <Portuguese>Gerir nível de habilidade da IA</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_RESOURCESMULTIPLIER">
+            <Original>Resources multiplier</Original>
+            <French>Multiplicateur de resources</French>
+            <German>Ressourcenmultiplikator</German>
+            <Spanish>Multiplicador de recursos</Spanish>
+            <Russian>Множитель ресурсов</Russian>
+            <Italian>Moltiplicatore di risorse</Italian>
+            <Chinesesimp>资源乘数</Chinesesimp>
+            <Chinese>資源乘數</Chinese>
+            <Turkish>Kaynak Geliri Çarpanı</Turkish>
+            <Portuguese>Multiplicador de recursos</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_FATIGUE">
+            <Original>Stamina</Original>
+            <French>Stamina</French>
+            <German>Ausdauer</German>
+            <Spanish>Estamina</Spanish>
+            <Russian>Усталость</Russian>
+            <Italian>Stamina</Italian>
+            <Chinesesimp>体力</Chinesesimp>
+            <Chinese>體力</Chinese>
+            <Turkish>Stamina</Turkish>
+            <Portuguese>Vigor (stamina)</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_INTRO">
+            <Original>Introduction</Original>
+            <French>Introduction</French>
+            <German>Einführung</German>
+            <Spanish>Introducción</Spanish>
+            <Russian>Введение</Russian>
+            <Italian>Introduzione</Italian>
+            <Chinesesimp>开场动画</Chinesesimp>
+            <Chinese>開場動畫</Chinese>
+            <Turkish>Tanıtım</Turkish>
+            <Portuguese>Introdução</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEPLOYMENTCAMERA">
+            <Original>Deployment cinematic</Original>
+            <French>Cinématique de déploiement</French>
+            <German>Zwischensequenz bei Einsatz</German>
+            <Spanish>Cinemática de comienzo</Spanish>
+            <Russian>Кино во время размещения</Russian>
+            <Italian>Filmato di Schieramento</Italian>
+            <Chinesesimp>部署动画</Chinesesimp>
+            <Chinese>佈署動畫</Chinese>
+            <Turkish>Doğma Sinematiği</Turkish>
+            <Portuguese>Introdução cinemática de mobilização</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_ENABLED">
+            <Original>Enabled</Original>
+            <French>Activé</French>
+            <German>Aktiviert</German>
+            <Spanish>Activado</Spanish>
+            <Russian>Вкл</Russian>
+            <Italian>Attivo</Italian>
+            <Chinesesimp>开启</Chinesesimp>
+            <Chinese>開啟</Chinese>
+            <Turkish>Aktif</Turkish>
+            <Portuguese>Ativado</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DISABLED">
+            <Original>Disabled</Original>
+            <French>Désactivé</French>
+            <German>Deaktiviert</German>
+            <Spanish>Desactivado</Spanish>
+            <Russian>Выкл</Russian>
+            <Italian>Disattivato</Italian>
+            <Chinesesimp>关闭</Chinesesimp>
+            <Chinese>關閉</Chinese>
+            <Turkish>Kapalı</Turkish>
+            <Portuguese>Desativado</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_FIRSTFOB">
+            <Original>Start the campaign with the first FOB already built</Original>
+            <French>Commencer la campagne avec une première FOB déjà construite</French>
+            <German>Starte die Kampagne mit einer bereits gebauten FOB</German>
+            <Spanish>Comenzar la campaña con la primera FOB ya construída</Spanish>
+            <Russian>Начать кампанию, когда первая FOB размещена</Russian>
+            <Italian>Comincia la campagna costruendo la prima FOB</Italian>
+            <Chinesesimp>部署起始前哨</Chinesesimp>
+            <Chinese>佈署起始前線基地</Chinese>
+            <Turkish>Oyuna ilk FOB kurulu olarak başla</Turkish>
+            <Portuguese>Iniciar a campanha com a primeira FOB já construída</Portuguese>
+        </Key>
+        <Key ID="STR_YES">
+            <Original>Yes</Original>
+            <French>Oui</French>
+            <German>Ja</German>
+            <Spanish>Si</Spanish>
+            <Russian>Да</Russian>
+            <Italian>Si</Italian>
+            <Chinesesimp>是</Chinesesimp>
+            <Chinese>是</Chinese>
+            <Turkish>Evet</Turkish>
+            <Portuguese>Sim</Portuguese>
+        </Key>
+        <Key ID="STR_NO">
+            <Original>No</Original>
+            <French>Non</French>
+            <German>Nein</German>
+            <Spanish>No</Spanish>
+            <Russian>Нет</Russian>
+            <Italian>NO</Italian>
+            <Chinesesimp>否</Chinesesimp>
+            <Chinese>否</Chinese>
+            <Turkish>Hayır</Turkish>
+            <Portuguese>Não</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP">
+            <Original>Maximum amount of AI units</Original>
+            <French>Quantité maximum d'unités IA</French>
+            <German>Maximale Anzahl KI-Einheiten</German>
+            <Spanish>Cantidad máxima de unidades de IA</Spanish>
+            <Russian>Максимальное количество единиц AI</Russian>
+            <Italian>Numero massimo di unità AI</Italian>
+            <Chinesesimp>AI单位最大数量</Chinesesimp>
+            <Chinese>AI 單位最大數量</Chinese>
+            <Turkish>AI birlik sınırı</Turkish>
+            <Portuguese>Quantidade máxima de unidades IA</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP1">
+            <Original>50% - Recommended for local hosting</Original>
+            <French>50% - Recommandé pour un hébergement local</French>
+            <German>50 % - Empfohlen für lokal gehostete Spiele</German>
+            <Spanish>50% - Recomendado para host local</Spanish>
+            <Russian>50% - Рекомендуется для локального хостинга</Russian>
+            <Italian>50% - Raccomandato per host locali</Italian>
+            <Chinesesimp>50% - 适用于本地主机</Chinesesimp>
+            <Chinese>50% - 適合本地 HOST 遊戲使用</Chinese>
+            <Turkish>50% - Yerel sunucu için uygun</Turkish>
+            <Portuguese>50% - Recomendado para hospedagem local</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP2">
+            <Original>75% - Dedicated server recommended</Original>
+            <French>75% - Serveur dédié recommandé</French>
+            <German>75 % - Dezidierter Server empfohlen</German>
+            <Spanish>75% - Recomendado para servidor dedicado</Spanish>
+            <Russian>75% - Выделенный сервер рекомендуется</Russian>
+            <Italian>75% - Raccomandato per server dedicati</Italian>
+            <Chinesesimp>75% - 适用于服务器</Chinesesimp>
+            <Chinese>75% - 適合伺服器使用</Chinese>
+            <Turkish>75% - Yerel sunucu için uygun</Turkish>
+            <Portuguese>75% - Recomendado para servidor dedicado</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP3">
+            <Original>100% - Dedicated server recommended</Original>
+            <French>100% - Serveur dédié recommandé</French>
+            <German>100 % - Dezidierter Server empfohlen</German>
+            <Spanish>100% - Recomendado para servidor dedicado</Spanish>
+            <Russian>100% - Выделенный сервер рекомендуется</Russian>
+            <Italian>100% - Raccomandato per server dedicati</Italian>
+            <Chinesesimp>100% - 适用于服务器</Chinesesimp>
+            <Chinese>100% - 適合伺服器使用</Chinese>
+            <Turkish>100% - Dedicated server için uygun</Turkish>
+            <Portuguese>100% - Recomendado para servidor dedicado</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP4">
+            <Original>125% - Dedicated server with headless client recommended</Original>
+            <French>125% - Serveur dédié avec headless client recommandé</French>
+            <German>125 % - Dezidierter Server mit Headless Client empfohlen</German>
+            <Spanish>125% - Recomendado para servidor dedicado con cliente descabezado</Spanish>
+            <Russian>125% - Выделенный сервер вместе с headless client рекомендуется</Russian>
+            <Italian>125% - Raccomandato per server dedicati con headless client</Italian>
+            <Chinesesimp>125% - 适用于有Headless Client辅助的服务器</Chinesesimp>
+            <Chinese>125% - 適合有無頭客戶端的伺服器使用</Chinese>
+            <Turkish>125% - Headless client'e sahip dedicated server için uygun</Turkish>
+            <Portuguese>125% - Recomendado para servidor com headless client</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP5">
+            <Original>150% - Dedicated server with multiple headless clients recommended</Original>
+            <French>150% - Serveur dédié avec clients headless multiples recommandé</French>
+            <German>150 % - Dezidierter Server mit mehreren Headless Clients empfohlen</German>
+            <Spanish>150% - Recomendado para servidor dedicado con múltiples clientes descabezados</Spanish>
+            <Russian>150% - Выделенный сервер вместе с несколькими headless client рекомендуется</Russian>
+            <Italian>150% - Raccomandato per server dedicati con molti headless client</Italian>
+            <Chinesesimp>150% - 适用于有多个Headless Client辅助的服务器</Chinesesimp>
+            <Chinese>150% - 適合有多個無頭客戶端的伺服器使用</Chinese>
+            <Turkish>150% - Çoklu headless client'e sahip dedicated server için uygun</Turkish>
+            <Portuguese>150% - Recomendado para servidor com mútiplos headless clients</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_UNITCAP6">
+            <Original>200% - Dedicated server with multiple headless clients recommended</Original>
+            <French>200% - Serveur dédié avec clients headless multiples recommandés</French>
+            <German>200 % - Dezidierter Server mit mehreren Headless Clients empfohlen</German>
+            <Spanish>200% - Recomendado para servidor dedicado con múltiples clientes descabezados</Spanish>
+            <Russian>200% - Выделенный сервер вместе с несколькими headless client рекомендуется</Russian>
+            <Italian>200% - Raccomandato per server dedicati con tanti headless client</Italian>
+            <Chinesesimp>200% - 适用于有多个Headless Client辅助的服务器</Chinesesimp>
+            <Chinese>200% - 適合有多個無頭客戶端的伺服器使用</Chinese>
+            <Turkish>200% - Çoklu headless client'e sahip dedicated server için uygun</Turkish>
+            <Portuguese>150% - Recomendado para servidor com mútiplos headless clients</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_CIVILIANS">
+            <Original>Civilian activity</Original>
+            <French>Activité civile</French>
+            <German>Zivile Aktivität</German>
+            <Spanish>Actividad civil</Spanish>
+            <Russian>Гражданская активность</Russian>
+            <Italian>Attività dei civili</Italian>
+            <Chinesesimp>平民存在感</Chinesesimp>
+            <Chinese>平民活動程度</Chinese>
+            <Turkish>Sivil aktivitesi</Turkish>
+            <Portuguese>Atividade Civil</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_CIVILIANS1">
+            <Original>None</Original>
+            <French>Aucune</French>
+            <German>Keine</German>
+            <Spanish>Ninguna</Spanish>
+            <Russian>Нету</Russian>
+            <Italian>Nessuna</Italian>
+            <Chinesesimp>无</Chinesesimp>
+            <Chinese>無(關閉平民活動)</Chinese>
+            <Turkish>Hiç</Turkish>
+            <Portuguese>Nenhuma</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_CIVILIANS2">
+            <Original>Reduced</Original>
+            <French>Réduite</French>
+            <German>Reduziert</German>
+            <Spanish>Reducida</Spanish>
+            <Russian>Снижена</Russian>
+            <Italian>Ridotta</Italian>
+            <Chinesesimp>较少</Chinesesimp>
+            <Chinese>較少</Chinese>
+            <Turkish>Düşük</Turkish>
+            <Portuguese>Reduzida</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_CIVILIANS3">
+            <Original>Normal</Original>
+            <French>Normale</French>
+            <German>Normal</German>
+            <Spanish>Normal</Spanish>
+            <Russian>Нормальная</Russian>
+            <Italian>Normale</Italian>
+            <Chinesesimp>正常</Chinesesimp>
+            <Chinese>正常</Chinese>
+            <Turkish>Normal</Turkish>
+            <Portuguese>Normal</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_CIVILIANS4">
+            <Original>Increased</Original>
+            <French>Augmentée</French>
+            <German>Erhöht</German>
+            <Spanish>Aumentada</Spanish>
+            <Russian>Увеличенная</Russian>
+            <Italian>Aumentata</Italian>
+            <Chinesesimp>较多</Chinesesimp>
+            <Chinese>較多</Chinese>
+            <Turkish>Arttırılmış</Turkish>
+            <Portuguese>Aumentada</Portuguese>
+        </Key>
+        <Key ID="STR_FRIENDLY_FIRE">
+            <Original>Warning: friendly fire</Original>
+            <French>Attention: tirs alliés</French>
+            <German>Achtung: Eigenbeschuss</German>
+            <Spanish>Atención: fuego amigo</Spanish>
+            <Russian>Предупреждение: дружественный огонь</Russian>
+            <Italian>Attenzione: fuoco amico</Italian>
+            <Chinesesimp>警告：误击友军</Chinesesimp>
+            <Chinese>警告：誤擊友軍</Chinese>
+            <Turkish>Dikkat: dost ateşi</Turkish>
+            <Portuguese>Atenção: Fogo amigo</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_TEAMKILL_PENALTY">
+            <Original>Teamkill penalty</Original>
+            <French>Pénalité pour tirs alliés</French>
+            <German>Strafe für das Töten von Verbündeten</German>
+            <Spanish>Penalización por fuego amigo</Spanish>
+            <Russian>Штраф за убийство своего</Russian>
+            <Italian>Penalità se si uccide un compagno di squadra</Italian>
+            <Chinesesimp>友军击杀惩罚</Chinesesimp>
+            <Chinese>友軍擊殺懲罰</Chinese>
+            <Turkish>Dost ateşi cezası</Turkish>
+            <Portuguese>Penalidade por fogo amigo</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_ADAPT_TO_PLAYERCOUNT">
+            <Original>Hostile presence adapts to player count</Original>
+            <French>La présence hostile s'adapte au nombre de joueurs</French>
+            <German>Feindpräsenz passt sich der Spielerzahl an</German>
+            <Spanish>Adaptar presencia hostil según la cantidad de jugadores</Spanish>
+            <Russian>Вражеские силы адаптируются к количеству игроков</Russian>
+            <Italian>presenza ostile adattata al numero dei giocatori</Italian>
+            <Chinesesimp>随玩家数量调整敌军活动</Chinesesimp>
+            <Chinese>隨玩家數量調整敵人活動程度</Chinese>
+            <Turkish>Düşman birlikleri oyuncu sayısına göre adapte olur</Turkish>
+            <Portuguese>Adaptar presença hostil de acordo com a quantidade de jogadores</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD1">
+            <Original>Infantry units</Original>
+            <French>Unités d'infanterie</French>
+            <German>Infanterie</German>
+            <Spanish>Unidades de infantería</Spanish>
+            <Russian>Пехотинцы</Russian>
+            <Italian>Unità di fanteria</Italian>
+            <Chinesesimp>步兵单位</Chinesesimp>
+            <Chinese>步兵單位</Chinese>
+            <Turkish>Birlik ünitleri</Turkish>
+            <Portuguese>Unidades de infantaria</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD2">
+            <Original>Light vehicles</Original>
+            <French>Véhicules légers</French>
+            <German>Leichte Fahrzeuge</German>
+            <Spanish>Vehículos ligeros</Spanish>
+            <Russian>Легкая техника</Russian>
+            <Italian>Veicoli Leggeri</Italian>
+            <Chinesesimp>轻型载具</Chinesesimp>
+            <Chinese>輕型載具</Chinese>
+            <Turkish>Hafif araçlar</Turkish>
+            <Portuguese>Veículos leves</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD3">
+            <Original>Armored vehicles</Original>
+            <French>Vehicules blindés</French>
+            <German>Gepanzerte Fahrzeuge</German>
+            <Spanish>Vehículos blindados</Spanish>
+            <Russian>Бронетехника</Russian>
+            <Italian>Veicoli Blindati</Italian>
+            <Chinesesimp>装甲载具</Chinesesimp>
+            <Chinese>裝甲載具</Chinese>
+            <Turkish>Zırhlı araçlar</Turkish>
+            <Portuguese>Veículos blindados</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD4">
+            <Original>Air vehicles</Original>
+            <French>Véhicules aériens</French>
+            <German>Luftfahrzeuge</German>
+            <Spanish>Vehículos aéreos</Spanish>
+            <Russian>Авиационная техника</Russian>
+            <Italian>Veicoli Aerei</Italian>
+            <Chinesesimp>空中载具</Chinesesimp>
+            <Chinese>空中載具</Chinese>
+            <Turkish>Uçak ve helikopterler</Turkish>
+            <Portuguese>Veículos aéreos</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD5">
+            <Original>Static defenses</Original>
+            <French>Defenses statiques</French>
+            <German>Statische Verteidigung</German>
+            <Spanish>Defensas estáticas</Spanish>
+            <Russian>Стационары</Russian>
+            <Italian>Difese statiche</Italian>
+            <Chinesesimp>固定防御</Chinesesimp>
+            <Chinese>固定式防禦</Chinese>
+            <Turkish>Statik savunma aletleri</Turkish>
+            <Portuguese>Defesas estáticas</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD6">
+            <Original>Buildings</Original>
+            <French>Batiments</French>
+            <German>Gebäude</German>
+            <Spanish>Edificios</Spanish>
+            <Russian>Постройки</Russian>
+            <Italian>Edifici</Italian>
+            <Chinesesimp>建筑工事</Chinesesimp>
+            <Chinese>建築工事</Chinese>
+            <Turkish>Yapılar</Turkish>
+            <Portuguese>Construções</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD7">
+            <Original>Logistics</Original>
+            <French>Logistique</French>
+            <German>Logistik</German>
+            <Spanish>Logística</Spanish>
+            <Russian>Снабжение</Russian>
+            <Italian>Logistica</Italian>
+            <Chinesesimp>后勤</Chinesesimp>
+            <Chinese>後勤</Chinese>
+            <Turkish>Lojistikler</Turkish>
+            <Portuguese>Logística</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD8">
+            <Original>Infantry squads</Original>
+            <French>Escouades d'infanterie</French>
+            <German>Infanteriegruppen</German>
+            <Spanish>Escuadras de infantería</Spanish>
+            <Russian>Пехотные отделения</Russian>
+            <Italian>Squadra Fanteria</Italian>
+            <Chinesesimp>步兵班</Chinesesimp>
+            <Chinese>步兵班</Chinese>
+            <Turkish>Asker timleri</Turkish>
+            <Portuguese>Grupos de combate de infantaria</Portuguese>
+        </Key>
+        <Key ID="STR_ACTIVE_SECTORS">
+            <Original>Active Sectors:</Original>
+            <French>Secteurs Actifs :</French>
+            <German>Aktive Sektoren:</German>
+            <Spanish>Sectores activos:</Spanish>
+            <Russian>Активные Зоны:</Russian>
+            <Italian>Settori Attivi:</Italian>
+            <Chinesesimp>活动中的战区：</Chinesesimp>
+            <Chinese>觸發中的戰區：</Chinese>
+            <Turkish>Aktif Sektörler:</Turkish>
+            <Portuguese>Setores ativos:</Portuguese>
+        </Key>
+        <Key ID="STR_OVERLOAD_HINT">
+            <Original>The unitcap setting has been exceeded and further sector activation is temporarily halted. You can
+                now see the list of currently active sectors where you shall concentrate your efforts.
+            </Original>
+            <French>La limite d'unités actives a été dépassée et l'activation de nouveaux secteurs est temporairement
+                stoppée. Vous pouvez maintenant voir la liste des sectors déjà actifs sur lesquels vous pouvez
+                concentrer vos efforts.
+            </French>
+            <German>Maximale Anzahl KI-Einheiten erreicht. Es können keine weitere Zonen aktiviert werden. Du kannst nun
+                die Liste der aktiven Gebiete sehen, auf die du deine Kraft fokussieren solltest.
+            </German>
+            <Spanish>El límite de unidades activas se ha excedido, por lo que la activación de sectores queda
+                temporalmente paralizada. Ahora puedes ver la lista de sectores activos donde concentrar tus esfuerzos
+            </Spanish>
+            <Russian>Превышено ограничение по количеству ботов в настройках миссии и активация зон временно
+                приостановлена. Теперь вы можете увидеть список активных в данный момент зон, где вы должны
+                сконцентрировать свои усилия.
+            </Russian>
+            <Italian>L'impostazione unitcap è stata superata e l'attivazione di ulteriori settori è interrotta
+                temporaneamente. Ora è possibile visualizzare l'elenco dei settori attualmente attivi in ​​cui si devono
+                concentrare i vostri sforzi.
+            </Italian>
+            <Chinesesimp>已达到单位上限，暂停其他战区的激活。你可以通过活动中的战区列表查看并确立主攻地区。</Chinesesimp>
+            <Chinese>敵人生成數量已達單位上限，系統將暫時停止其他戰區的敵軍觸發功能；你可以通過觸發中的戰區來查看並確定想主要進攻的戰區。</Chinese>
+            <Turkish>Unit sınırı aşıldır ve sektör aktivasyonu geçici olarak durduruldu. Şuan da ilgilenmeniz gereken
+                aktif sektörler listesi görüntülenmekte.
+            </Turkish>
+            <Portuguese>O limite de unidades foi excedido e a ativação de outros setores foi temporariamente pausada.
+                Você pode ver a lista de setores ativos onde deverá concentrar seus esforços.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_VEHICLE_LOCKED">
+            <Original>LOCKED BY</Original>
+            <French>VEROUILLE PAR</French>
+            <German>VERSCHLOSSEN VON</German>
+            <Spanish>BLOQUEADO POR</Spanish>
+            <Russian>ЗАБЛОКИРОВАНО</Russian>
+            <Italian>BLOCCATO DA</Italian>
+            <Chinesesimp>锁定于</Chinesesimp>
+            <Chinese>鎖定於</Chinese>
+            <Turkish>TARAFINDAN KİLİTLİ</Turkish>
+            <Portuguese>BLOQUEADO POR</Portuguese>
+        </Key>
+        <Key ID="STR_VEHICLE_UNLOCKED">
+            <Original>UNLOCKED BY</Original>
+            <French>DEVEROUILLE PAR</French>
+            <German>GEÖFFNET VON</German>
+            <Spanish>DESBLOQUEADO POR</Spanish>
+            <Russian>РАЗБЛОКИРОВАНО</Russian>
+            <Italian>SBLOCCATO DA</Italian>
+            <Chinesesimp>解锁于</Chinesesimp>
+            <Chinese>解鎖於</Chinese>
+            <Turkish>TARAFINDAN KİLİDİ AÇILDI</Turkish>
+            <Portuguese>DESBLOQUEADO POR</Portuguese>
+        </Key>
+        <Key ID="STR_SQUAD_MANAGEMENT">
+            <Original>SQUAD MANAGEMENT</Original>
+            <French>GESTION D'ESCOUADE</French>
+            <German>GRUPPENVERWALTUNG</German>
+            <Spanish>GESTIÓN DE ESCUADRA</Spanish>
+            <Russian>УПРАВЛЕНИЕ СОСТАВОМ ГРУПП</Russian>
+            <Italian>GESTIONE SQUADRA</Italian>
+            <Chinesesimp>班组管理</Chinesesimp>
+            <Chinese>班級管理</Chinese>
+            <Turkish>TİM YÖNETİMİ</Turkish>
+            <Portuguese>GESTÃO DO GRUPO DE COMBATE</Portuguese>
+        </Key>
+        <Key ID="STR_SQUAD_MANAGEMENT_ACTION">
+            <Original>-- SQUAD MANAGEMENT</Original>
+            <French>-- GESTION D'ESCOUADE</French>
+            <German>-- GRUPPENVERWALTUNG</German>
+            <Spanish>-- GESTIÓN DE ESCUADRA</Spanish>
+            <Russian>-- УПРАВЛЕНИЕ СОСТАВОМ ГРУПП</Russian>
+            <Italian>-- GESTIONE SQUADRA</Italian>
+            <Chinesesimp>-- 班组管理</Chinesesimp>
+            <Chinese>-- 班級管理</Chinese>
+            <Turkish>-- TİM YÖNETİMİ</Turkish>
+            <Portuguese>-- GESTÃO DO GRUPO DE COMBATE</Portuguese>
+        </Key>
+        <Key ID="STR_DEPLOY_ON_MEMBER">
+            <Original>Replace</Original>
+            <French>Remplacer</French>
+            <German>Ersetzen</German>
+            <Spanish>Reemplazar</Spanish>
+            <Russian>Заменить</Russian>
+            <Italian>Sostituisci</Italian>
+            <Chinesesimp>附身</Chinesesimp>
+            <Chinese>取代</Chinese>
+            <Turkish>Değiş</Turkish>
+            <Portuguese>Substituir</Portuguese>
+        </Key>
+        <Key ID="STR_DEPLOY_ON_MEMBER_TOOLTIP">
+            <Original>You will deploy on the selected squad member and replace them while keeping your current
+                loadout.
+            </Original>
+            <French>Vous allez vous déployer à la place du member d'escouade selectionné tout en conservant votre
+                équipement actuel.
+            </French>
+            <German>Du wirst das ausgewählte Gruppenmitglied ersetzen, während du deine Ausrüstung behältst.</German>
+            <Spanish>Reaparecerás en el miembro de la escuadra seleccionado, manteniendo tu equipación actual</Spanish>
+            <Russian>Вы будете развёрнуты на выбранном AI-солдате группы, и замените его, сохранив текущее снаряжение.
+            </Russian>
+            <Italian>Verrai schierato sul membro della squadra selezionata e lo rimpiazzerai mantenendo il loadout
+                corrente.
+            </Italian>
+            <Chinesesimp>你将附身到所选班组成员身上并保留你当前的装备</Chinesesimp>
+            <Chinese>你將使用你目前的身上裝備並取代選定的班級成員。</Chinese>
+            <Turkish>Seçilen şahış ile değişeceksin ve üstündeki herşey ona aktarılacak.</Turkish>
+            <Portuguese>Você irá reaparecer no membro selecionado e o substituir enquanto mantém seu equipamento
+                atual.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_REMOVE_MEMBER">
+            <Original>Remove</Original>
+            <French>Supprimer</French>
+            <German>Entfernen</German>
+            <Spanish>Suprimir</Spanish>
+            <Russian>Удалить</Russian>
+            <Italian>Rimuovi</Italian>
+            <Chinesesimp>移除</Chinesesimp>
+            <Chinese>移除</Chinese>
+            <Turkish>Kaldır</Turkish>
+            <Portuguese>Remover</Portuguese>
+        </Key>
+        <Key ID="STR_REMOVE_MEMBER_TOOLTIP">
+            <Original>The selected squad member will be deleted.</Original>
+            <French>Le membre d'escouade sélectionné sera supprimé.</French>
+            <German>Das ausgewählte Gruppenmitglied löschen.</German>
+            <Spanish>El miembro de la escuadra seleccionado será eliminado</Spanish>
+            <Russian>Выбранный член группы будет удалён.</Russian>
+            <Italian>Il soldato attualmente selezionato è stato rimosso</Italian>
+            <Chinesesimp>所选班组成员将会被移除。</Chinesesimp>
+            <Chinese>所選的班級成員將被移除</Chinese>
+            <Turkish>Bu tim üyesi silinecektir.</Turkish>
+            <Portuguese>O membro selecionado será deletado</Portuguese>
+        </Key>
+        <Key ID="STR_RESUPPLY">
+            <Original>Resupply</Original>
+            <French>Réapprovisionner</French>
+            <German>Versorgen</German>
+            <Spanish>Reabastecer</Spanish>
+            <Russian>Переснарядить</Russian>
+            <Italian>Riapprovvigionamento</Italian>
+            <Chinesesimp>补给</Chinesesimp>
+            <Chinese>補給</Chinese>
+            <Turkish>Tazele</Turkish>
+            <Portuguese>Reabastecer</Portuguese>
+        </Key>
+        <Key ID="STR_RESUPPLY_TOOLTIP">
+            <Original>If the selected squad member is close enough from a resupply point (mobile spawn or FOB) they will
+                get a brand new, full loadout.
+            </Original>
+            <French>Si le membre d'escouade sélectionné est assez près d'un point d'approvisionnement (spawn mobile ou
+                FOB) il recevra un nouvel équipement complet.
+            </French>
+            <German>Wenn das gewählte Gruppenmitglied nahe genug bei einem Versorgungspunkt (mobiler Spawn oder FOB)
+                ist, erhält es eine brandneue, vollständige Ausrüstung
+            </German>
+            <Spanish>Si el miembro de la escuadra se encuentra cerca de un punto de abastecimiento (spawn móvil o FOB)
+                obtendrá el equipamiento completo nuevo
+            </Spanish>
+            <Russian>Если выбранный член группы находится достаточно близко от точки пополнения запасов (мобильный КШМ
+                или FOB), он будет заменён новым, полностью снаряжённым.
+            </Russian>
+            <Italian>Se il membro di una squadra è nei pressi di una FOB o Respwan Mobile potrà ricaricare il suo
+                loadout.
+            </Italian>
+            <Chinesesimp>如果选择的班组成员距离补给点（机动复活点或前哨）够近时，他们将获得一套全新完整的装备。</Chinesesimp>
+            <Chinese>如果選定的班級乘員距離補給點（機動重生點或前線基地）夠近時，他們將獲得一套全新的完整裝備。</Chinese>
+            <Turkish>Seçilen tim üyesi bir mühimmat tazeleme noktasına yakın ise (mobil respawn veya FOB) üstündeki
+                herşey doldurulup, yenilenecektir.
+            </Turkish>
+            <Portuguese>Se o membro selecionado estiver próximo o suficiente de um ponto de reabastecimento (respawn
+                móvel ou FOB), irá adquirir um novo loadout.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_CONFIRM">
+            <Original>Confirm</Original>
+            <French>Confirmer</French>
+            <German>Bestätigen</German>
+            <Spanish>Confirmar</Spanish>
+            <Russian>Подтвердить</Russian>
+            <Italian>Conferma</Italian>
+            <Chinesesimp>确认</Chinesesimp>
+            <Chinese>確認</Chinese>
+            <Turkish>Onayla</Turkish>
+            <Portuguese>Confirmar</Portuguese>
+        </Key>
+        <Key ID="STR_HEALTH">
+            <Original>Health:</Original>
+            <French>Santé :</French>
+            <German>Leben:</German>
+            <Spanish>Salud:</Spanish>
+            <Russian>Здоровье:</Russian>
+            <Italian>Salute:</Italian>
+            <Chinesesimp>血量：</Chinesesimp>
+            <Chinese>血量：</Chinese>
+            <Turkish>Sağlık:</Turkish>
+            <Portuguese>Saúde:</Portuguese>
+        </Key>
+        <Key ID="STR_DISTANCE">
+            <Original>Distance:</Original>
+            <French>Distance :</French>
+            <German>Distanz:</German>
+            <Spanish>Distancia:</Spanish>
+            <Russian>Дистанция:</Russian>
+            <Italian>Distanza:</Italian>
+            <Chinesesimp>距离：</Chinesesimp>
+            <Chinese>距離：</Chinese>
+            <Turkish>Uzaklık:</Turkish>
+            <Portuguese>Distância:</Portuguese>
+        </Key>
+        <Key ID="STR_PRIMARY_WEAPON">
+            <Original>Primary</Original>
+            <French>Principale</French>
+            <German>Primär</German>
+            <Spanish>Principal</Spanish>
+            <Russian>Главный</Russian>
+            <Italian>Primaria</Italian>
+            <Chinesesimp>主要</Chinesesimp>
+            <Chinese>主要</Chinese>
+            <Turkish>Birincil</Turkish>
+            <Portuguese>Primária</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_WEAPON">
+            <Original>Secondary</Original>
+            <French>Secondaire</French>
+            <German>Sekundär</German>
+            <Spanish>Secundaria</Spanish>
+            <Russian>Подчинённый</Russian>
+            <Italian>Secondaria</Italian>
+            <Chinesesimp>次要</Chinesesimp>
+            <Chinese>次要</Chinese>
+            <Turkish>İkincil</Turkish>
+            <Portuguese>Secundária</Portuguese>
+        </Key>
+        <Key ID="STR_NONE">
+            <Original>None</Original>
+            <French>Aucune</French>
+            <German>Keine</German>
+            <Spanish>Ninguno</Spanish>
+            <Russian>Никто</Russian>
+            <Italian>Nessuno</Italian>
+            <Chinesesimp>无</Chinesesimp>
+            <Chinese>無</Chinese>
+            <Turkish>Hiçbiri</Turkish>
+            <Portuguese>Nenhum</Portuguese>
+        </Key>
+        <Key ID="STR_DRIVER">
+            <Original>Driver</Original>
+            <French>Conducteur</French>
+            <German>Fahrer</German>
+            <Spanish>Conductor</Spanish>
+            <Russian>Водитель</Russian>
+            <Italian>Guidatore</Italian>
+            <Chinesesimp>驾驶员</Chinesesimp>
+            <Chinese>駕駛</Chinese>
+            <Turkish>Sürücü</Turkish>
+            <Portuguese>Motorista</Portuguese>
+        </Key>
+        <Key ID="STR_GUNNER">
+            <Original>Gunner</Original>
+            <French>Tireur</French>
+            <German>Schütze</German>
+            <Spanish>Artillero</Spanish>
+            <Russian>Стрелок</Russian>
+            <Italian>Artigliere</Italian>
+            <Chinesesimp>炮手</Chinesesimp>
+            <Chinese>砲手</Chinese>
+            <Turkish>Silahçı</Turkish>
+            <Portuguese>Atirador</Portuguese>
+        </Key>
+        <Key ID="STR_COMMANDER">
+            <Original>Commander</Original>
+            <French>Commandant</French>
+            <German>Kommandant</German>
+            <Spanish>Comandante</Spanish>
+            <Russian>Командир</Russian>
+            <Italian>Comandante</Italian>
+            <Chinesesimp>车长</Chinesesimp>
+            <Chinese>車長</Chinese>
+            <Turkish>Komutan</Turkish>
+            <Portuguese>Comandante</Portuguese>
+        </Key>
+        <Key ID="STR_PASSENGER">
+            <Original>Passenger</Original>
+            <French>Passager</French>
+            <German>Passagier</German>
+            <Spanish>Pasajero</Spanish>
+            <Russian>Пассажир</Russian>
+            <Italian>Passeggero</Italian>
+            <Chinesesimp>乘客</Chinesesimp>
+            <Chinese>乘客</Chinese>
+            <Turkish>Yolcu</Turkish>
+            <Portuguese>Passageiro</Portuguese>
+        </Key>
+        <Key ID="STR_SQUAD_DEPLOY">
+            <Original>Squad deploy</Original>
+            <French>Déploiement d'escouade</French>
+            <German>Gruppeneinsatz</German>
+            <Spanish>Despliegue de escuadra</Spanish>
+            <Russian>Мобилизовать отряд</Russian>
+            <Italian>Schieramento Squadra</Italian>
+            <Chinesesimp>班组部署</Chinesesimp>
+            <Chinese>班級佈署</Chinese>
+            <Turkish>Tim çıkar</Turkish>
+            <Portuguese>Mobilizar Grupo de Combate</Portuguese>
+        </Key>
+        <Key ID="STR_REMOVE_OK">
+            <Original>You have deleted the selected squad member.</Original>
+            <French>Vous avez supprimé le membre de l'escouade sélectionné.</French>
+            <German>Du hast das ausgewählte Gruppenmitglied gelöscht.</German>
+            <Spanish>Has eliminado al miebro de la escuadra.</Spanish>
+            <Russian>Вы демобилизовали выбранного члена группы.</Russian>
+            <Italian>Hai eliminato il membro della squadra selezionato.</Italian>
+            <Chinesesimp>所选班组成员已移除。</Chinesesimp>
+            <Chinese>所選的班級乘員已移除。</Chinese>
+            <Turkish>Seçilen tim üyesini sildiniz.</Turkish>
+            <Portuguese>Você deletou o membro selecionado.</Portuguese>
+        </Key>
+        <Key ID="STR_RESUPPLY_OK">
+            <Original>The selected squad member has been resupplied.</Original>
+            <French>Le membre de l'escouade sélectionné a été réapprovisionné.</French>
+            <German>Das ausgewählte Gruppenmitglied wurde versorgt.</German>
+            <Spanish>El miembro seleccionado de la escuadra ha sido reamunicionado</Spanish>
+            <Russian>Выбранный член группы был переснаряжён</Russian>
+            <Italian>Il membro della squadra selezionato è stato rifornito</Italian>
+            <Chinesesimp>所选班组成员已补给。</Chinesesimp>
+            <Chinese>所選的班級成員以補給。</Chinese>
+            <Turkish>Seçilen tim üyesi mühimmatı tazelendi.</Turkish>
+            <Portuguese>O membro selecionado do grupo se remuniciou.</Portuguese>
+        </Key>
+        <Key ID="STR_RESUPPLY_KO">
+            <Original>The selected squad member isn't close enough from a FOB or mobile spawn.</Original>
+            <French>Le membre de l'escouade sélectionné n'est pas assez proche d'une FOB ou d'un spawn mobile.</French>
+            <German>Das ausgewählte Gruppenmitglied ist nicht nahe genug an einer FOB oder an einem mobilen Spawn.
+            </German>
+            <Spanish>El miembro seleccionado de la escuadra no está suficientemente cerca de una FOB o spawn móvil.
+            </Spanish>
+            <Russian>Выбранный член группы находится далеко от КШМ и FOB</Russian>
+            <Italian>Il membro della squadra non è sufficentemente vicino alla FOB o Respawn Mobile.</Italian>
+            <Chinesesimp>所选班组成员距离前哨或机动复活点太远。</Chinesesimp>
+            <Chinese>所選的班級成員距離前線基地或機動重生點太遠。</Chinese>
+            <Turkish>Seçilen tim üyesi FOB veya mobil spawn noktasına yakın değil.</Turkish>
+            <Portuguese>O membro selecionado do grupo não está próximo o suficiente de uma FOB ou respawn móvel.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TITLE">
+            <Original>PERMISSIONS MANAGEMENT</Original>
+            <French>GESTION DES PERMISSIONS</French>
+            <German>Rechteverwaltung</German>
+            <Spanish>GESTIÓN DE PERMISOS</Spanish>
+            <Russian>УПРАВЛЕНИЕ РАЗРЕШЕНИЯМИ</Russian>
+            <Italian>GESTIONE PERMESSI</Italian>
+            <Chinesesimp>权限管理</Chinesesimp>
+            <Chinese>權限管理</Chinese>
+            <Turkish>YETKİLERİ YÖNET</Turkish>
+            <Portuguese>GESTÃO DE PERMISSÕES</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_LIGHT">
+            <Original>Light vehicles</Original>
+            <French>Véhicules légers</French>
+            <German>Leichte Fahrzeuge</German>
+            <Spanish>Vehículos ligeros</Spanish>
+            <Russian>Лёгкая техника</Russian>
+            <Italian>Veicoli Leggeri</Italian>
+            <Chinesesimp>轻型载具</Chinesesimp>
+            <Chinese>輕型載具</Chinese>
+            <Turkish>Hafif araçlar</Turkish>
+            <Portuguese>Veículos leves</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_ARMORED">
+            <Original>Armored vehicles</Original>
+            <French>Véhicules blindés</French>
+            <German>Gepanzerte Fahrzeuge</German>
+            <Spanish>Vehículos blindados</Spanish>
+            <Russian>Бронированная техника</Russian>
+            <Italian>veicoli Blindati</Italian>
+            <Chinesesimp>装甲载具</Chinesesimp>
+            <Chinese>裝甲載具</Chinese>
+            <Turkish>Zırhlı araçlar</Turkish>
+            <Portuguese>Veículos blindados</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_AIR">
+            <Original>Air vehicles</Original>
+            <French>Véhicules aériens</French>
+            <German>Luftfahrzeuge</German>
+            <Spanish>Vehículos aéreos</Spanish>
+            <Russian>Авиация</Russian>
+            <Italian>Aerei</Italian>
+            <Chinesesimp>空中载具</Chinesesimp>
+            <Chinese>空中載具</Chinese>
+            <Turkish>Hava araçları</Turkish>
+            <Portuguese>Veículos aéreos</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_CONSTRUCTION">
+            <Original>Construction</Original>
+            <French>Construction</French>
+            <German>Konstruktionen</German>
+            <Spanish>Construcción</Spanish>
+            <Russian>Постройка</Russian>
+            <Italian>Costruzione</Italian>
+            <Chinesesimp>建造</Chinesesimp>
+            <Chinese>建造</Chinese>
+            <Turkish>İnşaat</Turkish>
+            <Portuguese>Construção</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_RECYCLING">
+            <Original>Recycling</Original>
+            <French>Recyclage</French>
+            <German>Wiederverwerten</German>
+            <Spanish>Reciclar</Spanish>
+            <Russian>Утилизация</Russian>
+            <Italian>Riciclaggio</Italian>
+            <Chinesesimp>回收</Chinesesimp>
+            <Chinese>回收</Chinese>
+            <Turkish>Geri dönüşüm</Turkish>
+            <Portuguese>Reciclando</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_MISC">
+            <Original>Others</Original>
+            <French>Autres</French>
+            <German>Andere</German>
+            <Spanish>Otros</Spanish>
+            <Russian>Остальное</Russian>
+            <Italian>Altro</Italian>
+            <Chinesesimp>其它</Chinesesimp>
+            <Chinese>其他</Chinese>
+            <Turkish>Diğerleri</Turkish>
+            <Portuguese>Outros</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_ALL">
+            <Original>All</Original>
+            <French>Toutes</French>
+            <German>Alle</German>
+            <Spanish>Todos</Spanish>
+            <Russian>Всё</Russian>
+            <Italian>Tutto</Italian>
+            <Chinesesimp>全部</Chinesesimp>
+            <Chinese>全部</Chinese>
+            <Turkish>Hepsi</Turkish>
+            <Portuguese>Todos</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_NONE">
+            <Original>None</Original>
+            <French>Aucune</French>
+            <German>Keine</German>
+            <Spanish>Ninguno</Spanish>
+            <Russian>Ничего</Russian>
+            <Italian>Nessuno</Italian>
+            <Chinesesimp>无</Chinesesimp>
+            <Chinese>無</Chinese>
+            <Turkish>Hiçbiri</Turkish>
+            <Portuguese>Nenhum</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_LIGHT">
+            <Original>Allows the player to operate light vehicles as driver and gunner.</Original>
+            <French>Autorise le joueur à utiliser les véhicules légers en tant que conducteur ou tireur.</French>
+            <German>Erlaubt es dem Spieler, leichte Fahrzeuge als Fahrer und Schütze zu bedienen.</German>
+            <Spanish>Permite al jugador utilizar vehículos ligeros como conductor y artillero</Spanish>
+            <Russian>Позволить игроку быть водителем и стрелком лёгкой техники.</Russian>
+            <Italian>Permetti al giocatore di entrare nei veicoli leggeri come guidatore e artigliere</Italian>
+            <Chinesesimp>允许玩家进入轻型载具的驾驶和炮手位。</Chinesesimp>
+            <Chinese>允許玩家進入輕型載具的駕駛與砲手位置。</Chinese>
+            <Turkish>Oyuncunun hafif araçları sürücü veya silahçı olarak kullanmasını sağlar</Turkish>
+            <Portuguese>Permite ao jogador operar veículos leves como condutor e atirador.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_ARMORED">
+            <Original>Allows the player to operate armored vehicles as driver, gunner and commander.</Original>
+            <French>Autorise le joueur à utiliser les véhicules blindés en tant que conducteur, tireur ou commandant.
+            </French>
+            <German>Erlaubt es dem Spieler, gepanzerte Fahrzeuge als Fahrer, Schütze und Kommandant zu bedienen.
+            </German>
+            <Spanish>Permite al jugador utilizar vehículos blindados como conductor, artillero y comandante</Spanish>
+            <Russian>Позволить игроку быть командиром, водителем и стрелком бронированной техники.</Russian>
+            <Italian>Permetti al giocatore di entrare nei veicoli blindati come guidatore e artigliere e comandante
+            </Italian>
+            <Chinesesimp>允许玩家进入装甲载具的驾驶、炮手和车长位。</Chinesesimp>
+            <Chinese>允許玩家進入裝甲載具的駕駛、砲手、車長位置。</Chinese>
+            <Turkish>Oyuncunun zırhlı araçları sürücü, komutan veya silahçı olarak kullanmasını sağlar</Turkish>
+            <Portuguese>Permite ao jogador operar veículos blindados como condutor, atirador e comandante.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_AIR">
+            <Original>Allows the player to operate air vehicles as driver and gunner.</Original>
+            <French>Autorise le joueur à utiliser les véhicules aériens en tant que conducteur ou tireur.</French>
+            <German>Erlaubt es dem Spieler, Luftfahrzeuge als Pilot und Schütze zu bedienen.</German>
+            <Spanish>Permite al jugador utilizar vehículos aéreos como conductor y artillero</Spanish>
+            <Russian>Позволить игроку быть пилотом и стрелком авиации.</Russian>
+            <Italian>Permetti al giocatore di entrare negli aerei come guidatore e artigliere</Italian>
+            <Chinesesimp>允许玩家进入空中载具的驾驶和炮手位。</Chinesesimp>
+            <Chinese>允許玩家進入空中載具的駕駛和砲手位置。</Chinese>
+            <Turkish>Oyuncunun bütün hava araçlarını sürücü veya silahçı olarak kullanmasını sağlar</Turkish>
+            <Portuguese>Permite ao jogador operar veículos aéreos como piloto e atirador.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_CONSTRUCTION">
+            <Original>Allows the player to use the BUILD menu.</Original>
+            <French>Autorise le joueur à utiliser le menu CONSTRUCTION.</French>
+            <German>Erlaubt es dem Spieler, das Baumenü zu benutzen.</German>
+            <Spanish>Permite al jugador utilizar el menú de CONSTRUCCIÓN</Spanish>
+            <Russian>Позволить игроку использовать меню постройки.</Russian>
+            <Italian>Permetti al giocatore di Costruire</Italian>
+            <Chinesesimp>允许玩家使用建造菜单</Chinesesimp>
+            <Chinese>允許玩家使用建造選單。</Chinese>
+            <Turkish>Oyuncunun İNŞA menüsünü kullanmasını sağlar</Turkish>
+            <Portuguese>Permite ao jogador utilizar o menu de CONTRUÇÃO.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_RECYCLING">
+            <Original>Allows the player to use the RECYCLE action.</Original>
+            <French>Autorise le joueur à utiliser l'action RECYCLER.</French>
+            <German>Erlaubt es dem Spieler, die "WIEDERVERWERTEN"-Aktion zu benutzen.</German>
+            <Spanish>Permite al jugador utilizar la acción de RECICLAR</Spanish>
+            <Russian>Позволить игроку утилизировать постройки и технику.</Russian>
+            <Italian>Permetti al giocatore di Riciclare</Italian>
+            <Chinesesimp>允许玩家使用回收功能。</Chinesesimp>
+            <Chinese>允許玩家使用回收功能。</Chinese>
+            <Turkish>Oyuncunun GERİ DÖNÜŞTÜR butonunu kullanmasını sağlar</Turkish>
+            <Portuguese>Permite ao jogador utilizar a ação "RECICLAR".</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_MISC">
+            <Original>Allows the player to use other actions: unflip, resource box manipulation, prisoner capture,
+                etc.
+            </Original>
+            <French>Autorise le joueur à utiliser les autres actions : retournement de véhicule, manipulation des boites
+                de munition, capture de prisoniers, etc.
+            </French>
+            <German>Erlaubt es dem Spieler, andere Aktionen durchzuführen: Umdrehen, Interaktion mit Munitionskisten,
+                Gefangennahme, usw.
+            </German>
+            <Spanish>Permite al jugador usar otras acciones: Recolocar vehículo, manipulación de cajas de munición,
+                captura de prisioneros, etc.
+            </Spanish>
+            <Russian>Позволить игроку остальные действия: перевернуть, манипуляции с ящиками боеприпасов, захват
+                пленных, итп.
+            </Russian>
+            <Italian>Permetti al giocatore di usare le altre funzioni come , catturare prigionieri,raddrizzare veicoli
+                ecc.
+            </Italian>
+            <Chinesesimp>允许玩家使用其他功能：翻正、货箱控制、俘虏战俘，等等。</Chinesesimp>
+            <Chinese>允許玩家使用其他功能，如：翻正、貨物控制（裝載、卸載、倉儲等）、俘虜戰俘，等等。</Chinese>
+            <Turkish>Oyuncunun şunları yapmasını sağlar: ters döndürme, kutuların yönetimi, esir yakalama, vb.</Turkish>
+            <Portuguese>Permite ao jogador executar outras ações: Desvirar veículo, manipular caixas de recursos,
+                captura de prisioneiros, etc.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_ALL">
+            <Original>Gives all permissions to the player.</Original>
+            <French>Donne toutes les permissions au joueur.</French>
+            <German>Gibt dem Spieler alle Rechte</German>
+            <Spanish>Darle todos los permisos al jugador</Spanish>
+            <Russian>Разрешить всё игроку.</Russian>
+            <Italian>Permetti tutto al giocatore.</Italian>
+            <Chinesesimp>给予玩家所有权限。</Chinesesimp>
+            <Chinese>給予玩家所有權限。</Chinese>
+            <Turkish>Bütün yetkileri verir.</Turkish>
+            <Portuguese>Libera todas as permissões para o jogador.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_TOOLTIP_NONE">
+            <Original>Removes all permissions from the player.</Original>
+            <French>Supprime toutes les permissions du joueur.</French>
+            <German>Nimmt dem Spieler alle Rechte weg.</German>
+            <Spanish>Quitar todos los permisos al jugador</Spanish>
+            <Russian>Запретить всё игроку.</Russian>
+            <Italian>Rimuovi tutti i permessi al giocatore.</Italian>
+            <Chinesesimp>移除玩家所有权限。</Chinesesimp>
+            <Chinese>移除玩家所有權限。</Chinese>
+            <Turkish>Hiçbir yetkisi olmaz.</Turkish>
+            <Portuguese>Remove todas as permissões do jogador.</Portuguese>
+        </Key>
+        <Key ID="STR_COMMANDER_ACTION">
+            <Original>-- PERMISSIONS</Original>
+            <French>-- PERMISSIONS</French>
+            <German>-- RECHTE</German>
+            <Spanish>-- PERMISOS</Spanish>
+            <Russian>-- РАЗРЕШЕНИЯ</Russian>
+            <Italian>-- PERMESSI</Italian>
+            <Chinesesimp>-- 权限</Chinesesimp>
+            <Chinese>-- 權限</Chinese>
+            <Turkish>-- YETKİLER</Turkish>
+            <Portuguese>-- PERMISSÕES</Portuguese>
+        </Key>
+        <Key ID="STR_SAVE_CHANGES">
+            <Original>Save Changes</Original>
+            <French>Sauvegarder</French>
+            <German>Änderungen speichern</German>
+            <Spanish>Guardar cambios</Spanish>
+            <Russian>Сохранить Изменения</Russian>
+            <Italian>Salva Modifiche</Italian>
+            <Chinesesimp>保存更改</Chinesesimp>
+            <Chinese>儲存變更</Chinese>
+            <Turkish>Değişiklikleri kaydet</Turkish>
+            <Portuguese>Salvar alterações</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSIONS_PARAM">
+            <Original>Permissions Management</Original>
+            <French>Gestion des Permissions</French>
+            <German>Rechteverwaltung</German>
+            <Spanish>Gestión de permisos</Spanish>
+            <Russian>Управление Разрешениями</Russian>
+            <Italian>Permessi Gestione</Italian>
+            <Chinesesimp>权限管理</Chinesesimp>
+            <Chinese>權限管理</Chinese>
+            <Turkish>Yetkileri Yönet</Turkish>
+            <Portuguese>Gestão de Permissões</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSION_NO_LIGHT">
+            <Original>You don't have permission from the commander to use light vehicles.</Original>
+            <French>Vous n'avez pas la permission du commandant pour utiliser les véhicules légers.</French>
+            <German>Du hast keine Rechte zur Nutzung leichter Fahrzeuge.</German>
+            <Spanish>No tienes permiso del comandante para usar vehículos ligeros</Spanish>
+            <Russian>У тебя нет разрешения от командира использовать легкую технику.</Russian>
+            <Italian>Non hai il permesso di usare veicoli leggeri</Italian>
+            <Chinesesimp>指挥官没有给你使用轻型载具的权限。</Chinesesimp>
+            <Chinese>指揮官並沒有提供你輕型載具機組員權限。</Chinese>
+            <Turkish>Hafif araçları kullanmak için yetkiniz yok.</Turkish>
+            <Portuguese>Você não tem permissão do comandante para utilizar veículos leves.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSION_NO_ARMOR">
+            <Original>You don't have permission from the commander to use armored vehicles.</Original>
+            <French>Vous n'avez pas la permission du commandant pour utiliser les véhicules blindés.</French>
+            <German>Du hast keine Rechte zur Nutzung gepanzerter Fahrzeuge</German>
+            <Spanish>No tienes permiso del comandante para usar vehículos blindados</Spanish>
+            <Russian>У тебя нет разрешения от командира использовать бронированную технику.</Russian>
+            <Italian>Non hai il permesso di usare veicoli pesanti</Italian>
+            <Chinesesimp>指挥官没有给你使用装甲载具的权限。</Chinesesimp>
+            <Chinese>指揮官並沒有提供你裝甲載具機組員權限。</Chinese>
+            <Turkish>Zırhlı araçları kullanmanız için yetkiniz yok.</Turkish>
+            <Portuguese>Você não tem permissão do comandante para utilizar veículos blindados.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSION_NO_AIR">
+            <Original>You don't have permission from the commander to use air vehicles.</Original>
+            <French>Vous n'avez pas la permission du commandant pour utiliser les véhicules aériens.</French>
+            <German>Du hast keine Rechte zur Nutzung von Luftfahrzeugen</German>
+            <Spanish>No tienes permiso del comandante para usar vehículos aéreos</Spanish>
+            <Russian>У тебя нет разрешения от командира использовать авиацию.</Russian>
+            <Italian>Non hai il permesso di usare veivoli</Italian>
+            <Chinesesimp>指挥官没有给你使用空中载具的权限。</Chinesesimp>
+            <Chinese>指揮官並沒有提供你空中載具機組員權限。</Chinese>
+            <Turkish>Hava araçlarını kullanmanız için yetkiniz yok.</Turkish>
+            <Portuguese>Você não tem permissão do comandante para utilizar veículos aéreos.</Portuguese>
+        </Key>
+        <Key ID="STR_PERMISSION_WARNING">
+            <Original>No permissions have been set. The commander must setup the permissions to allow player actions and
+                vehicle usage. Alternatively, the permission system can be disabled from the mission options.
+            </Original>
+            <French>Aucune permission n'a été définie. Le commandant doit configurer les permissions pour permettre aux
+                joueurs d'effectuer des actions et d'utiliser les véhicules. Sinon, le système de permissions peut être
+                désactivé dans les options de mission.
+            </French>
+            <German>Keine Rechte wurden vergeben. Der Kommandant muss die Rechte verwalten, um Spielern Aktionen und die
+                Nutzung von Fahrzeugen zu erlaubne. Alternativ kann das Rechtesystem in den Missionsoptionen deaktiviert
+                werden.
+            </German>
+            <Spanish>No hay permisos definidos. El comandante debe asignar los permisos para permitir a los jugadores el
+                uso de los vehículos y acciones. Alternativamente, puede desactivarse el sistema de permisos desde las
+                opciones de misión
+            </Spanish>
+            <Russian>Разрешения не были даны. Командир должен настроить разрешения, чтобы позволить игроку действия и
+                использование техники. Кроме того, система разрешений может быть отключена в настройках миссии.
+            </Russian>
+            <Italian>I permessi non sono settati.Il comandante deve entrare nel menu e attribuire i permessi ai
+                giocatori.
+            </Italian>
+            <Chinesesimp>没有设定任何权限。指挥官必须为玩家设定可用功能和载具。另外，权限系统可以在任务选项中关闭。</Chinesesimp>
+            <Chinese>沒有設定任何權限。指揮官必須為玩家指定可使用的功能與載具類型。另外，權限系統可以在任務選項中關閉。</Chinese>
+            <Turkish>Yetkiler ayarlanmadı. Komutan oyuncuların yapabilecekleri yetkileri ayarlamalı. Alternatif olarak,
+                yetki sistemi görev ayarlarından kapatılabilir.
+            </Turkish>
+            <Portuguese>Nenhuma permissão foi liberada. O comandante precisa alterar as permissões para permitir que o
+                jogador execute ações e utiliza veículos. Alternativamente, o sistema de permissão pode ser desabilitado
+                no menu de opções da missão.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_ARSENAL_TITLE">
+            <Original>ARSENAL</Original>
+            <French>ARSENAL</French>
+            <German>ARSENAL</German>
+            <Spanish>ARSENAL</Spanish>
+            <Russian>АРСЕНАЛ</Russian>
+            <Italian>ARSENALE</Italian>
+            <Chinesesimp>军火库</Chinesesimp>
+            <Chinese>軍火庫</Chinese>
+            <Turkish>ARSENAL</Turkish>
+            <Portuguese>ARSENAL</Portuguese>
+        </Key>
+        <Key ID="STR_EDIT_LOADOUT">
+            <Original>Edit loadout</Original>
+            <French>Modifier équipement</French>
+            <German>Ausrüstung bearbeiten</German>
+            <Spanish>Modificar equipamiento</Spanish>
+            <Russian>Редактировать</Russian>
+            <Italian>Modifica Equipaggiamneto</Italian>
+            <Chinesesimp>编辑装备</Chinesesimp>
+            <Chinese>編輯裝備</Chinese>
+            <Turkish>Ekipmanı düzenle</Turkish>
+            <Portuguese>Modificar equipamento</Portuguese>
+        </Key>
+        <Key ID="STR_LOAD_LOADOUT">
+            <Original>Take loadout</Original>
+            <French>Charger l'équipement</French>
+            <German>Ausrüstung laden</German>
+            <Spanish>Coger equipamiento</Spanish>
+            <Russian>Загрузить</Russian>
+            <Italian>Prendi Equipaggiamento</Italian>
+            <Chinesesimp>拿取装备</Chinesesimp>
+            <Chinese>領取裝備</Chinese>
+            <Turkish>Ekipman al</Turkish>
+            <Portuguese>Aceitar equipamento</Portuguese>
+        </Key>
+        <Key ID="STR_DEFAULT">
+            <Original>Default</Original>
+            <French>Par défaut</French>
+            <German>Standard</German>
+            <Spanish>Por defecto</Spanish>
+            <Russian>Стандартно</Russian>
+            <Italian>Default</Italian>
+            <Chinesesimp>默认</Chinesesimp>
+            <Chinese>預設</Chinese>
+            <Turkish>Varsayılan</Turkish>
+            <Portuguese>Padrão</Portuguese>
+        </Key>
+        <Key ID="STR_FOB_REPACKAGE">
+            <Original>-- REPACKAGE FOB --</Original>
+            <French>-- REPLIER FOB --</French>
+            <German>-- FOB EINPACKEN --</German>
+            <Spanish>-- EMPAQUETAR FOB --</Spanish>
+            <Russian>-- СВЕРНУТЬ FOB --</Russian>
+            <Italian>-- SMONTA FOB --</Italian>
+            <Chinesesimp>-- 收起前哨 --</Chinesesimp>
+            <Chinese>-- 收起前線基地 --</Chinese>
+            <Turkish>-- FOB YENIDEN PAKETLE --</Turkish>
+            <Portuguese>-- MOBILIZAR FOB --</Portuguese>
+        </Key>
+        <Key ID="STR_FOB_REPACKAGE_TITLE">
+            <Original>REPACKAGE FOB</Original>
+            <French>REPLIER FOB</French>
+            <German>FOB EINPACKEN</German>
+            <Spanish>EMPAQUETAR FOB</Spanish>
+            <Russian>СВЕРНУТЬ FOB</Russian>
+            <Italian>SMONTA FOB</Italian>
+            <Chinesesimp>收起前哨</Chinesesimp>
+            <Chinese>收起前線基地</Chinese>
+            <Turkish>FOB YENIDEN PAKETLE</Turkish>
+            <Portuguese>MOBILIZAR FOB</Portuguese>
+        </Key>
+        <Key ID="STR_FOB_REPACKAGE_CONFIRM">
+            <Original>Are you sure you want to repackage this FOB?</Original>
+            <French>Etes-vous sur de vouloir replier cette fob?</French>
+            <German>Bist du dir sicher, dass du deine FOB einpacken willst?</German>
+            <Spanish>¿Estas seguro de querer reempaquetar esta FOB?</Spanish>
+            <Russian>Ты уверен что хочешь свернуть эту FOB?</Russian>
+            <Italian>Sei sicuro di voler smontare la FOB?</Italian>
+            <Chinesesimp>你确定要收起这个前哨？</Chinesesimp>
+            <Chinese>你確定要收起這個前線基地？</Chinese>
+            <Turkish>Bu FOB'yi yeniden paketlemek istediğinize emin misiniz?</Turkish>
+            <Portuguese>Você tem certeza que quer mobilizar esta FOB?</Portuguese>
+        </Key>
+        <Key ID="STR_FOB_REPACKAGE_HINT">
+            <Original>FOB repackaged.</Original>
+            <French>FOB repliée.</French>
+            <German>FOB eingepackt.</German>
+            <Spanish>FOB reempaquetada</Spanish>
+            <Russian>FOB свёрнута</Russian>
+            <Italian>FOB smontata.</Italian>
+            <Chinesesimp>前哨已收起。</Chinesesimp>
+            <Chinese>前線基地已收起。</Chinese>
+            <Turkish>FOB yeniden paketlendi.</Turkish>
+            <Portuguese>FOB mobilizada.</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM">
+            <Original>HALO jump</Original>
+            <French>Saut HALO</French>
+            <German>HALO-Sprung</German>
+            <Spanish>Salto HALO</Spanish>
+            <Russian>HALO прыжок</Russian>
+            <Italian>PARACADUTARSI</Italian>
+            <Chinesesimp>伞降</Chinesesimp>
+            <Chinese>跳傘</Chinese>
+            <Turkish>HALO atlayışı</Turkish>
+            <Portuguese>Salto em queda livre</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM1">
+            <Original>Enabled - No cooldown</Original>
+            <French>Activé - Pas de cooldown</French>
+            <German>Aktiviert - Keine Abklingzeit</German>
+            <Spanish>Activado - Sin tiempo de espera</Spanish>
+            <Russian>Вкл - без перерыва</Russian>
+            <Italian>Attivato - Senza attesa</Italian>
+            <Chinesesimp>开启 - 无冷却</Chinesesimp>
+            <Chinese>開啟 - 無冷卻</Chinese>
+            <Turkish>Açık - Süre yok</Turkish>
+            <Portuguese>Ativado - Sem tempo de espera</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM2">
+            <Original>Enabled - 5 minutes cooldown</Original>
+            <French>Activé - Cooldown de 5 minutes</French>
+            <German>Aktiviert - 5 Minuten Abklingzeit</German>
+            <Spanish>Activado - 5 minutos de espera</Spanish>
+            <Russian>Вкл - 5 минут перерыв</Russian>
+            <Italian>Attivato - 5 minuti di attesa</Italian>
+            <Chinesesimp>开启 - 5分钟冷却</Chinesesimp>
+            <Chinese>開啟 - 5 分鐘冷卻</Chinese>
+            <Turkish>Açık - 5 dakika bekleme süresi</Turkish>
+            <Portuguese>Ativado - Espera de 5 minutos</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM3">
+            <Original>Enabled - 10 minutes cooldown</Original>
+            <French>Activé - Cooldown de 10 minutes</French>
+            <German>Aktiviert - 10 Minuten Abklingzeit</German>
+            <Spanish>Activado - 10 minutos de espera</Spanish>
+            <Russian>Вкл - 10 минут перерыв</Russian>
+            <Italian>Attivato - 10 minuti di attesa</Italian>
+            <Chinesesimp>开启 - 10分钟冷却</Chinesesimp>
+            <Chinese>開啟 - 10 分鐘冷卻</Chinese>
+            <Turkish>Açık - 10 dakika bekleme süresi</Turkish>
+            <Portuguese>Ativado - Espera de 10 minutos</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM4">
+            <Original>Enabled - 15 minutes cooldown</Original>
+            <French>Activé - Cooldown de 15 minutes</French>
+            <German>Aktiviert - 15 Minuten Abklingzeit</German>
+            <Spanish>Activado - 15 minutos de espera</Spanish>
+            <Russian>Вкл - 15 минут перерыв</Russian>
+            <Italian>Attivato - 15 minuti di attesa</Italian>
+            <Chinesesimp>开启 - 15分钟冷却</Chinesesimp>
+            <Chinese>開啟 - 15 分鐘冷卻</Chinese>
+            <Turkish>Açık - 15 dakika bekleme süresi</Turkish>
+            <Portuguese>Ativado - Espera de 15 minutos</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM5">
+            <Original>Enabled - 20 minutes cooldown</Original>
+            <French>Activé - Cooldown de 20 minutes</French>
+            <German>Aktiviert - 20 Minuten Abklingzeit</German>
+            <Spanish>Activado - 20 minutos de espera</Spanish>
+            <Russian>Вкл - 20 минут перерыв</Russian>
+            <Italian>Attivato - 20 minuti di attesa</Italian>
+            <Chinesesimp>开启 - 20分钟冷却</Chinesesimp>
+            <Chinese>開啟 - 20 分鐘冷卻</Chinese>
+            <Turkish>Açık - 20 dakika bekleme süresi</Turkish>
+            <Portuguese>Ativado - Espera de 20 minutos</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_PARAM6">
+            <Original>Enabled - 30 minutes cooldown</Original>
+            <French>Activé - Cooldown de 30 minutes</French>
+            <German>Aktiviert - 30 Minuten Abklingzeut</German>
+            <Spanish>Activado - 30 minutos de espera</Spanish>
+            <Russian>Вкл - 30 минут перерыв</Russian>
+            <Italian>Attivato - 30 minuti di attesa</Italian>
+            <Chinesesimp>开启 - 30分钟冷却</Chinesesimp>
+            <Chinese>開啟 - 30 分鐘冷卻</Chinese>
+            <Turkish>Açık - 30 dakika bekleme süresi</Turkish>
+            <Portuguese>Ativado - Espera de 30 minutos</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_DENIED_COOLDOWN">
+            <Original>Can't perform HALO jump, you are on cooldown for %1 more minute(s).</Original>
+            <French>Impossible d'effectuer un suat HALO, vous êtes en cooldown pour encore %1 minute(s).</French>
+            <German>HALO Sprung noch nicht möglich. Verbleibende Abklingzeit von %1 Minuten.</German>
+            <Spanish>No puedes saltar en HALO, te quedan %1 minuto(s) de espera.</Spanish>
+            <Russian>HALO прыжок недоступен, подождите %1 минут</Russian>
+            <Italian>Non puoi paracadutarti, hai un attesa di %1 minuti.</Italian>
+            <Chinesesimp>无法进行伞降，剩余冷却时间为%1分钟。</Chinesesimp>
+            <Chinese>無法進行跳傘，還需要 %1 分鐘的冷卻時間。</Chinese>
+            <Turkish>HALO jump yapılamıyor, %1 dakika beklemelisiniz.</Turkish>
+            <Portuguese>Não é possível executar o salto em queda livre, o tempo de espera é de %1 minuto(s).
+            </Portuguese>
+        </Key>
+        <Key ID="STR_HALO_ACTION">
+            <Original>-- HALO JUMP</Original>
+            <French>-- SAUT HALO</French>
+            <German>-- HALO-SPRUNG</German>
+            <Spanish>-- SALTO HALO</Spanish>
+            <Russian>-- HALO прыжок</Russian>
+            <Italian>-- PARACADUTARSI</Italian>
+            <Chinesesimp>-- 伞降</Chinesesimp>
+            <Chinese>-- 跳傘</Chinese>
+            <Turkish>-- HALO Atla</Turkish>
+            <Portuguese>-- Salto em queda livre</Portuguese>
+        </Key>
+        <Key ID="STR_HALO_TITLE">
+            <Original>HALO JUMP</Original>
+            <French>SAUT HALO</French>
+            <German>HALO-SPRUNG</German>
+            <Spanish>SALTO HALO</Spanish>
+            <Russian>HALO ПРЫЖОК</Russian>
+            <Italian>PARACADUTARSI</Italian>
+            <Chinesesimp>伞降</Chinesesimp>
+            <Chinese>跳傘</Chinese>
+            <Turkish>HALO ATLAYIŞI</Turkish>
+            <Portuguese>Salto em queda livre</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_CLEAR_CARGO">
+            <Original>Clear spawned vehicle cargo</Original>
+            <German>Inventar gespawnter Fahrzeuge leeren</German>
+            <Italian>Cancella il carico del veicolo creato</Italian>
+            <Portuguese>Remover carga do veículo requisitado</Portuguese>
+            <Chinese>移除載具上的物品</Chinese>
+        </Key>
+        <Key ID="STR_DEPLOY_IN_PROGRESS">
+            <Original>Deployment in progress...</Original>
+            <French>Déploiement en cours...</French>
+            <German>Verlegung im Gange</German>
+            <Spanish>Despliegue en curso...</Spanish>
+            <Russian>В процессе выполнения ...</Russian>
+            <Italian>In attesa del lancio ...</Italian>
+            <Chinesesimp>正在部署中...</Chinesesimp>
+            <Chinese>正在佈署中...</Chinese>
+            <Turkish>Atlanılıyor...</Turkish>
+            <Portuguese>Mobilização em andamento...</Portuguese>
+        </Key>
+        <Key ID="STR_WHITELIST_PARAM">
+            <Original>Use the commander whitelist</Original>
+            <French>Utiliser la whitelist pour le commandant</French>
+            <German>Nutze die Whitelist für den Kommandanten</German>
+            <Spanish>Utilizar la lista blanca para Comandantes</Spanish>
+            <Russian>Использование "белого" списка командиров</Russian>
+            <Italian>Usa la whitelist del comandante</Italian>
+            <Chinesesimp>使用指挥官白名单</Chinesesimp>
+            <Chinese>使用指揮官白名單</Chinese>
+            <Turkish>Komutanlar için beyaz liste kullan</Turkish>
+            <Portuguese>Use a lista de permissões de comandantes</Portuguese>
+        </Key>
+        <Key ID="STR_WHITELIST_ENABLED">
+            <Original>Enabled - Only use if you have modified your whitelist.sqf!</Original>
+            <German>Aktiviert - Nur benutzen, wenn du deine whitelist.sqf verändert hast!</German>
+            <French>Activé - A n'utiliser que si vous avez modifié votre whitelist.sqf !</French>
+            <Spanish>Activado - ¡Sólo utilizar si has modificado tu whitelist.sqf</Spanish>
+            <Russian>Вкл - Использовать только если вы редактировали файл whitelist.sqf!</Russian>
+            <Italian>Attiva - Solo se hai modificato la tua whitelist.sqf!</Italian>
+            <Chinesesimp>开启 - 只有在设立了whitelist.sqf时才能用这个选项！</Chinesesimp>
+            <Chinese>開啟 - 只有在設立了whitelist.sqf時才能使用這個選項！</Chinese>
+            <Turkish>Aktif - whitelist.sqf dosyası ayarlanmış olmalı.</Turkish>
+            <Portuguese>Ativado - Apenas use se tiver modificado o arquivo whitelist.sqf!</Portuguese>
+        </Key>
+        <Key ID="STR_BUILD_ENEMIES_NEARBY">
+            <Original>Cannot build: hostile forces nearby.</Original>
+            <French>Impossible de construire: forces hostiles à proximité.</French>
+            <German>Kann nicht gebaut werden: Feindkräfte in der Nähe</German>
+            <Spanish>No se puede construir: fuerzas hostiles cercanas</Spanish>
+            <Russian>Постройка невозможна: враги рядом.</Russian>
+            <Italian>Impossibile costruire: forze ostili nelle vicinanze</Italian>
+            <Chinesesimp>无法建造：附近有敌军部队。</Chinesesimp>
+            <Chinese>目前無法建造：附近有敵軍部隊。</Chinese>
+            <Turkish>Kurulamaz: Düşmanlar yakında.</Turkish>
+            <Portuguese>Não é possível construir: Forças hostis na proximidade.</Portuguese>
+        </Key>
+        <Key ID="STR_CLEANUP_PARAM">
+            <Original>Cleanup abandoned vehicles outside FOBs</Original>
+            <French>Nettoyer les véhicules abandonnés loin d'une FOB</French>
+            <German>Räumt verlassene Fahrzeuge auserhalb von FOBs weg</German>
+            <Spanish>Limpieza de vehículos abandonados fuera de FOBs</Spanish>
+            <Russian>Удаление брошенной техники вне FOB.</Russian>
+            <Italian>Eliminazione di veicoli abbandonati fuori le FOB</Italian>
+            <Chinesesimp>清理前哨外的废弃载具</Chinesesimp>
+            <Chinese>清理前線基地外的廢棄載具</Chinese>
+            <Turkish>FOB dışındaki araçların temizlenmesi</Turkish>
+            <Portuguese>Remover veículos abandonados fora das FOBs</Portuguese>
+        </Key>
+        <Key ID="STR_CLEANUP_PARAM1">
+            <Original>Enabled - 1 hour delay</Original>
+            <French>Activé - 1 heure de délai</French>
+            <German>Aktiv - 1 Stunde Verzögerung</German>
+            <Spanish>Activado- abandonados durante 1 hora</Spanish>
+            <Russian>Вкл - задержка 1 час</Russian>
+            <Italian>Attivato - eliminazione ogni ora</Italian>
+            <Chinesesimp>开启 - 1小时延迟</Chinesesimp>
+            <Chinese>開啟 - 延遲 1 小時</Chinese>
+            <Turkish>Açık - 1 saat gecikmeli</Turkish>
+            <Portuguese>Ativado - 1 hora para remoção</Portuguese>
+        </Key>
+        <Key ID="STR_CLEANUP_PARAM2">
+            <Original>Enabled - 2 hours delay</Original>
+            <French>Activé - 2 heures de délai</French>
+            <German>Aktiv - 2 Stunde Verzögerung</German>
+            <Spanish>Activado - abandonados durante 2 horas</Spanish>
+            <Russian>Вкл - задержка 2 часа</Russian>
+            <Italian>Attivato - eliminazione ogni 2 ore</Italian>
+            <Chinesesimp>开启 - 2小时延迟</Chinesesimp>
+            <Chinese>開啟 - 延遲 2 小時</Chinese>
+            <Turkish>Açık - 2 saat gecikmeli</Turkish>
+            <Portuguese>Ativado - 2 horas para remoção</Portuguese>
+        </Key>
+        <Key ID="STR_CLEANUP_PARAM3">
+            <Original>Enabled - 4 hours delay</Original>
+            <French>Activé - 4 heures de délai</French>
+            <German>Aktiv - 4 Stunden Verzögerung</German>
+            <Spanish>Activado - abandonados durante 4 horas</Spanish>
+            <Russian>Вкл - задержка 4 часа</Russian>
+            <Italian>Attivato - eliminazione ogni 4 ore</Italian>
+            <Chinesesimp>开启 - 4小时延迟</Chinesesimp>
+            <Chinese>開啟 - 延遲 4 小時</Chinese>
+            <Turkish>Açık - 4 saat gecikmeli</Turkish>
+            <Portuguese>Ativado - 4 horas para remoção</Portuguese>
+        </Key>
+        <Key ID="STR_SORRY">
+            <Original>Sorry!</Original>
+            <French>Désolé !</French>
+            <German>Entschuldigung!</German>
+            <Spanish>Lo siento!</Spanish>
+            <Russian>Извини!</Russian>
+            <Italian>Scusa!</Italian>
+            <Chinesesimp>抱歉！</Chinesesimp>
+            <Chinese>抱歉！</Chinese>
+            <Turkish>Özür dilerim!</Turkish>
+            <Portuguese>Desculpe!</Portuguese>
+        </Key>
+        <Key ID="STR_COMMANDER_NOT_AUTHORIZED">
+            <Original>You are not authorized to use the commander slot on this server.</Original>
+            <French>Vous n'êtes pas authorizé à utiliser la place de commandant sur ce serveur.</French>
+            <German>Du bist auf diesem Server nicht als Kommandant autorisiert.</German>
+            <Spanish>No estás autorizado para usar el slot de comandante en este servidor.</Spanish>
+            <Russian>Вы не авторизованы, чтобы использовать слот коммандира на этом сервере.</Russian>
+            <Italian>Non sei autorizzato ad usare lo slot comandante in questo server.</Italian>
+            <Chinesesimp>你没有使用这个服务器指挥官栏位的权限。</Chinesesimp>
+            <Chinese>你並沒有使用這個伺服器指揮官欄位的權限。</Chinese>
+            <Turkish>Komutan slotunu kullanmak için seçilmemişsiniz.</Turkish>
+            <Portuguese>Você não está autorizado a usar o slot de comandante neste servidor.</Portuguese>
+        </Key>
+        <Key ID="STR_MAKE_RESPAWN_LOADOUT">
+            <Original>Save respawn loadout</Original>
+            <French>Equipement de respawn</French>
+            <German>Ausrüstung bei Respawn festlegen</German>
+            <Spanish>Guardar el equipamiento para respawn</Spanish>
+            <Russian>Всегда загружать</Russian>
+            <Italian>Salva Equipaggiamento</Italian>
+            <Chinesesimp>保存重生装备</Chinesesimp>
+            <Chinese>設定為重生裝備</Chinese>
+            <Turkish>Respawn ekipmanını kaydet.</Turkish>
+            <Portuguese>Salvar equipamento para respawn.</Portuguese>
+        </Key>
+        <Key ID="STR_MAKE_RESPAWN_LOADOUT_HINT">
+            <Original>Your current loadout will be restored on every respawn.</Original>
+            <French>Votre equipement actuel sera restauré à chaque respawn.</French>
+            <German>Deine Ausrüstung wird bei jedem Respwan wiederhergestellt.</German>
+            <Spanish>Tu actual equipamiento seá mantenido en cada respawn.</Spanish>
+            <Russian>Ваше текущее снаряжение будет загружаться после каждого возраждения</Russian>
+            <Italian>Il tuo equipaggiamneto sarà ricaricato ad ogni respawn</Italian>
+            <Chinesesimp>你的装备将在重生时恢复到现有状态。</Chinesesimp>
+            <Chinese>重生後，你的裝備將恢復到現有狀態。</Chinese>
+            <Turkish>Şuanki ekipmanınız her doğduğunuzda yeniden verilecek.</Turkish>
+            <Portuguese>Seu equipamento atual será restaurado em cada respawn.</Portuguese>
+        </Key>
+        <Key ID="STR_LOAD_PLAYER_LOADOUT">
+            <Original>Load from player</Original>
+            <French>Charger depuis joueur</French>
+            <German>Von Spieler laden</German>
+            <Spanish>Cargar desde jugador</Spanish>
+            <Russian>Из игрока</Russian>
+            <Italian>Carica da giocatore</Italian>
+            <Chinesesimp>读取其他玩家装备</Chinesesimp>
+            <Chinese>複製其他玩家裝備</Chinese>
+            <Turkish>Diğer oyuncudan al</Turkish>
+            <Portuguese>Copiar do jogador</Portuguese>
+        </Key>
+        <Key ID="STR_LOAD_PLAYER_LOADOUT_HINT">
+            <Original>Successful loadout transfer from %1.</Original>
+            <French>Transfer d'équipement réussi depuis %1.</French>
+            <German>Erfolgreich Ausrüstung von %1 übertragen.</German>
+            <Spanish>Transferencia de equipamiento de %1 terminada.</Spanish>
+            <Russian>Успешная загрузка снаряжения игрока %1</Russian>
+            <Italian>Equipaggiamento traferito correttamente da %1</Italian>
+            <Chinesesimp>成功从%1读取了装备</Chinesesimp>
+            <Chinese>成功複製了 %1 的裝備</Chinese>
+            <Turkish>%1 den ekipman alındı.</Turkish>
+            <Portuguese>Transferência de loadout de %1 realizada.</Portuguese>
+        </Key>
+        <Key ID="STR_LOADOUT">
+            <Original>Loadout:</Original>
+            <French>Equipement :</French>
+            <German>Ausrüstung:</German>
+            <Spanish>Equipamiento:</Spanish>
+            <Russian>Снаряжение:</Russian>
+            <Italian>Equipaggiamento:</Italian>
+            <Chinesesimp>装备：</Chinesesimp>
+            <Chinese>裝備</Chinese>
+            <Turkish>Ekipman:</Turkish>
+            <Portuguese>Equipamento:</Portuguese>
+        </Key>
+        <Key ID="STR_SPAWN_POINT">
+            <Original>Deployment location:</Original>
+            <French>Lieu de déploiement :</French>
+            <German>Einsatzposition:</German>
+            <Spanish>Lugar para el despliegue:</Spanish>
+            <Russian>Позиция размешения:</Russian>
+            <Italian>Luogo di Schieramento:</Italian>
+            <Chinesesimp>部署地点：</Chinesesimp>
+            <Chinese>佈署地點：</Chinese>
+            <Turkish>Doğma noktası:</Turkish>
+            <Portuguese>Local para mobilização:</Portuguese>
+        </Key>
+        <Key ID="STR_AGGRESSIVITY_PARAM">
+            <Original>OPFOR aggressivity</Original>
+            <French>Aggressivité de l'OPFOR</French>
+            <German>OPFOR Aggressivität</German>
+            <Spanish>Agresividad del OPFOR</Spanish>
+            <Russian>Уровень обеспокоенности OPFOR</Russian>
+            <Italian>Aggressività OPFOR</Italian>
+            <Chinesesimp>敌军进攻性</Chinesesimp>
+            <Chinese>敵軍侵略度</Chinese>
+            <Turkish>OPFOR agresifliği</Turkish>
+            <Portuguese>Agressividade inimiga</Portuguese>
+        </Key>
+        <Key ID="STR_AGGRESSIVITY_PARAM0">
+            <Original>Anemic</Original>
+            <French>Anémique</French>
+            <German>Mutlos</German>
+            <Spanish>Anémica</Spanish>
+            <Russian>Вяло</Russian>
+            <Italian>Anemico</Italian>
+            <Chinesesimp>可悲</Chinesesimp>
+            <Chinese>可悲</Chinese>
+            <Turkish>Pasif</Turkish>
+            <Portuguese>Anêmica</Portuguese>
+        </Key>
+        <Key ID="STR_AGGRESSIVITY_PARAM1">
+            <Original>Weak</Original>
+            <French>Faible</French>
+            <German>Schwach</German>
+            <Spanish>Floja</Spanish>
+            <Russian>Слабо</Russian>
+            <Italian>Debole</Italian>
+            <Chinesesimp>弱小</Chinesesimp>
+            <Chinese>弱小</Chinese>
+            <Turkish>Zayıf</Turkish>
+            <Portuguese>Fraca</Portuguese>
+        </Key>
+        <Key ID="STR_AGGRESSIVITY_PARAM2">
+            <Original>Normal</Original>
+            <French>Normale</French>
+            <German>Normal</German>
+            <Spanish>Normal</Spanish>
+            <Russian>Нормально</Russian>
+            <Italian>Normale</Italian>
+            <Chinesesimp>正常</Chinesesimp>
+            <Chinese>正常</Chinese>
+            <Turkish>Normal</Turkish>
+            <Portuguese>Normal</Portuguese>
+        </Key>
+        <Key ID="STR_AGGRESSIVITY_PARAM3">
+            <Original>Strong</Original>
+            <French>Forte</French>
+            <German>Stark</German>
+            <Spanish>Fuerte</Spanish>
+            <Russian>Сильно</Russian>
+            <Italian>Forte</Italian>
+            <Chinesesimp>强大</Chinesesimp>
+            <Chinese>強大</Chinese>
+            <Turkish>Güçlü</Turkish>
+            <Portuguese>Forte</Portuguese>
+        </Key>
+        <Key ID="STR_AGGRESSIVITY_PARAM4">
+            <Original>Extreme</Original>
+            <French>Extreme</French>
+            <German>Extrem</German>
+            <Spanish>Extrema</Spanish>
+            <Russian>Очень сильно</Russian>
+            <Italian>Estremo</Italian>
+            <Chinesesimp>噩梦</Chinesesimp>
+            <Chinese>惡夢</Chinese>
+            <Turkish>Extreme</Turkish>
+            <Portuguese>Extrema</Portuguese>
+        </Key>
+        <Key ID="STR_WEATHER_PARAM">
+            <Original>Weather</Original>
+            <French>Meteo</French>
+            <German>Wetter</German>
+            <Spanish>Clima</Spanish>
+            <Russian>Погода</Russian>
+            <Italian>Meteo</Italian>
+            <Chinesesimp>天气</Chinesesimp>
+            <Chinese>天氣</Chinese>
+            <Turkish>Hava</Turkish>
+            <Portuguese>Clima</Portuguese>
+        </Key>
+        <Key ID="STR_WEATHER_PARAM1">
+            <Original>Always sunny</Original>
+            <French>Soleil permanent</French>
+            <German>Immer sonnig</German>
+            <Spanish>Siempre soleado</Spanish>
+            <Russian>Всегда солнечно</Russian>
+            <Italian>Semopre Soleggiato</Italian>
+            <Chinesesimp>永远晴天</Chinesesimp>
+            <Chinese>永遠晴天</Chinese>
+            <Turkish>Hep güneşli</Turkish>
+            <Portuguese>Sempre ensolarado</Portuguese>
+        </Key>
+        <Key ID="STR_WEATHER_PARAM2">
+            <Original>Random without rain</Original>
+            <French>Aléatoire sans pluie</French>
+            <German>Zufällig ohne Regen</German>
+            <Spanish>Aleatorio sin lluvia</Spanish>
+            <Russian>Случайно, без дождя</Russian>
+            <Italian>Casuale senza pioggia</Italian>
+            <Chinesesimp>随机但无雨</Chinesesimp>
+            <Chinese>隨機但無雨</Chinese>
+            <Turkish>Rasgele ama yağmursuz</Turkish>
+            <Portuguese>Aleatório sem chuva</Portuguese>
+        </Key>
+        <Key ID="STR_WEATHER_PARAM3">
+            <Original>Random</Original>
+            <French>Aléatoire</French>
+            <German>Zufällig</German>
+            <Spanish>Aleatorio</Spanish>
+            <Russian>Случайно</Russian>
+            <Italian>Casuale</Italian>
+            <Chinesesimp>随机</Chinesesimp>
+            <Chinese>完全隨機</Chinese>
+            <Turkish>Rasgele</Turkish>
+            <Portuguese>Aleatório</Portuguese>
+        </Key>
+        <Key ID="STR_SHORTER_NIGHTS_PARAM">
+            <Original>Shorter nights</Original>
+            <French>Nuits plus courtes</French>
+            <German>Kürzere Nächte</German>
+            <Spanish>Noches más cortas</Spanish>
+            <Russian>Короткие ночи</Russian>
+            <Italian>Notte Breve</Italian>
+            <Chinesesimp>短暂夜晚</Chinesesimp>
+            <Chinese>短暫夜晚</Chinese>
+            <Turkish>Kısa geceler</Turkish>
+            <Portuguese>Noites curtas</Portuguese>
+        </Key>
+        <Key ID="STR_REPAIRING">
+            <Original>Repairing</Original>
+            <French>Réparation</French>
+            <German>Repariert</German>
+            <Spanish>Reparando</Spanish>
+            <Russian>Ремонт</Russian>
+            <Italian>Riparazione</Italian>
+            <Chinesesimp>修理中</Chinesesimp>
+            <Chinese>修理中</Chinese>
+            <Turkish>Tamir</Turkish>
+            <Portuguese>Reparando</Portuguese>
+        </Key>
+        <Key ID="STR_REARMING">
+            <Original>Rearming in %1s</Original>
+            <French>Réarmement dans %1s</French>
+            <German>Aufmunitioniert in %1s</German>
+            <Spanish>Rearmando en %1s</Spanish>
+            <Russian>Перезарядка за %1с</Russian>
+            <Italian>Riarmando 1%</Italian>
+            <Chinesesimp>%1后开始补充弹药</Chinesesimp>
+            <Chinese>%1 秒後開始補充彈藥</Chinese>
+            <Turkish>%1 saniye içinde yeniden dolduruluyor</Turkish>
+            <Portuguese>Remuniciando em %1s</Portuguese>
+        </Key>
+        <Key ID="STR_REFUELING">
+            <Original>Refueling</Original>
+            <French>Ravitaillement</French>
+            <German>Auftanken</German>
+            <Spanish>Repostando</Spanish>
+            <Russian>Заправка</Russian>
+            <Italian>Rifornendo</Italian>
+            <Chinesesimp>加油中</Chinesesimp>
+            <Chinese>加油中</Chinese>
+            <Turkish>Yakıt koyuluyor</Turkish>
+            <Portuguese>Reabastecendo</Portuguese>
+        </Key>
+        <Key ID="STR_INTEL">
+            <Original>-- TAKE INTEL</Original>
+            <French>-- PRENDRE INTEL</French>
+            <German>-- GEHEIMDIENSTINFORMATIONEN AUFNEHMEN</German>
+            <Spanish>-- COGER INTELIGENCIA</Spanish>
+            <Russian>-- ПОЛУЧИТЬ РАЗВЕДДАННЫЕ</Russian>
+            <Italian>-- PREDI INTEL</Italian>
+            <Chinesesimp>-- 拿取情报</Chinesesimp>
+            <Chinese>-- 拿取情報</Chinese>
+            <Turkish>-- İSTİHBAHRAT AL</Turkish>
+            <Portuguese>-- PEGAR INTELIGÊNCIA</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_OBJECTIVES">
+            <Original>-- SECONDARY OBJECTIVES</Original>
+            <French>-- OBJECTIFS SECONDAIRES</French>
+            <German>-- SEKUNDÄRE ZIELE</German>
+            <Spanish>-- OBJETIVOS SECUNDARIOS</Spanish>
+            <Russian>-- ДОПОЛНИТЕЛЬНЫЕ ЗАДАЧИ</Russian>
+            <Italian>-- OBIETTIVI SECONDARI</Italian>
+            <Chinesesimp>-- 次要目标</Chinesesimp>
+            <Chinese>-- 次要目標</Chinese>
+            <Turkish>-- İKİNCİ GÖREVLER</Turkish>
+            <Portuguese>-- OBJETIVOS SECUNDÁRIOS</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_OBJECTIVES_TITLE">
+            <Original>SECONDARY OBJECTIVES</Original>
+            <French>OBJECTIFS SECONDAIRES</French>
+            <German>SEKUNDÄRE ZIELE</German>
+            <Spanish>OBJETIVOS SECUNDARIOS</Spanish>
+            <Russian>ДОПОЛНИТЕЛЬНЫЕ ЗАДАЧИ</Russian>
+            <Italian>OBIETTIVI SECONDARI</Italian>
+            <Chinesesimp>次要目标</Chinesesimp>
+            <Chinese>次要目標</Chinese>
+            <Turkish>İKİNCİ GÖREVLER</Turkish>
+            <Portuguese>OBJETIVOS SECUNDÁRIOS</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_OBJECTIVES_START">
+            <Original>Start</Original>
+            <French>Commencer</French>
+            <German>Beginnen</German>
+            <Spanish>Empezar</Spanish>
+            <Russian>Старт</Russian>
+            <Italian>Inizia</Italian>
+            <Chinesesimp>开始</Chinesesimp>
+            <Chinese>開始</Chinese>
+            <Turkish>Başla</Turkish>
+            <Portuguese>Iniciar</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_INTEL">
+            <Original>Current intel: %1</Original>
+            <French>Intel actuelle : %1</French>
+            <German>Aktuelle Geheimdienstinformationen: %1</German>
+            <Spanish>Inteligencia actual: %1</Spanish>
+            <Russian>Разведданные: %1</Russian>
+            <Italian>Intel Attuale: %1</Italian>
+            <Chinesesimp>当前情报：%1</Chinesesimp>
+            <Chinese>目前情報：%1</Chinese>
+            <Turkish>Şuanki istihbahrat: %1</Turkish>
+            <Portuguese>Inteligência atual: %1</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_NOT_ENOUGH_INTEL">
+            <Original>Insufficient intel points</Original>
+            <French>Points d'intel insuffisants</French>
+            <German>Zu wenige Geheimdienstinformationen</German>
+            <Spanish>Puntos de inteligencia insuficientes</Spanish>
+            <Russian>Недостаточно информации</Russian>
+            <Italian>Punti intel insufficenti</Italian>
+            <Chinesesimp>情报点不足</Chinesesimp>
+            <Chinese>情報點不足</Chinese>
+            <Turkish>Yetersiz istihbahrat</Turkish>
+            <Portuguese>Pontos de inteligencia insuficientes</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_IN_PROGRESS">
+            <Original>Secondary mission already in progress</Original>
+            <French>Mission secondaire déjà en cours</French>
+            <German>Sekundäre Mission läuft bereits</German>
+            <Spanish>Misión secundaria ya en curso</Spanish>
+            <Russian>Дополнительная задача уже есть</Russian>
+            <Italian>Missione secondaria attualmente in progresso</Italian>
+            <Chinesesimp>次要任务正在进行中</Chinesesimp>
+            <Chinese>次要目標正在進行中</Chinese>
+            <Turkish>Başka bir görev zaten çalışıyor.</Turkish>
+            <Portuguese>A missão secundária já está em andamento</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_INCOMING_TEXT">
+            <Original>Hostile forces are heading towards %1.</Original>
+            <French>Les forces hostiles se dirigent vers %1.</French>
+            <German>Feindliche Streitkräfte bewegen sich auf %1 zu.</German>
+            <Spanish>Fuerzas hostiles acercándose a %1.</Spanish>
+            <Russian>Замечена вражеская группа рядом с %1</Russian>
+            <Italian>Forze ostili sono in avvicinamento su %1.</Italian>
+            <Chinesesimp>敌军部队正在前往%1</Chinesesimp>
+            <Chinese>敵軍正在前往 %1</Chinese>
+            <Turkish>Düşmanlar %1 'e gidiyor.'</Turkish>
+            <Portuguese>Forças hostis estão a caminho de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_CSAT_CONVOY">
+            <Original>OPFOR Convoy</Original>
+            <French>Convoi OPFOR</French>
+            <German>OPFOR Konvoi</German>
+            <Spanish>Convoy OPFOR</Spanish>
+            <Russian>Конвой OPFOR</Russian>
+            <Italian>Convoglio OPFOR</Italian>
+            <Chinesesimp>敌军车队</Chinesesimp>
+            <Chinese>敵方車隊</Chinese>
+            <Turkish>OPFOR Konvoyu</Turkish>
+            <Portuguese>Comboio inimigo</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_CSAT_CONVOY_WP">
+            <Original>Waypoint</Original>
+            <French>Point de passage</French>
+            <German>Wegpunkt</German>
+            <Spanish>Punto de ruta</Spanish>
+            <Russian>Путевая точка</Russian>
+            <Italian>Punto di Passaggio</Italian>
+            <Chinesesimp>路径点</Chinesesimp>
+            <Chinese>路徑點</Chinese>
+            <Turkish>Varış noktası</Turkish>
+            <Portuguese>Waypoint</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CONVOY_DESTROYED_TEXT">
+            <Original>OPFOR Convoy neutralized.</Original>
+            <French>Convoi OPFOR neutralisé.</French>
+            <German>OPFOR Konvoi neutralisiert.</German>
+            <Spanish>Convoy OPFOR neutralizado</Spanish>
+            <Russian>Конвой OPFOR нейтрализован.</Russian>
+            <Italian>Convoglio OPFOR neutralizzato.</Italian>
+            <Chinesesimp>敌军车队已被消灭</Chinesesimp>
+            <Chinese>敵方車隊已被殲滅</Chinese>
+            <Turkish>OPFOR Konvoyu etkisizleştirildi.</Turkish>
+            <Portuguese>Comboio inimigo neutralizado.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CONVOY_SPOTTED_TEXT">
+            <Original>OPFOR Convoy near %1.</Original>
+            <French>Convoi OPFOR près de %1.</French>
+            <German>OPFOR Konvoi nahe %1.</German>
+            <Spanish>Convoy OPFOR cerca de 1%</Spanish>
+            <Russian>Конвой OPFOR рядом с %1.</Russian>
+            <Italian>Convoglio OPFOR vicino %1.</Italian>
+            <Chinesesimp>敌军车队接近%1</Chinesesimp>
+            <Chinese>敵方車隊接近 %1</Chinese>
+            <Turkish>OPFOR Konvoyu %1 tarafında.</Turkish>
+            <Portuguese>Comboio inimigo nas proximidades de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_GOTIT">
+            <Original>Got it!</Original>
+            <French>J'ai pigé!</French>
+            <German>Verstanden!</German>
+            <Spanish>Lo tengo!</Spanish>
+            <Russian>Вас понял!</Russian>
+            <Italian>Ricevuto!</Italian>
+            <Chinesesimp>明白了！</Chinesesimp>
+            <Chinese>收到！</Chinese>
+            <Turkish>Anlaşıldı!</Turkish>
+            <Portuguese>Entendido!</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_ACTION">
+            <Original>-- TUTORIAL</Original>
+            <French>-- TUTORIAL</French>
+            <German>-- TUTORIAL</German>
+            <Italian>-- TUTORIAL</Italian>
+            <Spanish>-- TUTORIAL</Spanish>
+            <Russian>-- РУКОВОДСТВО</Russian>
+            <Chinesesimp>-- 教程</Chinesesimp>
+            <Chinese>-- 教學</Chinese>
+            <Turkish>-- EĞİTİM</Turkish>
+            <Portuguese>-- TUTORIAL</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE">
+            <Original>TUTORIAL</Original>
+            <French>TUTORIAL</French>
+            <German>TUTORIAL</German>
+            <Italian>TUTORIAL</Italian>
+            <Spanish>TUTORIAL</Spanish>
+            <Russian>РУКОВОДСТВО</Russian>
+            <Chinesesimp>教程</Chinesesimp>
+            <Chinese>教學</Chinese>
+            <Turkish>EĞİTİM</Turkish>
+            <Portuguese>TUTORIAL</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_MISSION0">
+            <Original>FOB Hunting</Original>
+            <French>Chasse à la FOB</French>
+            <German>FOB Jagd</German>
+            <Spanish>Caza de FOB</Spanish>
+            <Russian>Охота за вражескими FOB</Russian>
+            <Italian>Caccia alla FOB</Italian>
+            <Chinesesimp>狩猎前哨</Chinesesimp>
+            <Chinese>獵殺前線基地</Chinese>
+            <Turkish>FOB Avı</Turkish>
+            <Portuguese>Caça à FOB</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_BRIEFING0">
+            <Original>
+                &lt;t size='1.3' color='#ffa000'&gt;FOB HUNTING&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                OPFOR forces use an array of small logistic bases situated behind the front lines. Destroying those
+                assets would greatly disrupt the OPFOR supply lines and impair their capacity to react to our actions.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Your mission is to destroy all supply assets (trucks, containers) at the objective by any means at your
+                disposal. Unfortunately our intelligence is not able to provide you with a precise position for the
+                base, you will have to locate the objective in the red zone on your map.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Reward: OPFOR alert level reduced by 40%&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Original>
+            <French>
+                &lt;t size='1.3' color='#ffa000'&gt;CHASSE A LA FOB&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Les forces de l'OPFOR utilisent des bases logistiques situées derrière la ligne de front. Détruire ces
+                objectifs pertubera les lignes d'approvisionnement de l'OPFOR et les empêchera de réagir efficacement à
+                nos actions.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Votre mission est de détruire tous les équipements logistiques (camions, containers) présents sur
+                l'objectif. Malheureusement nos renseignements ne permettent pas de vous donner la position précise de
+                la base, vous devrez la chercher dans la zone rouge visible sur votre carte.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Coût: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Récompense: niveau d'alerte de l'OPFOR réduit de 40%&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </French>
+            <German>
+                &lt;t size='1.3' color='#ffa000'&gt;FOB JAGD&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Die OPFOR Streitkräfte benutzen ein Netzwerk von kleineren Nachschubbasen hinter den Frontlinien. Diese
+                zu zerstören würden die OPFOR Nachschublinien und ihre Reaktionsmöglichkeiten stark einschränken.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Ihr Auftrag ist es alle Nachschubkapazitäten (Container und Trucks) zu zerstören. Leider ist unser
+                Geheimdienst nicht in der Lage, Ihnen die genaue Position des Ortes mitzuteilen. Sie werden das Ziel
+                innerhalb der makierten roten Zone auf der Karte suchen müssen.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Kosten: 15&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Belohnung: OPFOR Alarmstatus wird um 40% reduziert&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </German>
+            <Spanish>
+                &lt;t size='1.3' color='#ffa000'&gt;CAZA DE FOB&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Las fuerzas del OPFOR utilizan una red de bases logísticas situadas tras las líneas enemigas. Destruir
+                estos recursos interrunpira las líneas de abastecimiento del enemigo y entorpecerán su capacidad para
+                responder a tus acciones.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Tu misión consiste en destruir todos los recursos (camiones, containers) en el objetivo por cualquier
+                medio que esté en tus manos. Desafortunadamente nuestra inteligencia no permite obtener una localización
+                precisa de la base, deberás encontrarla dentro de la zona marcada en rojo en el mapa.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa: nivel de alerta del OPFOR reducido en un 40%&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Spanish>
+            <Russian>
+                &lt;t size='1.3' color='#ffa000'&gt;ОХОТА ЗА FOB&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;&lt;t size='1'&gt;Силы OPFOR используют небольшие базы снабжения, расположенные за
+                линией фронта. Уничтожение материальных средств этих баз значительно нарушит связи снабжения OPFOR и
+                ухудшит их способность реагировать на ваши действия.&lt;/t&gt;&lt;br/&gt; &lt;t size='1'&gt;
+                Ваша миссия состоит в том, чтобы уничтожить на базах все средства снабжения (грузовики, контейнеры)
+                любыми средствами, находящимися в вашем распоряжении. К сожалению, наша разведка не в состоянии
+                предоставить вам точное положение этих баз, вам придется найти их самостоятельно. Ищите базы снабжения в
+                районе красной зоны, отмеченной на вашей карте.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Требуется: 15&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Награда: уровень тревоги OPFOR уменьшится на 40%&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Russian>
+            <Italian>
+                &lt;t size='1.3' color='#ffa000'&gt;CACCIA ALLA FOB&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Le forze OPFOR utilizzano una serie di piccole basi logistiche situate dietro il fronte. Distruggere
+                tali basi serve ad interrompere le linee di alimentazione OPFOR e mettere in pericolo la loro capacità
+                di reagire alle nostre azioni.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                La vostra missione è di distruggere tutte le attività di approvvigionamento (camion, contenitori) presso
+                l 'obiettivo con ogni mezzo a vostra disposizione. Purtroppo la nostra intelligence non è in grado di
+                fornire una posizione precisa della base, si dovrà individuare l'obiettivo all'interno della zona rossa
+                sulla mappa.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Ricompensa: livello di allerta OPFOR ridotto del 40%&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Italian>
+            <Chinesesimp>
+                &lt;t size='1.3' color='#ffa000'&gt;狩猎前哨&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                敌军部队在阵地后方建有一组小型后勤基地。摧毁这些设施将会极大的打击敌军的补给线，并拖慢他们的反应速度。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                你的任务是不惜一切代价摧毁目标区域所有补给物资（卡车、集装箱）。遗憾的是我们的情报部门无法为你提供这些基地的准确位置，你必须在地图的红色区域中自行搜索目标。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;花费：15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;奖励：敌军警戒等级降低40%&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;t size='1.3' color='#ffa000'&gt;獵殺前線基地&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                敵方在陣地後建立了一組小型前線基地作為後勤用，一旦成功摧毀他們將能給予敵軍補給線致命性的打擊、並使他們對我們的進攻感到措手不及。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                遺憾的是我們的情報單位並沒有辦法掌握確切位置，你的任務是在地圖上的紅色區域中尋找到敵方前線基地並摧毀所有基地內的補給物資（卡車、貨櫃）。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;花費：15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;獎勵：敵方警戒度降低 40 %&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Chinese>
+            <Turkish>
+                &lt;t size='1.3' color='#ffa000'&gt;FOB AVI&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                OPFOR kuvvetleri küçük çaplı bir işlemler yönetiyor. Bunları yoketmek onlara zarar verirken bir yandanda
+                bizim yararımıza olacak.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Sizin göreviniz oradaki varlıkları ve eşyaları yoketmek olacak(kamyonet ve mühimmatlar). Malesef
+                istihbaharatımız tam bölge yerini verememekte. Yakın alanlara gidip kendiniz bulmalısınız.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Maliyet: 15&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Ödül: OPFOR uyarı seviyesi %40 a düşecek.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Turkish>
+            <Portuguese>
+                &lt;t size='1.3' color='#ffa000'&gt;CAÇA À FOB&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                As forças de oposição (FOROP) utilizam um conjunto de pequenas bases de logística situadas além do
+                fronte de batalha. Destruindo tais recursos desestabilizaria consideravelmente suas linhas de suprimento
+                e afetaria sua capacidade de reagir às nossas ações.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Sua missão é destruir todas as fontes de recurso (caminhões, contêineres) que estão no objetivo, a
+                qualquer custo. Infelizmente, nossa inteligência não foi capaz de fornecer dados da localização precisa
+                da base. Dessa forma, você deverá localizar o objetivo dentro da zona vermelha identificada em seu mapa.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 15&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa: Alerta das forças de oposição reduzidos em 40%.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_MISSION1">
+            <Original>Convoy Hijack</Original>
+            <French>Interception de convoi</French>
+            <German>Konvoi Hinterhalt</German>
+            <Spanish>Interceptar el Convoy</Spanish>
+            <Russian>Налёт на конвой врага</Russian>
+            <Italian>Intercetta il Convoglio</Italian>
+            <Chinesesimp>劫掠车队</Chinesesimp>
+            <Chinese>攔截車隊</Chinese>
+            <Turkish>Konvoy baskını</Turkish>
+            <Portuguese>Interceptação de comboio</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_BRIEFING1">
+            <Original>
+                &lt;t size='1.3' color='#ffa000'&gt;CONVOY HIJACK&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                OPFOR forces use road convoys to resupply their defensive positions. Intercepting one of these convoys
+                would effectively disrupt their supply lines, and we could use the occasion to retrieve an hefty amount
+                of ammunition.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Your mission is to stop the OPFOR convoy by any means necessary. You can destroy it, or hijack it to
+                retrieve all the ammunition you can grab. The target will be spotted on your map.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Reward: OPFOR alert level reduced by 15%&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Side reward: All the ammunition you can retrieve.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Original>
+            <French>
+                &lt;t size='1.3' color='#ffa000'&gt;INTERCEPTION DE CONVOI&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Les forces de l'OPFOR utilisent des convois routiers pour réaprovisionner leurs positions. Intercepter
+                un de ces convois pertuberait leurs lignes d'approvisionnement, et nous pourrions utiliser l'occasion
+                pour récupérer une grande quantité de munitions.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Votre mission est de stopper le convoi de l'OPFOR par tous les moyens nécessaires. Vous pouvez le
+                détruire, ou le stopper pour récupérer un maximum de munitions. La cible sera marquée sur votre carte.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Coût: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Récompense: niveau d'alerte de l'OPFOR réduit de 15%&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Récompense secondaire: toutes les munitions que vous pourrez
+                récupérer.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </French>
+            <German>
+                &lt;t size='1.3' color='#ffa000'&gt;KONVOI HINTERHALT&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Die OPFOR Streitkräfte benutzen Straßenkonvois um ihre Verteidigungspositionen zu versorgen. Diese
+                Konvois abzufangen würden ihre Nachschublinien effektiv unterbrechen und außerdem könnten wir die
+                Möglichkeit nutzen, um selbst eine große Menge an Munition zu erbeuten.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Ihr Auftrag ist es, den OPFOR Konvoi auf jede erdenkliche Weise zu stoppen. Sie können ihn zerstören
+                oder übernehmen, um soviel Munition wie möglich zu erbeuten. Das Ziel wird auf Ihrer Karte aufgeklärt.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Kosten: 10&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Belohnung: OPFOR Alarmstatus wird um 15% reduziert&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Weitere Belohnung: Soviel Munition wie Sie erbeuten können.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </German>
+            <Spanish>
+                &lt;t size='1.3' color='#ffa000'&gt;INTERCEPTAR EL CONVOY&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Las fuerzas OPFOR utilizan convoys de carretera para reabastecer sus posiciones defensivas. Interceptar
+                uno de estos convoy rompería de forma efectiva sus líneas de suministro, y podríamos aprovechar la
+                ocasión para obtener una buena cantidad de munición.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Tu misión consiste en parar ese convoy por cualquier medio. Puedes destruirlo o capturarlo para capturar
+                toda la munición que sea posible. El objetivo aparecerá marcado en el mapa.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Coste: 10&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa: Nivel de alerta OPFOR reducido 15%&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa secundaria: Toda la munición que puedas traer.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Spanish>
+            <Russian>&lt;t size='1.3' color='#ffa000'&gt;НАЛЁТ НА КОНВОЙ&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Силы OPFOR используют автоколонны для снабжения своих оборонительных позиций. Перехват одного из этих
+                конвоев эффективно нарушил бы их связи снабжения, и мы могли бы использовать эту возможность для
+                получения большого количество вооружения.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Ваша задача состоит в том, чтобы остановить конвой OPFOR любой ценой. Вы можете уничтожить его, или
+                захватить его для получения ресурса вооружения. Цель будет отмечена на вашей карте.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Стоимость: 10&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Награда: уровень тревоги OPFOR уменьшится на 15%&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Вторичная награда: Всё вооружение, которое можно получить за
+                утилизацию груза конвоя.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Russian>
+            <Italian>
+                &lt;t size='1.3' color='#ffa000'&gt;INTERCETTA IL CONVOGLIO&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Le forze OPFOR utilizzano convogli stradali per rifornire le loro posizioni difensive. Intercettare uno
+                di questi convogli potrebbe effettivamente distruggere le loro linee di rifornimento, e potete sfruttare
+                l'occasione per recuperare una notevole quantità di munizioni.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                La tua missione è quella di fermare il convoglio OPFOR con ogni mezzo necessario. Si può distruggerlo, o
+                dirottarlo e recuperare tutte le munizioni. L'obiettivo sarà evidenziato sulla mappa.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Ricompensa: livello di allerta OPFOR ridotto del 15%&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Seconda ricompensa: è possibile recuperare tutte le munizioni.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Italian>
+            <Chinesesimp>
+                &lt;t size='1.3' color='#ffa000'&gt;劫掠车队&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                敌军部队的防御位置通过地面车队进行补给。拦截这种车队可以有效打击他们的补给线，而这也是让我们截获弹药的大好机会。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                你的任务是不惜一切代价拦截敌军车队。由你决定是摧毁还是截获所有的弹药。目标将会标示在你的地图上。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;花费：10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;奖励：敌军警戒等级降低15%&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;次要奖励：你能截获的所有弹药。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;t size='1.3' color='#ffa000'&gt;攔截車隊&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                敵方正透過補給車隊來為他們的防禦陣線進行補給，攔截車隊將能有效打擊他們的補給線，而這也是我們從敵軍繳獲彈藥資源的大好機會。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                你的任務是攔截車隊，你可以自行決定要摧毀或是掠奪車隊上的所有彈藥，情報單位將會協助標示目標位置與目標可能前往的路徑點在你的地圖上。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;花費：10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;獎勵：敵軍警戒度降低 15 %&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;次要獎勵：所有你能從車隊上所繳獲的彈藥資源。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Chinese>
+            <Turkish>
+                &lt;t size='1.3' color='#ffa000'&gt;CONVOY BASKINI&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                OPFOR kuvvetleri kendi bölgelerine konvoy ile mühimmat desteği yapıyor. Sizin göreviniz bu konvoyu
+                durdurup kurtarabildiğiniz mühimmatı kendinize almaktır.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Göreviniz bu konvoyu ne pahasına olursa olsun durdurmak. Patlatmadığınız mühimmatı kendi bölgenize
+                taşıyabilirsiniz. Konvoy haritada işaretlenecektir.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Maliyeti: 10&lt;img
+                image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Ödül: OPFOR uyarı seviyesi %15 kadar düşecektir.&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Yan ödül: Kurtardığınız mühimmatlar.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Turkish>
+            <Portuguese>
+                &lt;t size='1.3' color='#ffa000'&gt;INTERCEPTAÇÃO DE COMBOIO&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                As forças de oposição (FOROP) utilizam comboios terrestres para reabastecer suas posições defensivas.
+                Interceptando um desses comboios afetaria efetivamente suas linhas de suprimento, e poderíamos usar a
+                ocasião para recuperar uma grande quantidade de munições.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Sua missão é deter o comboio das forças de oposição utilizando qualquer meio possível. Você pode
+                destruí-lo ou sequestrá-lo para recuperar toda a munição que conseguir transportar. O alvo será
+                identificado em coordenadas específicas no seu mapa.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 10&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa: Nível de alerta das forças de oposição reduzido em 15%.&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa aliada: Toda a munição que conseguir.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\convoy_obj.jpg'/&gt;&lt;/t&gt;
+            </Portuguese>
+        </Key>
 
-		<!-- Added in v0.922 -->
-		<Key ID="STR_PARAM_BLUFOR_DEFENDERS">
-			<Original>BLUFOR defenders in owned sectors</Original>
-			<French>Défenseurs BLUFOR dans les secteurs capturés</French>
-			<German>BLUFOR Verteidiger in besetzten Sektoren</German>
-			<Spanish>Defensores BLUFOR en los sectores controlados</Spanish>
-			<Russian>BLUFOR защитники в захваченных зонах</Russian>
-			<Italian>Trupppe BLUFOR nei settori controllati</Italian>
-			<Chinesesimp>我军部队防御己方战区</Chinesesimp>
-			<Chinese>我軍部隊協防我方戰區</Chinese>
-			<Turkish>Sektörlerdeki BLUFOR savunmacıları</Turkish>
-			<Portuguese>Defensores aliados nos setores controlados</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_AUTODANGER">
-			<Original>Auto-danger behaviour on BLUFOR forces</Original>
-			<French>Comportement 'danger' automatique sur les forces BLUFOR</French>
-			<German>Automatisches Verhalten "Gefahr" bei BLUFOR Kräften</German>
-			<Spanish>Comportamiento de Auto-Alerta en las fuerzas BLUFOR</Spanish>
-			<Russian>Авто-опасность для сил BLUFOR</Russian>
-			<Italian>Comportamento Auto-Allerta per forze BLUFOR</Italian>
-			<Chinesesimp>我军部队自动警戒行为</Chinesesimp>
-			<Chinese>我軍部隊自動警戒行為</Chinese>
-			<Turkish>BLUFOR için Oto-tehlike davranışı</Turkish>
-			<Portuguese>Comportamento automático de alerta nas forças aliadas</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_FOBS_COUNT">
-			<Original>Maximum number of FOBs allowed</Original>
-			<French>Nombre maximal de FOBs autorisé</French>
-			<German>Maximale Anzahl an erlaubten FOBs</German>
-			<Russian>Максимальное количество FOB</Russian>
-			<Spanish>Número máximo de FOBs permitidas</Spanish>
-			<Italian>Numero massimo di FOB consentite</Italian>
-			<Chinesesimp>最大前哨数量</Chinesesimp>
-			<Chinese>最大前線基地數量</Chinese>
-			<Turkish>Maksimum FOB sayısı</Turkish>
-			<Portuguese>Número máximo de FOBs permitidas</Portuguese>
-		</Key>
-		<Key ID="STR_HINT_FOBS_EXCEEDED">
-			<Original>You are not allowed to deploy more than %1 FOBs at the same time.</Original>
-			<French>Vous n'êtes pas autorisé à déployer plus de %1 FOBs en même temps.</French>
-			<German>Sie haben nicht die Erlaubnis, mehr als %1 FOBs zur selben Zeit zu errichten.</German>
-			<Spanish>No se permite desplegar más de %1 FOBs al mismo tiempo</Spanish>
-			<Russian>Вам не разрешено развертывать более %1 FOB одновременно.</Russian>
-			<Italian>Non sei autorizzato a costruire piè di %1 FOB allo stesso tempo</Italian>
-			<Chinesesimp>你不能同时部署超过%1个前哨。</Chinesesimp>
-			<Chinese>你不能佈署超過 %1 個前線基地。</Chinese>
-			<Turkish>Buraya %1 den fazla FOB koyamazsınız.</Turkish>
-			<Portuguese>Você não está autorizado a instalar mais de %1 FOB(s) ao mesmo tempo.</Portuguese>
-		</Key>
-		<Key ID="STR_HINT_LOADOUT_LOADED">
-			<Original>%1 loadout successfully loaded.</Original>
-			<French>Equipement %1 chargé avec succès.</French>
-			<German>Ausrüstungsset %1 erfolgreich geladen.</German>
-			<Spanish>Equipamiento %1 cargado correctamente</Spanish>
-			<Russian>Снаряжение %1 успешно загружено.</Russian>
-			<Italian>%1 equipaggiamento correttamente caricato</Italian>
-			<Chinesesimp>成功读取%1装备。</Chinesesimp>
-			<Chinese>成功讀取 %1 裝備。</Chinese>
-			<Turkish>%1 ekipmanı başarıyla alındı.</Turkish>
-			<Portuguese>Equipamento %1 carregado com sucesso</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_MISSION2">
-			<Original>Search and Rescue</Original>
-			<French>Recherche et Sauvetage</French>
-			<German>Helikopterbergung</German>
-			<Spanish>Búsqueda y rescate</Spanish>
-			<Russian>Поиск и спасение</Russian>
-			<Italian>Cerca e Soccorri</Italian>
-			<Chinesesimp>搜索与营救</Chinesesimp>
-			<Chinese>搜索與營救</Chinese>
-			<Turkish>Ara ve kurtar</Turkish>
-			<Portuguese>Busca e Resgate</Portuguese>
-		</Key>
-		<Key ID="STR_SECONDARY_BRIEFING2">
-			<Original>
-			&lt;t size='1.3' color='#ffa000'&gt;SEARCH AND RESCUE&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			We have lost contact with a recon helicopter on mission behind the enemy lines. We believe the chopper was shot down by hostile forces.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			The helicopter may have crashlanded anywhere in a large zone around its last known position. Your mission is to retrieve the chopper crew and their precious intel. Hostile forces may have found them first, so you must be quick, careful, and ready to engage.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Reward: 20 intel points (10 for each crew alive).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Original>
-			<French>
-			&lt;t size='1.3' color='#ffa000'&gt;RECHERCHE ET SAUVETAGE&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Nous avons perdu le contact avec un helicoptère de reconnaissance en mission derrière les lignes ennemies. Il a probablement été abattu par les forces hostiles.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			L'hélicopter a pu finir sa course dans une large zone autour de sa dernière position connue. Votre mission est de retrouver l'équipage et sa précieuse intel. Les forces hostiles les auront peut-être déjà retrouvés, votre action doit donc être rapide et décisive.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cout: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Récompense: 20 points d'intel (10 pour chaque équipage vivant).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</French>
-			<German>
-			&lt;t size='1.3' color='#ffa000'&gt;SUCHEN UND ZERSTÖREN&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Wir haben den Kontakt mit einem Aufklärungshelikopter, der auf einer Mission hinter feindlichen Linien war, verloren. Wir vermuten, dass der Helikotper von feindlichen Kräften abgeschossen wurde.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Der Helikopter muss irgendwo in einem größeren Bereich um seine letzte bekannte Position notgelandet sein. Ihr Auftrag ist es, die Besatzung zu finden und deren Aufklärungsbericht zu beschaffen. Feindliche Kräfte könnten sie bereits gefunden haben, also müssen sie schnell, vorsichtig und auf alles vorbereitet sein.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Reward: 20 intel points (10 for each crew alive).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</German>
-			<Spanish>
-			&lt;t size='1.3' color='#ffa000'&gt;BÚSQUEDA Y RESCATE&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Hemos perdido contacto con un helicóptero de reconocimiento durante una misión tras las líneas enemigas. Creemos que el helicóptero ha sido derribado por las fuerzas hostiles.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			El helicóptero habría aterrizado forzosamente en alguna parte alrededor de su última posición conocida. Tu misión consiste en traer de vuelta a su tripulación y a la preciada información de interligencia que allí se encuentra. Las fuerzas hostiles pueden haberlos encontrado antes, así que hay que ser rápidos, cuidadosos y estar preparados para enfrentarse.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Coste: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa: 20 puntos de intel (10 por cada tripulante).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Spanish>
-			<Russian>
-			&lt;t size='1.3' color='#ffa000'&gt;SEARCH AND RESCUE&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Мы потеряли связь с вертолетом спецотряда, на задании в тылу врага. Мы считаем, что вертолет был сбит вражескими силами.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Вертолет, возможно, упал где-то в большой зоне вокруг последнего известного положения. Ваша миссия состоит в том, чтобы спасти экипаж вертолета и их драгоценных Интел. Враги, возможно, нашли их первыми, поэтому вы должны быть быстрым, внимательным, и готовы к битве.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Reward: 20 intel points (10 for each crew alive).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Russian>
-			<Italian>
-			&lt;t size='1.3' color='#ffa000'&gt;CERCA E SOCCORRI&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Abbiamo perso il contatto con un elicottero da ricognizione in missione dietro le linee nemiche. Riteniamo che l'elicottero sia stato abbattuto da forze ostili.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			L'elicottero può essersi schiantato ovunque in una vasta zona attorno alla sua ultima posizione nota. La vostra missione è quella di recuperare l'equipaggio  e la loro preziosa Intel. Forze ostili possono averli trovati prima di voi, quindi è necessario essere rapidi, attenti e pronto a tutto.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;20 Punti Intel (10 per ogni membro in vita).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Italian>
-			<Chinesesimp>
-			&lt;t size='1.3' color='#ffa000'&gt;搜索与营救&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			我军一架侦察直升机在敌后执行任务时失联了。我们有理由相信是敌军打下了它。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			直升机有可能坠落在其最后已知位置的一大片地区中。你的任务是营救机组成员和他们宝贵的情报。敌军部队很有可能已经抓捕了他们，因此你必须尽快、谨慎的行动，并做好交战的准备。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;花费：8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;奖励：20情报点（每名幸存组员价值10点）。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;t size='1.3' color='#ffa000'&gt;搜索與營救&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			我們的一架直升機在敵後進行任務時失去了聯繫，我们有理由相信是敵軍打下了它。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			戰情單位已經協助標示出直升機的最後已知地区，你的任務是前往進行搜索並營救出直升機機組員們與他們任務中取得的寶貴情報。敵軍部隊很有可能已經派出部隊前往搜捕他們，所有你們亦須盡快而謹慎的行動，時刻做好交戰的準備。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;花費：8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;獎勵：20 點情報點（每位倖存的機組員價值 10 點情報點）。&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-			</Chinese>
-			<Turkish>
-			&lt;t size='1.3' color='#ffa000'&gt;ARA VE KURTAR&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Dost bir keşif helikopterini düşman sahasında kaybettik. Helikopterin düşman kuvvetleri tarafından vurulduğuna inanıyoruz.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Helikopter son görülen yerde düştüğünü biliyoruz. Göreviniz helikopter personelini bulup ve taşıdığı önemli istihbahratı getirmenizdir. Düşman kuvvetler onu önceden bulabilirler dikkatli olun ve saldırıya açık olun.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Ödül: 20 istihbahrat puanı (Her yaşayan kişi için 10).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-		</Turkish>
-		<Portuguese>
-			&lt;t size='1.3' color='#ffa000'&gt;BUSCA E RESGATE&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			Perdemos contato com um helicóptero de reconhecimento presente em uma missão atrás das linhas inimigas. Acreditamos que o helicóptero foi abatido por forças hostis.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1'&gt;
-			O helicóptero pode ter feito um pouso forçado em local próximo de sua última posição conhecida. Sua missão é recuperar a tripulação do helicóptero e sua preciosa inteligência. Forças hostis podem tê-los localizado primeiro, portanto seja rápido, cuidadoso e esteja pronto para engajar o inimigo.&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
-			&lt;br/&gt;
-			&lt;t size='1.15' color='#ffa000'&gt;Recompensa: 20 pontos de inteligência (10 para cada membro vivo da tripulação).&lt;/t&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			&lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
-		</Portuguese>
-		</Key>
+        <!-- Added in v0.922 -->
+        <Key ID="STR_PARAM_BLUFOR_DEFENDERS">
+            <Original>BLUFOR defenders in owned sectors</Original>
+            <French>Défenseurs BLUFOR dans les secteurs capturés</French>
+            <German>BLUFOR Verteidiger in besetzten Sektoren</German>
+            <Spanish>Defensores BLUFOR en los sectores controlados</Spanish>
+            <Russian>BLUFOR защитники в захваченных зонах</Russian>
+            <Italian>Trupppe BLUFOR nei settori controllati</Italian>
+            <Chinesesimp>我军部队防御己方战区</Chinesesimp>
+            <Chinese>我軍部隊協防我方戰區</Chinese>
+            <Turkish>Sektörlerdeki BLUFOR savunmacıları</Turkish>
+            <Portuguese>Defensores aliados nos setores controlados</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_AUTODANGER">
+            <Original>Auto-danger behaviour on BLUFOR forces</Original>
+            <French>Comportement 'danger' automatique sur les forces BLUFOR</French>
+            <German>Automatisches Verhalten "Gefahr" bei BLUFOR Kräften</German>
+            <Spanish>Comportamiento de Auto-Alerta en las fuerzas BLUFOR</Spanish>
+            <Russian>Авто-опасность для сил BLUFOR</Russian>
+            <Italian>Comportamento Auto-Allerta per forze BLUFOR</Italian>
+            <Chinesesimp>我军部队自动警戒行为</Chinesesimp>
+            <Chinese>我軍部隊自動警戒行為</Chinese>
+            <Turkish>BLUFOR için Oto-tehlike davranışı</Turkish>
+            <Portuguese>Comportamento automático de alerta nas forças aliadas</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_FOBS_COUNT">
+            <Original>Maximum number of FOBs allowed</Original>
+            <French>Nombre maximal de FOBs autorisé</French>
+            <German>Maximale Anzahl an erlaubten FOBs</German>
+            <Russian>Максимальное количество FOB</Russian>
+            <Spanish>Número máximo de FOBs permitidas</Spanish>
+            <Italian>Numero massimo di FOB consentite</Italian>
+            <Chinesesimp>最大前哨数量</Chinesesimp>
+            <Chinese>最大前線基地數量</Chinese>
+            <Turkish>Maksimum FOB sayısı</Turkish>
+            <Portuguese>Número máximo de FOBs permitidas</Portuguese>
+        </Key>
+        <Key ID="STR_HINT_FOBS_EXCEEDED">
+            <Original>You are not allowed to deploy more than %1 FOBs at the same time.</Original>
+            <French>Vous n'êtes pas autorisé à déployer plus de %1 FOBs en même temps.</French>
+            <German>Sie haben nicht die Erlaubnis, mehr als %1 FOBs zur selben Zeit zu errichten.</German>
+            <Spanish>No se permite desplegar más de %1 FOBs al mismo tiempo</Spanish>
+            <Russian>Вам не разрешено развертывать более %1 FOB одновременно.</Russian>
+            <Italian>Non sei autorizzato a costruire piè di %1 FOB allo stesso tempo</Italian>
+            <Chinesesimp>你不能同时部署超过%1个前哨。</Chinesesimp>
+            <Chinese>你不能佈署超過 %1 個前線基地。</Chinese>
+            <Turkish>Buraya %1 den fazla FOB koyamazsınız.</Turkish>
+            <Portuguese>Você não está autorizado a instalar mais de %1 FOB(s) ao mesmo tempo.</Portuguese>
+        </Key>
+        <Key ID="STR_HINT_LOADOUT_LOADED">
+            <Original>%1 loadout successfully loaded.</Original>
+            <French>Equipement %1 chargé avec succès.</French>
+            <German>Ausrüstungsset %1 erfolgreich geladen.</German>
+            <Spanish>Equipamiento %1 cargado correctamente</Spanish>
+            <Russian>Снаряжение %1 успешно загружено.</Russian>
+            <Italian>%1 equipaggiamento correttamente caricato</Italian>
+            <Chinesesimp>成功读取%1装备。</Chinesesimp>
+            <Chinese>成功讀取 %1 裝備。</Chinese>
+            <Turkish>%1 ekipmanı başarıyla alındı.</Turkish>
+            <Portuguese>Equipamento %1 carregado com sucesso</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_MISSION2">
+            <Original>Search and Rescue</Original>
+            <French>Recherche et Sauvetage</French>
+            <German>Helikopterbergung</German>
+            <Spanish>Búsqueda y rescate</Spanish>
+            <Russian>Поиск и спасение</Russian>
+            <Italian>Cerca e Soccorri</Italian>
+            <Chinesesimp>搜索与营救</Chinesesimp>
+            <Chinese>搜索與營救</Chinese>
+            <Turkish>Ara ve kurtar</Turkish>
+            <Portuguese>Busca e Resgate</Portuguese>
+        </Key>
+        <Key ID="STR_SECONDARY_BRIEFING2">
+            <Original>
+                &lt;t size='1.3' color='#ffa000'&gt;SEARCH AND RESCUE&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                We have lost contact with a recon helicopter on mission behind the enemy lines. We believe the chopper
+                was shot down by hostile forces.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                The helicopter may have crashlanded anywhere in a large zone around its last known position. Your
+                mission is to retrieve the chopper crew and their precious intel. Hostile forces may have found them
+                first, so you must be quick, careful, and ready to engage.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Reward: 20 intel points (10 for each crew alive).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Original>
+            <French>
+                &lt;t size='1.3' color='#ffa000'&gt;RECHERCHE ET SAUVETAGE&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Nous avons perdu le contact avec un helicoptère de reconnaissance en mission derrière les lignes
+                ennemies. Il a probablement été abattu par les forces hostiles.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                L'hélicopter a pu finir sa course dans une large zone autour de sa dernière position connue. Votre
+                mission est de retrouver l'équipage et sa précieuse intel. Les forces hostiles les auront peut-être déjà
+                retrouvés, votre action doit donc être rapide et décisive.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cout: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Récompense: 20 points d'intel (10 pour chaque équipage vivant).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </French>
+            <German>
+                &lt;t size='1.3' color='#ffa000'&gt;SUCHEN UND ZERSTÖREN&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Wir haben den Kontakt mit einem Aufklärungshelikopter, der auf einer Mission hinter feindlichen Linien
+                war, verloren. Wir vermuten, dass der Helikotper von feindlichen Kräften abgeschossen wurde.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Der Helikopter muss irgendwo in einem größeren Bereich um seine letzte bekannte Position notgelandet
+                sein. Ihr Auftrag ist es, die Besatzung zu finden und deren Aufklärungsbericht zu beschaffen. Feindliche
+                Kräfte könnten sie bereits gefunden haben, also müssen sie schnell, vorsichtig und auf alles vorbereitet
+                sein.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Reward: 20 intel points (10 for each crew alive).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </German>
+            <Spanish>
+                &lt;t size='1.3' color='#ffa000'&gt;BÚSQUEDA Y RESCATE&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Hemos perdido contacto con un helicóptero de reconocimiento durante una misión tras las líneas enemigas.
+                Creemos que el helicóptero ha sido derribado por las fuerzas hostiles.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                El helicóptero habría aterrizado forzosamente en alguna parte alrededor de su última posición conocida.
+                Tu misión consiste en traer de vuelta a su tripulación y a la preciada información de interligencia que
+                allí se encuentra. Las fuerzas hostiles pueden haberlos encontrado antes, así que hay que ser rápidos,
+                cuidadosos y estar preparados para enfrentarse.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Coste: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa: 20 puntos de intel (10 por cada tripulante).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Spanish>
+            <Russian>
+                &lt;t size='1.3' color='#ffa000'&gt;SEARCH AND RESCUE&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Мы потеряли связь с вертолетом спецотряда, на задании в тылу врага. Мы считаем, что вертолет был сбит
+                вражескими силами.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Вертолет, возможно, упал где-то в большой зоне вокруг последнего известного положения. Ваша миссия
+                состоит в том, чтобы спасти экипаж вертолета и их драгоценных Интел. Враги, возможно, нашли их первыми,
+                поэтому вы должны быть быстрым, внимательным, и готовы к битве.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Reward: 20 intel points (10 for each crew alive).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Russian>
+            <Italian>
+                &lt;t size='1.3' color='#ffa000'&gt;CERCA E SOCCORRI&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Abbiamo perso il contatto con un elicottero da ricognizione in missione dietro le linee nemiche.
+                Riteniamo che l'elicottero sia stato abbattuto da forze ostili.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                L'elicottero può essersi schiantato ovunque in una vasta zona attorno alla sua ultima posizione nota. La
+                vostra missione è quella di recuperare l'equipaggio e la loro preziosa Intel. Forze ostili possono
+                averli trovati prima di voi, quindi è necessario essere rapidi, attenti e pronto a tutto.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;20 Punti Intel (10 per ogni membro in vita).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Italian>
+            <Chinesesimp>
+                &lt;t size='1.3' color='#ffa000'&gt;搜索与营救&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                我军一架侦察直升机在敌后执行任务时失联了。我们有理由相信是敌军打下了它。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                直升机有可能坠落在其最后已知位置的一大片地区中。你的任务是营救机组成员和他们宝贵的情报。敌军部队很有可能已经抓捕了他们，因此你必须尽快、谨慎的行动，并做好交战的准备。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;花费：8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;奖励：20情报点（每名幸存组员价值10点）。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;t size='1.3' color='#ffa000'&gt;搜索與營救&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                我們的一架直升機在敵後進行任務時失去了聯繫，我们有理由相信是敵軍打下了它。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                戰情單位已經協助標示出直升機的最後已知地区，你的任務是前往進行搜索並營救出直升機機組員們與他們任務中取得的寶貴情報。敵軍部隊很有可能已經派出部隊前往搜捕他們，所有你們亦須盡快而謹慎的行動，時刻做好交戰的準備。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;花費：8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;獎勵：20 點情報點（每位倖存的機組員價值 10 點情報點）。&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Chinese>
+            <Turkish>
+                &lt;t size='1.3' color='#ffa000'&gt;ARA VE KURTAR&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Dost bir keşif helikopterini düşman sahasında kaybettik. Helikopterin düşman kuvvetleri tarafından
+                vurulduğuna inanıyoruz.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Helikopter son görülen yerde düştüğünü biliyoruz. Göreviniz helikopter personelini bulup ve taşıdığı
+                önemli istihbahratı getirmenizdir. Düşman kuvvetler onu önceden bulabilirler dikkatli olun ve saldırıya
+                açık olun.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Ödül: 20 istihbahrat puanı (Her yaşayan kişi için 10).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Turkish>
+            <Portuguese>
+                &lt;t size='1.3' color='#ffa000'&gt;BUSCA E RESGATE&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                Perdemos contato com um helicóptero de reconhecimento presente em uma missão atrás das linhas inimigas.
+                Acreditamos que o helicóptero foi abatido por forças hostis.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1'&gt;
+                O helicóptero pode ter feito um pouso forçado em local próximo de sua última posição conhecida. Sua
+                missão é recuperar a tripulação do helicóptero e sua preciosa inteligência. Forças hostis podem tê-los
+                localizado primeiro, portanto seja rápido, cuidadoso e esteja pronto para engajar o inimigo.&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='1.15' color='#00a0ff'&gt;Cost: 8&lt;img image='\A3\Ui_f\data\GUI\Cfg\Ranks\general_gs.paa'/&gt;&lt;/t&gt;
+                &lt;br/&gt;
+                &lt;t size='1.15' color='#ffa000'&gt;Recompensa: 20 pontos de inteligência (10 para cada membro vivo da
+                tripulação).&lt;/t&gt;
+                &lt;br/&gt;&lt;br/&gt;
+                &lt;t size='10'&gt;&lt;img image='res\secondary\fob_obj.jpg'/&gt;&lt;/t&gt;
+            </Portuguese>
+        </Key>
 
-		<!-- Added in v0.924 -->
-		<Key ID="STR_PARAM_SQUAD_SIZE">
-			<Original>AI recruitment limit per squad</Original>
-			<French>Limite de recrutement d'IA par escouade</French>
-			<German>KI Rekrutierungslimit per Squad</German>
-			<Spanish>Límite de reclutamiento IA por escuadra</Spanish>
-			<Russian>Ограничение найма ИИ в отряд</Russian>
-			<Italian>Limite di reclutamento AI per squadra</Italian>
-			<Chinesesimp>每班AI招募限制</Chinesesimp>
-			<Chinese>每班AI招募限制</Chinese>
-			<Turkish>Tim içindeki maksimum AI limiti</Turkish>
-			<Portuguese>Limite de recrutamento de IA por grupo</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SAR_STARTED">
-			<Original>Crashed helicopter near %1.</Original>
-			<French>Helicopter crashé près de %1.</French>
-			<German>Helikopterabsturz in der Nähe von %1</German>
-			<Spanish>Helicóptero derribado cerca de %1</Spanish>
-			<Russian>Разбился вертолет рядом %1.</Russian>
-			<Italian>L'elicottero si è schiantato  nei pressi di %1.</Italian>
-			<Chinesesimp>直升机坠毁在%1附近</Chinesesimp>
-			<Chinese>直升機墜落在 %1 附近</Chinese>
-			<Turkish>Düşmüş helikopter %1 yakınlarında.</Turkish>
-			<Portuguese>Helicóptero abatido nas proximidades de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SAR_FAILED">
-			<Original>SAR mission failed, both crew are KIA.</Original>
-			<French>Mission SAR échouée, les deux équipages sont morts.</French>
-			<German>SAR Mission fehlgeschlagen. Beide Crewmitglieder gefallen.</German>
-			<Spanish>Misión de Búsqueda y Rescate fallida, ambos tripulantes están muertos</Spanish>
-			<Russian>Миссия спасение не удалась, экипаж погиб.</Russian>
-			<Italian>Missione Cerca e Soccorri FALLITA,l'equipaggio è stato ucciso</Italian>
-			<Chinesesimp>营救任务失败，两名组员均已阵亡。</Chinesesimp>
-			<Chinese>營救任務失敗，直升機機組員全員陣亡。</Chinese>
-			<Turkish>Arama kurtarma görevi başarısız. Ekip çatışmada öldü.</Turkish>
-			<Portuguese>A missão de busca e resgate falhou, ambos os tripulantes morreram em combate.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_SAR_SUCCESS">
-			<Original>SAR mission succeeded.</Original>
-			<French>Mission SAR réussie.</French>
-			<German>SAR Mission erfolgreich</German>
-			<Spanish>Misión de Búsqueda y Rescate completada satisfactoriamente</Spanish>
-			<Russian>Миссия спасения выполнена</Russian>
-			<Italian>Missione Cerca e Soccorri completata con successo</Italian>
-			<Chinesesimp>营救任务成功。</Chinesesimp>
-			<Chinese>營救任務成功。</Chinese>
-			<Turkish>Arama kurtarma başarılı.</Turkish>
-			<Portuguese>Missão de busca e resgate concluída com sucesso.</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_MAPMARKERS">
-			<Original>Player mapmarkers activation through extended options</Original>
-			<German>Kartenmarkierungen von Spielern über Erweiterte Optionen aktivierbar</German>
-			<Spanish>Activación de marcas de mapa de jugador a través de opciones extendidas</Spanish>
-			<Russian>Активация картмаркеров игроков с помощью расширенных опций</Russian>
-			<Italian>i mapmarker si attivano dal menu opzioni avanzate</Italian>
-			<Chinesesimp>通过扩展选项激活玩家地图标记</Chinesesimp>
-			<Chinese>通過擴增選項來開啟玩家地圖標記。</Chinese>
-			<Turkish>Oyuncu harita işaretleri diğer ayarlardan açılabilir</Turkish>
-			<Portuguese>Ativação de identificação dos jogadores no mapa, através de opções avançadas</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_MOBILERESPAWN">
-			<Original>Mobile respawn</Original>
-			<German>Mobiler Respawn</German>
-			<Spanish>Respawn Móvil</Spanish>
-			<Russian>Мобильный респаун</Russian>
-			<Italian>Respawn Mobile</Italian>
-			<Chinesesimp>机动复活点</Chinesesimp>
-			<Chinese>機動重生點</Chinese>
-			<Turkish>Mobil respawn</Turkish>
-			<Portuguese>Respawn móvel</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_MOBILEARSENAL">
-			<Original>Mobile arsenal</Original>
-			<German>Mobiles Arsenal</German>
-			<Spanish>Arsenal Móvil</Spanish>
-			<Russian>Мобильный арсенал</Russian>
-			<Italian>Arsenale Mobile</Italian>
-			<Chinesesimp>机动军火库</Chinesesimp>
-			<Chinese>機動軍火庫</Chinese>
-			<Turkish>Mobil ekipman</Turkish>
-			<Portuguese>Arsenal móvel</Portuguese>
-		</Key>
+        <!-- Added in v0.924 -->
+        <Key ID="STR_PARAM_SQUAD_SIZE">
+            <Original>AI recruitment limit per squad</Original>
+            <French>Limite de recrutement d'IA par escouade</French>
+            <German>KI Rekrutierungslimit per Squad</German>
+            <Spanish>Límite de reclutamiento IA por escuadra</Spanish>
+            <Russian>Ограничение найма ИИ в отряд</Russian>
+            <Italian>Limite di reclutamento AI per squadra</Italian>
+            <Chinesesimp>每班AI招募限制</Chinesesimp>
+            <Chinese>每班AI招募限制</Chinese>
+            <Turkish>Tim içindeki maksimum AI limiti</Turkish>
+            <Portuguese>Limite de recrutamento de IA por grupo</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SAR_STARTED">
+            <Original>Crashed helicopter near %1.</Original>
+            <French>Helicopter crashé près de %1.</French>
+            <German>Helikopterabsturz in der Nähe von %1</German>
+            <Spanish>Helicóptero derribado cerca de %1</Spanish>
+            <Russian>Разбился вертолет рядом %1.</Russian>
+            <Italian>L'elicottero si è schiantato nei pressi di %1.</Italian>
+            <Chinesesimp>直升机坠毁在%1附近</Chinesesimp>
+            <Chinese>直升機墜落在 %1 附近</Chinese>
+            <Turkish>Düşmüş helikopter %1 yakınlarında.</Turkish>
+            <Portuguese>Helicóptero abatido nas proximidades de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SAR_FAILED">
+            <Original>SAR mission failed, both crew are KIA.</Original>
+            <French>Mission SAR échouée, les deux équipages sont morts.</French>
+            <German>SAR Mission fehlgeschlagen. Beide Crewmitglieder gefallen.</German>
+            <Spanish>Misión de Búsqueda y Rescate fallida, ambos tripulantes están muertos</Spanish>
+            <Russian>Миссия спасение не удалась, экипаж погиб.</Russian>
+            <Italian>Missione Cerca e Soccorri FALLITA,l'equipaggio è stato ucciso</Italian>
+            <Chinesesimp>营救任务失败，两名组员均已阵亡。</Chinesesimp>
+            <Chinese>營救任務失敗，直升機機組員全員陣亡。</Chinese>
+            <Turkish>Arama kurtarma görevi başarısız. Ekip çatışmada öldü.</Turkish>
+            <Portuguese>A missão de busca e resgate falhou, ambos os tripulantes morreram em combate.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_SAR_SUCCESS">
+            <Original>SAR mission succeeded.</Original>
+            <French>Mission SAR réussie.</French>
+            <German>SAR Mission erfolgreich</German>
+            <Spanish>Misión de Búsqueda y Rescate completada satisfactoriamente</Spanish>
+            <Russian>Миссия спасения выполнена</Russian>
+            <Italian>Missione Cerca e Soccorri completata con successo</Italian>
+            <Chinesesimp>营救任务成功。</Chinesesimp>
+            <Chinese>營救任務成功。</Chinese>
+            <Turkish>Arama kurtarma başarılı.</Turkish>
+            <Portuguese>Missão de busca e resgate concluída com sucesso.</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_MAPMARKERS">
+            <Original>Player mapmarkers activation through extended options</Original>
+            <German>Kartenmarkierungen von Spielern über Erweiterte Optionen aktivierbar</German>
+            <Spanish>Activación de marcas de mapa de jugador a través de opciones extendidas</Spanish>
+            <Russian>Активация картмаркеров игроков с помощью расширенных опций</Russian>
+            <Italian>i mapmarker si attivano dal menu opzioni avanzate</Italian>
+            <Chinesesimp>通过扩展选项激活玩家地图标记</Chinesesimp>
+            <Chinese>通過擴增選項來開啟玩家地圖標記。</Chinese>
+            <Turkish>Oyuncu harita işaretleri diğer ayarlardan açılabilir</Turkish>
+            <Portuguese>Ativação de identificação dos jogadores no mapa, através de opções avançadas</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_MOBILERESPAWN">
+            <Original>Mobile respawn</Original>
+            <German>Mobiler Respawn</German>
+            <Spanish>Respawn Móvil</Spanish>
+            <Russian>Мобильный респаун</Russian>
+            <Italian>Respawn Mobile</Italian>
+            <Chinesesimp>机动复活点</Chinesesimp>
+            <Chinese>機動重生點</Chinese>
+            <Turkish>Mobil respawn</Turkish>
+            <Portuguese>Respawn móvel</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_MOBILEARSENAL">
+            <Original>Mobile arsenal</Original>
+            <German>Mobiles Arsenal</German>
+            <Spanish>Arsenal Móvil</Spanish>
+            <Russian>Мобильный арсенал</Russian>
+            <Italian>Arsenale Mobile</Italian>
+            <Chinesesimp>机动军火库</Chinesesimp>
+            <Chinese>機動軍火庫</Chinese>
+            <Turkish>Mobil ekipman</Turkish>
+            <Portuguese>Arsenal móvel</Portuguese>
+        </Key>
 
-		<!-- Added or changed in v0.95 -->
-		<Key ID="STR_INDIV_FLAG">
-			<Original>Killah Potatoes flag</Original>
-			<German>Killah Potatoes Flagge</German>
-			<Spanish>Bandera de Killah Potatoes</Spanish>
-			<Russian>КР флаг</Russian>
-			<Italian>Bandiera dei Killah Potatoes</Italian>
-			<Chinesesimp>Killah Potatoes旗</Chinesesimp>
-			<Chinese>Killah Potatoes旗</Chinese>
-			<Turkish>Killah Potatoes bayrağı</Turkish>
-			<Portuguese>Bandeira da Killah Potatoes</Portuguese>
-		</Key>
-		<Key ID="STR_SMALL_STORAGE">
-			<Original>Small storage area</Original>
-			<German>Kleiner Lagerbereich</German>
-			<Spanish>Almacén pequeño</Spanish>
-			<Russian>Небольшая платформа склада</Russian>
-			<Italian>Area deposito piccola</Italian>
-			<Chinesesimp>小型货物仓储区</Chinesesimp>
-			<Chinese>小型貨物倉儲區</Chinese>
-			<Turkish>Küçük depo</Turkish>
-			<Portuguese>Depósito pequeno</Portuguese>
-		</Key>
-		<Key ID="STR_LARGE_STORAGE">
-			<Original>Large storage area</Original>
-			<German>Großer Lagerbereich</German>
-			<Spanish>Almacén grande</Spanish>
-			<Russian>Большая платформа склада</Russian>
-			<Italian>Area deposito grande</Italian>
-			<Chinesesimp>大型货物仓储区</Chinesesimp>
-			<Chinese>大型貨物倉儲區</Chinese>
-			<Turkish>Büyük depo</Turkish>
-			<Portuguese>Depósito grande</Portuguese>
-		</Key>
-		<Key ID="STR_RECYCLE_BUILDING">
-			<Original>Salvage Depot</Original>
-			<German>Demontageeinrichtung</German>
-			<Russian>Собрать склад</Russian>
-			<Italian>Edificio smaltimento rifiuti</Italian>
-			<Chinesesimp>回收站</Chinesesimp>
-			<Chinese>回收站</Chinese>
-			<Turkish>Dönüşüm deposu</Turkish>
-			<Portuguese>Centro de desmanche de veículos</Portuguese>
-		</Key>
-		<Key ID="STR_HELI_BUILDING">
-			<Original>Flight Control</Original>
-			<German>Flugkontrolle</German>
-			<Spanish>Torre de Control Aéreo</Spanish>
-			<Russian>Управление полетом</Russian>
-			<Italian>Torre di controllo Aerea</Italian>
-			<Chinesesimp>空管塔台</Chinesesimp>
-			<Chinese>空管塔台</Chinese>
-			<Turkish>Uçuş Kontrol</Turkish>
-			<Portuguese>Controle de tráfego aéreo</Portuguese>
-		</Key>
-		<Key ID="STR_HELI_SLOT">
-			<Original>Helipad</Original>
-			<German>Helikopterlandeplatz</German>
-			<Spanish>Helipuerto</Spanish>
-			<Russian>Верт.площадка</Russian>
-			<Italian>Eliporto</Italian>
-			<Chinesesimp>停机坪</Chinesesimp>
-			<Chinese>停機坪</Chinese>
-			<Turkish>Heliped</Turkish>
-			<Portuguese>Heliporto</Portuguese>
-		</Key>
-		<Key ID="STR_PLANE_SLOT">
-			<Original>Tent Hangar</Original>
-			<German>Zelthangar</German>
-			<Spanish>Hangar de aviones</Spanish>
-			<Russian>Ангар</Russian>
-			<Italian>Hangar Aereo</Italian>
-			<Chinesesimp>机库</Chinesesimp>
-			<Chinese>機庫</Chinese>
-			<Turkish>Çadırdan hangar</Turkish>
-			<Portuguese>Hangar para aeronaves</Portuguese>
-		</Key>
-		<Key ID="STR_BOX_CANTSTORE">
-			<Original>There is no free storage area nearby.</Original>
-			<German>Keine freie Lagerfläche in der Nähe.</German>
-			<Spanish>No hay sitio de almacenamiento cercano</Spanish>
-			<Russian>Рядом с вами нет свободного места</Russian>
-			<Italian>Non c'è un area deposito nelle vicinanze</Italian>
-			<Chinesesimp>这附近没有空闲的仓储区</Chinesesimp>
-			<Chinese>這附近沒有具備足夠空間的倉儲區</Chinese>
-			<Turkish>Yakınlarda boş depo yok</Turkish>
-			<Portuguese>Não há depósito disponível nas proximidades.</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_STORE_CRATE">
-			<Original>-- STORE CRATE</Original>
-			<German>-- KISTE EINLAGERN</German>
-			<Spanish>-- CAJA DE ALMACENAJE</Spanish>
-			<Russian>-- ХРАНЕНИЕ МАГАЗИНА</Russian>
-			<Italian>-- DEPOSITA CASSA</Italian>
-			<Chinesesimp>-- 仓储货箱</Chinesesimp>
-			<Chinese>-- 倉儲貨物</Chinese>
-			<Turkish>-- KUTUYU DEPOLA</Turkish>
-			<Portuguese>-- ARMAZENAR CAIXA NO DEPÓSITO</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_UNSTORE_SUPPLY">
-			<Original>-- UNLOAD SUPPLY CRATE</Original>
-			<German>-- NACHSCHUB ABLADEN</German>
-			<Spanish>-- DESCARGA CAJA DE SUMINISTRO</Spanish>
-			<Russian>-- ЗАГРУЗИТЬ СРОК ПОСТАВКИ</Russian>
-			<Italian>-- SCARICA CASSA RIFORNIMENTI</Italian>
-			<Chinesesimp>-- 卸载补给箱</Chinesesimp>
-			<Chinese>-- 卸載補給箱</Chinese>
-			<Turkish>-- İKMAL KUTUSUNU ÇIKAR</Turkish>
-			<Portuguese>-- DESCARREGAR CAIXA DE SUPRIMENTOS</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_UNSTORE_AMMO">
-			<Original>-- UNLOAD AMMO CRATE</Original>
-			<German>-- MUNITION ABLADEN</German>
-			<Spanish>-- DESCARGA CAJA DE MUNICIÓN</Spanish>
-			<Russian>-- РАЗГРУЗКА БОЕПРИПАСОВ</Russian>
-			<Italian>-- SCARICA CASSA MUNIZIONI</Italian>
-			<Chinesesimp>-- 卸载弹药箱</Chinesesimp>
-			<Chinese>-- 卸載彈藥箱</Chinese>
-			<Turkish>-- MERMİ KUTUSUNU ÇIKAR</Turkish>
-			<Portuguese>-- DESCARREGAR CAIXA DE MUNIÇÃO</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_UNSTORE_FUEL">
-			<Original>-- UNLOAD FUEL CRATE</Original>
-			<German>-- KRAFTSTOFF ABLADEN</German>
-			<Spanish>-- DESCARGA CAJA DE COMBUSTIBLE</Spanish>
-			<Russian>-- РАЗГРУЗКА ТОПЛИВА</Russian>
-			<Italian>-- SCARICA CASSA CARBURANTE</Italian>
-			<Chinesesimp>-- 卸载燃料箱</Chinesesimp>
-			<Chinese>-- 卸載油料箱</Chinese>
-			<Turkish>-- BENZIN KUTUSUNU ÇIKAR</Turkish>
-			<Portuguese>-- DESCARREGAR BARRIS DE COMBUSTÍVEL</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_CRATE_VALUE">
-			<Original>-- CHECK CONTENT</Original>
-			<German>-- INHALT PRÜFEN</German>
-			<Spanish>-- COMPROBAR CONTENIDO</Spanish>
-			<Russian>-- ПРОВЕРИТЬ СОДЕРЖАНИЕ</Russian>
-			<Italian>-- CONTROLLA CARICO</Italian>
-			<Chinesesimp>-- 检查存货</Chinesesimp>
-			<Chinese>-- 檢查存貨</Chinese>
-			<Turkish>-- İÇİNDEKİLER KONTROL ET</Turkish>
-			<Portuguese>-- CHECAR CONTEÚDO</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_CRATE_VALUE_HINT">
-			<Original>Crate contains %1 resources</Original>
-			<German>Kiste beinhaltet %1 Ressourcen</German>
-			<Spanish>La caja contiene %1 recursos</Spanish>
-			<Russian>Ящик содержит %1 ресурсов</Russian>
-			<Italian>La cassa continene %1 risorse</Italian>
-			<Chinesesimp>该货箱装有%1资源</Chinesesimp>
-			<Chinese>該貨箱裝有 %1 資源</Chinese>
-			<Turkish>Kutuda %1 kaynak var</Turkish>
-			<Portuguese>Caixa contém %1 recursos</Portuguese>
-		</Key>
-		<Key ID="STR_VECACTION">
-			<Original>-- Change alignment</Original>
-			<German>-- Ausrichtung ändern</German>
-			<Spanish>-- Cambiar alineación</Spanish>
-			<Russian>-- Изменить выравнивание</Russian>
-			<Italian>-- Cambia allineamento</Italian>
-			<Chinesesimp>-- 更改对齐方案</Chinesesimp>
-			<Chinese>-- 變更對齊方式</Chinese>
-			<Turkish>-- Hizaları değiştir</Turkish>
-			<Portuguese>-- Mudar alinhamento</Portuguese>
-		</Key>
-		<Key ID="STR_CANCEL_ERROR">
-			<Original>Not enough free storage space</Original>
-			<German>Nicht genug Lagerkapazität</German>
-			<Spanish>No hay suficiente espacio disponible</Spanish>
-			<Russian>Недостаточно свободного места для хранения</Russian>
-			<Italian>Non c'è abbastanza spazio disponibile</Italian>
-			<Chinesesimp>没有足够的仓储空间</Chinesesimp>
-			<Chinese>沒有足夠的倉儲空間</Chinese>
-			<Turkish>Yeteri kadar boş alan yok</Turkish>
-			<Portuguese>Não há espaço de armazenamento suficiente</Portuguese>
-		</Key>
-		<Key ID="STR_PREPLACED_ERROR">
-			<Original>You can't recycle preplaced objects</Original>
-			<German>Vorplatzierte Objekte können nicht recycelt werden</German>
-			<Russian>Вы не можете повторно использовать предварительно размещенные объекты</Russian>
-			<Italian>Non puoi riciclare oggetti statici</Italian>
-			<Chinesesimp>你不能回收预置物体</Chinesesimp>
-			<Chinese>你不能回收預置物件</Chinese>
-			<Turkish>Koyulmayan objeleri geri dönüştüremezsiniz</Turkish>
-			<Portuguese>Você não pode reciclar objetos pré inseridos</Portuguese>
-		</Key>
-		<Key ID="STR_NORECBUILDING_ERROR">
-			<Original>Can't recycle:\nNo Salvage Depot in FOB area</Original>
-			<German>Wiederverwerten nicht möglich:\nKeine Demontageeinrichtung im Bereich der FOB</German>
-			<Russian>Невозможно выполнить переработку:\nNo месте аварийного склада в области FOB</Russian>
-			<Italian>Nessun edificio per il riciclaggio presente nell'area</Italian>
-			<Chinesesimp>无法回收：\n前哨区域内没有回收站</Chinesesimp>
-			<Chinese>無法回收：\n前線基地區域內沒有回收站</Chinese>
-			<Turkish>Geri dönüşemez:\nYakınlarda Dönüşüm Deposu yok</Turkish>
-			<Portuguese>Não é possível reciclar:\nNão há centro de desmanche de veículos na área da FOB</Portuguese>
-		</Key>
-		<Key ID="STR_REASSIGN_ZEUS">
-			<Original>-- REASSIGN ZEUS</Original>
-			<German>-- ZEUS NEU ZUWEISEN</German>
-			<Russian>-- РЕАГИРОВАТЬ ZEUS</Russian>
-			<Italian>-- RIASSEGNA ZEUS</Italian>
-			<Chinesesimp>-- 重新分配ZEUS</Chinesesimp>
-			<Chinese>-- 重新分配宙斯</Chinese>
-			<Turkish>-- ZEUSU SEÇ</Turkish>
-			<Portuguese>-- REDESIGNAR ZEUS</Portuguese>
-		</Key>
-		<Key ID="STR_RESOURCE_GLOBAL">
-			<Original>GLOBAL</Original>
-			<German>GESAMT</German>
-			<Russian>ГЛОБАЛЬНЫЙ</Russian>
-			<Italian>GLOBALE</Italian>
-			<Chinesesimp>总览</Chinesesimp>
-			<Chinese>總覽</Chinese>
-			<Turkish>KÜRESEL</Turkish>
-			<Portuguese>GLOBAL</Portuguese>
-		</Key>
-		<Key ID="STR_RESOURCE_GLOBAL_ACTION">
-			<Original>-- Switch resource display</Original>
-			<German>-- Ressourcenanzeige wechseln</German>
-			<Russian>-- Переключение отображения ресурсов</Russian>
-			<Italian>-- Cambia visualizzazione risorse</Italian>
-			<Chinesesimp>-- 切换资源显示</Chinesesimp>
-			<Chinese>-- 切換資源顯示</Chinese>
-			<Turkish>-- Kaynak bölgesini değiştir</Turkish>
-			<Portuguese>-- Alterar painel de recursos</Portuguese>
-		</Key>
-		<Key ID="STR_BLACKLISTED_ITEM_FOUND">
-			<Original>Following items are not allowed:\n%1</Original>
-			<German>Folgende Gegenstände sind nicht erlaubt:\n%1</German>
-			<Russian>Следующие элементы не разрешены:\n%1</Russian>
-			<Italian>Questi elementi non sono ammessi:\n%1</Italian>
-			<Chinesesimp>以下物品已被禁用：\n%1</Chinesesimp>
-			<Chinese>以下品已被禁用：\n%1</Chinese>
-			<Turkish>Şu eşyalar yasaklı:\n%1</Turkish>
-			<Portuguese>Os seguintes itens não são permitidos:\n%1</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_ACTION">
-			<Original>-- Production Settings</Original>
-			<German>-- Produktionseinstellungen</German>
-			<Russian>-- Настройки производства</Russian>
-			<Italian>-- Impostazioni produzione</Italian>
-			<Chinesesimp>-- 产出设定</Chinesesimp>
-			<Chinese>-- 生產設定</Chinese>
-			<Turkish>-- Üretim ayarları</Turkish>
-			<Portuguese>-- Definições de Produção</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_HEADER">
-			<Original>Production Settings</Original>
-			<German>Produktionseinstellungen</German>
-			<Russian>Настройки производства</Russian>
-			<Italian>Impostazioni Produzione</Italian>
-			<Chinesesimp>产出设定</Chinesesimp>
-			<Chinese>生產設定</Chinese>
-			<Turkish>Üretim ayarları</Turkish>
-			<Portuguese>Definições de Produção</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_TYPE">
-			<Original>Sector Type:</Original>
-			<German>Sektortyp:</German>
-			<Russian>Тип сектора:</Russian>
-			<Italian>Tipo Settore:</Italian>
-			<Chinesesimp>战区类型：</Chinesesimp>
-			<Chinese>戰區類型：</Chinese>
-			<Turkish>Sektör türü</Turkish>
-			<Portuguese>Classe do setor:</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_CITY">
-			<Original>City</Original>
-			<German>Stadt</German>
-			<Russian>Город</Russian>
-			<Italian>Città</Italian>
-			<Chinesesimp>城市</Chinesesimp>
-			<Chinese>城市</Chinese>
-			<Turkish>Şehir</Turkish>
-			<Portuguese>Cidade</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_FACTORY">
-			<Original>Factory</Original>
-			<German>Fabrik</German>
-			<Russian>Завод</Russian>
-			<Italian>Fabbrica</Italian>
-			<Chinesesimp>工厂</Chinesesimp>
-			<Chinese>工廠</Chinese>
-			<Turkish>Fabrika</Turkish>
-			<Portuguese>Fábrica</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_PRODUCING">
-			<Original>Producing:</Original>
-			<German>Produziert:</German>
-			<Russian>Производства:</Russian>
-			<Italian>Prodotto:</Italian>
-			<Chinesesimp>正在生产：</Chinesesimp>
-			<Chinese>正在生產：</Chinese>
-			<Turkish>Üretiyor</Turkish>
-			<Portuguese>Produzindo:</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_NOTHING">
-			<Original>Nothing</Original>
-			<German>Nichts</German>
-			<Russian>Ничего</Russian>
-			<Italian>Niente</Italian>
-			<Chinesesimp>无</Chinesesimp>
-			<Chinese>無</Chinese>
-			<Turkish>Hiçbirşey</Turkish>
-			<Portuguese>Nada</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_STORAGE">
-			<Original>Storage:</Original>
-			<German>Lagerbereich:</German>
-			<Russian>Место хранения:</Russian>
-			<Italian>Area Stoccaggio:</Italian>
-			<Chinesesimp>仓储：</Chinesesimp>
-			<Chinese>倉儲：</Chinese>
-			<Turkish>Depo:</Turkish>
-			<Portuguese>Depósito:</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_NOSTORAGE">
-			<Original>Not present</Original>
-			<German>Nicht vorhanden</German>
-			<Russian>нет</Russian>
-			<Italian>Inesistente</Italian>
-			<Chinesesimp>仓储：</Chinesesimp>
-			<Chinese>沒有倉儲物品</Chinese>
-			<Turkish>Depolama yok</Turkish>
-			<Portuguese>Inexistente</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_TIMER">
-			<Original>Time left:</Original>
-			<German>Verbl. Zeit:</German>
-			<Russian>Время вышло:</Russian>
-			<Italian>Tempo rimasto:</Italian>
-			<Chinesesimp>剩余时间：</Chinesesimp>
-			<Chinese>剩餘時間：</Chinese>
-			<Turkish>Kalan süre:</Turkish>
-			<Portuguese>Tempo restante:</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_NOTIMER">
-			<Original>No production</Original>
-			<German>Keine Produktion</German>
-			<Russian>Нет производства</Russian>
-			<Italian>Nessuna produzione:</Italian>
-			<Chinesesimp>无产出</Chinesesimp>
-			<Chinese>沒有產出</Chinese>
-			<Turkish>Üretim yok</Turkish>
-			<Portuguese>Sem produção</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_MINUTES">
-			<Original>%1 minutes</Original>
-			<German>%1 Minuten</German>
-			<Russian>%1 Минут</Russian>
-			<Italian>%1 Minuti</Italian>
-			<Chinesesimp>%1分钟</Chinesesimp>
-			<Chinese>%1 分鐘</Chinese>
-			<Turkish>%1 dakika</Turkish>
-			<Portuguese>%1 minutos</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_FACILITIES">
-			<Original>Facilities available</Original>
-			<German>Verfügbare Einrichtungen</German>
-			<Russian>Услуги доступны</Russian>
-			<Italian>Strutture Disponibili</Italian>
-			<Chinesesimp>可用工厂</Chinesesimp>
-			<Chinese>可用工廠</Chinese>
-			<Turkish>Bölgeler hazır</Turkish>
-			<Portuguese>Instalações disponíveis</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_STORAGEDETAIL">
-			<Original>Stock Overview</Original>
-			<German>Übersicht Lagerbestände</German>
-			<Russian>Обзор запасов</Russian>
-			<Italian>Scorte</Italian>
-			<Chinesesimp>仓储总览</Chinesesimp>
-			<Chinese>倉儲總覽</Chinese>
-			<Turkish>Stok Listesi</Turkish>
-			<Portuguese>Visão geral do armazém</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_CRATE">
-			<Original>%1 Crate</Original>
-			<German>%1 Kiste</German>
-			<Russian>%1 Ящик</Russian>
-			<Italian>%1 Cassa</Italian>
-			<Chinesesimp>%1箱</Chinesesimp>
-			<Chinese>%1 箱</Chinese>
-			<Turkish>%1 Kutu</Turkish>
-			<Portuguese>%1 Caixa</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_CRATES">
-			<Original>%1 Crates</Original>
-			<German>%1 Kisten</German>
-			<Russian>%1 Ящиков</Russian>
-			<Italian>%1 Casse</Italian>
-			<Chinesesimp>%1箱</Chinesesimp>
-			<Chinese>%1 箱</Chinese>
-			<Turkish>%1 Kutular</Turkish>
-			<Portuguese>%1 caixas</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_PRODUCE">
-			<Original>Choose Production</Original>
-			<German>Produktionswahl</German>
-			<Russian>Выбрать продукцию</Russian>
-			<Italian>Seleziona Produzione</Italian>
-			<Chinesesimp>选择产出</Chinesesimp>
-			<Chinese>選擇產出</Chinese>
-			<Turkish>Üretimi seç</Turkish>
-			<Portuguese>Selecione a produção</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_SAVED">
-			<Original>Sector setting saved.</Original>
-			<German>Sektoreinstellung gespeichert.</German>
-			<Russian>Настройки сектора сохранены.</Russian>
-			<Italian>Settaggi settore salvati.</Italian>
-			<Chinesesimp>战区设置已保存。</Chinesesimp>
-			<Chinese>戰區設定已保存。</Chinese>
-			<Turkish>Sektör ayarı kaydedildi.</Turkish>
-			<Portuguese>Definição do setor salva</Portuguese>
-		</Key>
-		<Key ID="STR_SECSTORAGEBUILD_ACTION">
-			<Original>-- Build storage --</Original>
-			<German>-- Lagerfläche bauen --</German>
-			<Russian>-- Создание хранилища --</Russian>
-			<Italian>-- Crea area di stoccaggio --</Italian>
-			<Chinesesimp>-- 建造仓储库 --</Chinesesimp>
-			<Chinese>-- 建造倉儲空間 --</Chinese>
-			<Turkish>-- Depolama aç --</Turkish>
-			<Portuguese>-- Construir depósito --</Portuguese>
-		</Key>
-		<Key ID="STR_SECSUPPLYBUILD_ACTION">
-			<Original>-- Build supply facility --</Original>
-			<German>-- Nachschubeinrichtung bauen --</German>
-			<Russian>-- Построить систему снабжения --</Russian>
-			<Italian>-- Crea impianto approvvigionamento --</Italian>
-			<Chinesesimp>-- 建造补给工厂 --</Chinesesimp>
-			<Chinese>-- 建造補給工廠 --</Chinese>
-			<Turkish>-- İkmal kutusu üretimi kur --</Turkish>
-			<Portuguese>-- Construir fábrica de suprimentos --</Portuguese>
-		</Key>
-		<Key ID="STR_SECAMMOBUILD_ACTION">
-			<Original>-- Build ammo facility --</Original>
-			<German>-- Munitionseinrichtung bauen --</German>
-			<Russian>-- Создать боеприпасы --</Russian>
-			<Italian>-- Crea impianto munizioni --</Italian>
-			<Chinesesimp>-- 建造弹药工厂 --</Chinesesimp>
-			<Chinese>-- 建造彈藥工廠 --</Chinese>
-			<Turkish>-- Mermi kutusu üretimi kur --</Turkish>
-			<Portuguese>-- Construir fábrica de munição --</Portuguese>
-		</Key>
-		<Key ID="STR_SECFUELBUILD_ACTION">
-			<Original>-- Build fuel facility --</Original>
-			<German>-- Kraftstoffeinrichtung bauen --</German>
-			<Russian>-- Построить топливный объект --</Russian>
-			<Italian>-- Crea impianto carburante --</Italian>
-			<Chinesesimp>-- 建造燃料工厂 --</Chinesesimp>
-			<Chinese>-- 建造油料工廠 --</Chinese>
-			<Turkish>-- Benzin kutusu üretimi kur --</Turkish>
-			<Portuguese>-- Construir refinaria de combustível --</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_FACFALSE">
-			<Original>Needed facility not built in sector.</Original>
-			<German>Benötigte Einrichtung nicht vorhanden.</German>
-			<Russian>Необходимый объект не построен в секторе.</Russian>
-			<Italian>Impianto necessario non costruito nel settore.</Italian>
-			<Chinesesimp>该战区内没有所需的工厂。</Chinesesimp>
-			<Chinese>該戰區內沒有所需的工廠。</Chinese>
-			<Turkish>İstenilen üretim sektörde kurulu değil.</Turkish>
-			<Portuguese>É necessária uma fábrica não construída neste setor</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_FACBUILD_ERROR">
-			<Original>Not enough resources.\n\nYou need:\n%1 Supplies\n%2 Ammo\n%3 Fuel</Original>
-			<German>Nicht genug Ressourcen.\n\nDu benötigst:\n%1 Nachschub\n%2 Munition\n%3 Kraftstoff</German>
-			<Russian>Недостаточно ресурсов.\n\nВам нужно: \n%1 Расходные материалы \n%2 Боеприпасы \n%3 Топливо</Russian>
-			<Italian>Risorse insufficenti.\n\nHai bisogno di:\n%1 approvvigionamenti\n%2 Munizioni\n%3 Carburante </Italian>
-			<Chinesesimp>资源不足。\n\n你需要\n%1补给\n%2弹药\n%3燃料</Chinesesimp>
-			<Chinese>資源不足。\n\n你需要\n%1補給\n%2彈藥\n%3油料</Chinese>
-			<Turkish>Yetersiz kaynak.\n\nLazım olan: \n%1 İkmal \n%2 Mermi\n%3 Benzin</Turkish>
-			<Portuguese>Sem recursos suficientes.\n\nVocê precisa de:\n%1 Suprimentos\n%2 Munição\n%3 Combustível</Portuguese>
-		</Key>
-		<Key ID="STR_PRODUCTION_FACBUILD_SUCCESS">
-			<Original>Facility established.</Original>
-			<German>Einrichtung etabliert.</German>
-			<Russian>Учреждение создано.</Russian>
-			<Italian>Struttura creata.</Italian>
-			<Chinesesimp>工厂已建立。</Chinesesimp>
-			<Chinese>工廠已建立。</Chinese>
-			<Turkish>Üretim kuruldu.</Turkish>
-			<Portuguese>Estrutura criada.</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_AILOGISTICS">
-			<Original>AI Logistics Module</Original>
-			<German>AI Logistik Modul</German>
-			<Russian>Модуль логистики AI</Russian>
-			<Italian>AI Logistica</Italian>
-			<Chinesesimp>AI后勤模块</Chinesesimp>
-			<Chinese>AI 後勤模塊</Chinese>
-			<Turkish>AI Lojistiği</Turkish>
-			<Portuguese>Módulo Logístico automatizado</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_ACTION">
-			<Original>-- Logistic Overview</Original>
-			<German>-- Logistikübersicht</German>
-			<Russian>-- Обзор логистики</Russian>
-			<Italian>-- Vedi Logistica</Italian>
-			<Chinesesimp>-- 后勤总览</Chinesesimp>
-			<Chinese>-- 後勤總覽</Chinese>
-			<Turkish>-- Lojistik</Turkish>
-			<Portuguese>-- Visão Geral da Logística</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_HEADER">
-			<Original>Logistic Overview</Original>
-			<German>Logistikübersicht</German>
-			<Russian>Обзор логистики</Russian>
-			<Italian>Vedi Logistica</Italian>
-			<Chinesesimp>后勤总览</Chinesesimp>
-			<Chinese>後勤總覽</Chinese>
-			<Turkish>Lojistikler</Turkish>
-			<Portuguese>Visão Geral da Logística</Portuguese>
-		</Key>
-		<Key ID="STR_ADD">
-			<Original>Add</Original>
-			<German>Hinzfg</German>
-			<Russian>Добавить</Russian>
-			<Italian>Aggiungi</Italian>
-			<Chinesesimp>添加</Chinesesimp>
-			<Chinese>添加</Chinese>
-			<Turkish>Ekle</Turkish>
-			<Portuguese>Adicionar</Portuguese>
-		</Key>
-		<Key ID="STR_DEL">
-			<Original>Del</Original>
-			<German>Entf</German>
-			<Russian>Удалить</Russian>
-			<Italian>Elimina</Italian>
-			<Chinesesimp>删除</Chinesesimp>
-			<Chinese>刪除</Chinese>
-			<Turkish>Sil</Turkish>
-			<Portuguese>Deletar</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_STATUS">
-			<Original>Status:</Original>
-			<German>Status:</German>
-			<Russian>Статус</Russian>
-			<Italian>Stato:</Italian>
-			<Chinesesimp>状态：</Chinesesimp>
-			<Chinese>狀態：</Chinese>
-			<Turkish>Durum:</Turkish>
-			<Portuguese>Status:</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_STANDBY">
-			<Original>Standby</Original>
-			<German>Bereitschaft</German>
-			<Russian>Ожидание</Russian>
-			<Italian>In Attesa</Italian>
-			<Chinesesimp>等待中</Chinesesimp>
-			<Chinese>等待中</Chinese>
-			<Turkish>Beklemede</Turkish>
-			<Portuguese>Aguardando ordens</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_LOADING">
-			<Original>Loading</Original>
-			<German>Verladen</German>
-			<Russian>Загрузка</Russian>
-			<Italian>Caricamento</Italian>
-			<Chinesesimp>装载中</Chinesesimp>
-			<Chinese>裝載中</Chinese>
-			<Turkish>Yükleniyor</Turkish>
-			<Portuguese>Carregando</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TRAVEL">
-			<Original>On the way</Original>
-			<German>Unterwegs</German>
-			<Russian>В пути</Russian>
-			<Italian>In movimento</Italian>
-			<Chinesesimp>运输中</Chinesesimp>
-			<Chinese>運輸中</Chinese>
-			<Turkish>Yolda</Turkish>
-			<Portuguese>A caminho</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_ABORT">
-			<Original>Aborting mission</Original>
-			<German>Auftragsabbruch</German>
-			<Russian>Прерывание миссии</Russian>
-			<Italian>Termina missione</Italian>
-			<Chinesesimp>放弃任务中</Chinesesimp>
-			<Chinese>放棄任務中</Chinese>
-			<Turkish>İptal ediliyor</Turkish>
-			<Portuguese>Abortando missão</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_NORESSOURCES">
-			<Original>No resources</Original>
-			<German>Keine Ressourcen</German>
-			<Russian>Нет ресурсов</Russian>
-			<Italian>Risorse non avviabili</Italian>
-			<Chinesesimp>资源不足</Chinesesimp>
-			<Chinese>資源不足</Chinese>
-			<Turkish>Kaynak yok</Turkish>
-			<Portuguese>Sem recursos</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_NOSPACE">
-			<Original>No storagespace</Original>
-			<German>Kein Lagerplatz</German>
-			<Russian>Нет места для хранения</Russian>
-			<Italian>Spazio non avviabile</Italian>
-			<Chinesesimp>仓储空间不足</Chinesesimp>
-			<Chinese>倉儲空間不足</Chinese>
-			<Turkish>Depolama yeri yok</Turkish>
-			<Portuguese>Sem espaço no depósito</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_DESTINATION">
-			<Original>Next destination:</Original>
-			<German>Nächster Zielort:</German>
-			<Russian>Следующая цель:</Russian>
-			<Italian>Prossima destinazione:</Italian>
-			<Chinesesimp>下个目的地：</Chinesesimp>
-			<Chinese>下個目的地：</Chinese>
-			<Turkish>Diğer istikamet:</Turkish>
-			<Portuguese>Próximo destino:</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_LOADEDDETAIL">
-			<Original>Current convoy cargo</Original>
-			<German>Aktuelle Konvoiladung</German>
-			<Russian>Текущий состав конвоя</Russian>
-			<Italian>Carico convoglio attuale</Italian>
-			<Chinesesimp>当前车队货物</Chinesesimp>
-			<Chinese>目前車隊貨物</Chinese>
-			<Turkish>Şuanki konvoy kargosu</Turkish>
-			<Portuguese>Comboio de carga atual</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TRUCKCOUNT">
-			<Original>Assigned Trucks</Original>
-			<German>Zugeteilte LKWs</German>
-			<Russian>Назначенные грузовики</Russian>
-			<Italian>Camion Assegnati</Italian>
-			<Chinesesimp>已指派的卡车</Chinesesimp>
-			<Chinese>已指派的卡車</Chinese>
-			<Turkish>Seçili kamyonlar</Turkish>
-			<Portuguese>Veículos em uso</Portuguese>
-		</Key>
-		<Key ID="STR_LOGSTIC_BUYTRUCK">
-			<Original>Assign Truck</Original>
-			<German>LKW zuteilen</German>
-			<Russian>Назначить грузовик</Russian>
-			<Italian>Assegna camion</Italian>
-			<Chinesesimp>指派卡车</Chinesesimp>
-			<Chinese>指派卡車</Chinese>
-			<Turkish>Kamyon seç</Turkish>
-			<Portuguese>Designar Transporte</Portuguese>
-		</Key>
-		<Key ID="STR_LOGSTIC_SELLTRUCK">
-			<Original>Unassign Truck</Original>
-			<German>LKW abziehen</German>
-			<Russian>Отменить передачу</Russian>
-			<Italian>Rimuovi camion</Italian>
-			<Chinesesimp>取消指派卡车</Chinesesimp>
-			<Chinese>取消指派卡車</Chinese>
-			<Turkish>Seçimi iptal et</Turkish>
-			<Portuguese>Dispensar Transporte</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TT_BUYTRUCK">
-			<Original>Costs: 100 supplies and 100 fuel.</Original>
-			<German>Kosten: 100 Nachschub und 100 Kraftstoff.</German>
-			<Russian>Затраты: 100 поставок и 100 единиц топлива.</Russian>
-			<Italian>Costo: 100 approvvigionamenti e 100 carburante.</Italian>
-			<Chinesesimp>花费：100补给和100燃料。</Chinesesimp>
-			<Chinese>花費：100 補給和 100 油料。</Chinese>
-			<Turkish>Maliyeti : 100 ikmal ve 100 benzin</Turkish>
-			<Portuguese>Custa: 100 de suprimento e 100 de combustível.</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TT_SELLTRUCK">
-			<Original>Gives: 50 supplies and 50 fuel.</Original>
-			<German>Erstattet: 50 Nachschub und 50 Kraftstoff.</German>
-			<Russian>Дает: 50 предметов снабжения и 50 единиц топлива.</Russian>
-			<Italian>Rimborso: 50 approvvigionamenti e 50 carburante.</Italian>
-			<Chinesesimp>回收：50补给和50燃料。</Chinesesimp>
-			<Chinese>回收：50 補給和 50 燃料。</Chinese>
-			<Turkish>Veriyor: 50 ikmal ve 50 benzin.</Turkish>
-			<Portuguese>Fornece: 50 de suprimento e 50 de combustível.</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_CONFIRM">
-			<Original>Confirm Mission</Original>
-			<German>Auftrag bestätigen</German>
-			<Russian>Подтвердить миссию</Russian>
-			<Italian>Conferma missione</Italian>
-			<Chinesesimp>执行任务</Chinesesimp>
-			<Chinese>執行任務</Chinese>
-			<Turkish>Onayla</Turkish>
-			<Portuguese>Confirmar Missão</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_CANCEL">
-			<Original>Abort Mission</Original>
-			<German>Auftrag abbrechen</German>
-			<Russian>Отменить миссию</Russian>
-			<Italian>Termina missione</Italian>
-			<Chinesesimp>放弃任务</Chinesesimp>
-			<Chinese>放棄任務</Chinese>
-			<Turkish>İptal et</Turkish>
-			<Portuguese>Abortar Missão</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_CANTAFFORD">
-			<Original>Not enough resources</Original>
-			<German>Nicht genug Ressourcen</German>
-			<Russian>недостаточно ресурсов</Russian>
-			<Italian>Risorse insufficenti</Italian>
-			<Chinesesimp>资源不足</Chinesesimp>
-			<Chinese>資源不足</Chinese>
-			<Turkish>Yetersiz kaynak</Turkish>
-			<Portuguese>Sem recursos suficientes</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_ROUTETITLE">
-			<Original>Mission planning</Original>
-			<German>Auftragsplanung</German>
-			<Russian>Планирование миссии</Russian>
-			<Italian>Pianificazione degli ordini</Italian>
-			<Chinesesimp>任务计划</Chinesesimp>
-			<Chinese>任務計畫</Chinese>
-			<Turkish>Planlama</Turkish>
-			<Portuguese>Planejamento de missão</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_LABELA">
-			<Original>Destination A</Original>
-			<German>Ziel A</German>
-			<Russian>Пункт назначения A</Russian>
-			<Italian>Destinazione A</Italian>
-			<Chinesesimp>地点 A</Chinesesimp>
-			<Chinese>地點 A</Chinese>
-			<Turkish>A istikameti</Turkish>
-			<Portuguese>Destino A</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_LABELB">
-			<Original>Destination B</Original>
-			<German>Ziel B</German>
-			<Russian>Пункт назначения В</Russian>
-			<Italian>Destinazione B</Italian>
-			<Chinesesimp>地点 B</Chinesesimp>
-			<Chinese>地點 B</Chinese>
-			<Turkish>B istikameti</Turkish>
-			<Portuguese>Destino B</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TT_SUPPLY">
-			<Original>Supplies value from here to the other destination. (only whole numbers)</Original>
-			<German>Nachschubmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
-			<Russian>Расставляет стоимость отсюда до другого пункта назначения. (Целые числа)</Russian>
-			<Italian>Valore approvvigionamenti da qui all'altra destinazione. (solo numeri interi)</Italian>
-			<Chinesesimp>从这里运往另一地点的补给数量。（请用整数）</Chinesesimp>
-			<Chinese>從這裡運往另一地點的補給數量。（請用整數）</Chinese>
-			<Turkish>Burdan diğer istikamete gidecek ikmaller. (sadece sayılar)</Turkish>
-			<Portuguese>Valores de suprimento daqui para o outro destino. (apenas valores inteiros)</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TT_AMMO">
-			<Original>Ammo value from here to the other destination. (only whole numbers)</Original>
-			<German>Munitionsmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
-			<Russian>Боеприпасы отсюда до другого места назначения. (Целые числа)</Russian>
-			<Italian>Valore munizioni da qui all'altra destinazione. (solo numeri interi)</Italian>
-			<Chinesesimp>从这里运往另一地点的弹药数量。（请用整数）</Chinesesimp>
-			<Chinese>從這裡運往另一地點的彈藥數量。（請用整數）</Chinese>
-			<Turkish>Burdan diğer istikamete gidecek mermiler. (sadece sayılar)</Turkish>
-			<Portuguese>Valores de munição daqui para o outro destino. (apenas valores inteiros)</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_TT_FUEL">
-			<Original>Fuel value from here to the other destination. (only whole numbers)</Original>
-			<German>Kraftstoffmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
-			<Russian>Топливо отсюда до другого места назначения. (Целые числа)</Russian>
-			<Italian>Valore carburante da qui all'altra destinazione. (solo numeri interi)</Italian>
-			<Chinesesimp>从这里运往另一地点的燃料数量。（请用整数）</Chinesesimp>
-			<Chinese>從這裡運往另一地點的油料數量。（請用整數）</Chinese>
-			<Turkish>Burdan diğer istikamete gidecek benzinler. (sadece sayılar)</Turkish>
-			<Portuguese>Valores de combustível daqui para o outro destino. (apenas valores inteiros)</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_SAVE_ERROR">
-			<Original>Your mission is not possible.</Original>
-			<German>Auftrag nicht möglich.</German>
-			<Russian>Ваша миссия не возможна.</Russian>
-			<Italian>La tua missione non è possibile.</Italian>
-			<Chinesesimp>无法执行你的任务。</Chinesesimp>
-			<Chinese>無法執行你的任務。</Chinese>
-			<Turkish>Bu istikamet imkansız.</Turkish>
-			<Portuguese>Não é possível executar a missão designada.</Portuguese>
-		</Key>
-		<Key ID="STR_LOGISTIC_STANDBY_ERROR">
-			<Original>You can't abort this mission at the moment.</Original>
-			<German>Du kannst diesen Auftrag momentan nicht abbrechen.</German>
-			<Russian>На данный момент вы не можете прервать эту миссию.</Russian>
-			<Italian>Non puoi terminare la missione in questo momento.</Italian>
-			<Chinesesimp>目前你不能放弃此任务。</Chinesesimp>
-			<Chinese>目前你不能放棄此任務。</Chinese>
-			<Turkish>Bu görevi şuan iptal edemezsiniz.</Turkish>
-			<Portuguese>Não é possível abortar esta missão neste momento.</Portuguese>
-		</Key>
+        <!-- Added or changed in v0.95 -->
+        <Key ID="STR_INDIV_FLAG">
+            <Original>Killah Potatoes flag</Original>
+            <German>Killah Potatoes Flagge</German>
+            <Spanish>Bandera de Killah Potatoes</Spanish>
+            <Russian>КР флаг</Russian>
+            <Italian>Bandiera dei Killah Potatoes</Italian>
+            <Chinesesimp>Killah Potatoes旗</Chinesesimp>
+            <Chinese>Killah Potatoes旗</Chinese>
+            <Turkish>Killah Potatoes bayrağı</Turkish>
+            <Portuguese>Bandeira da Killah Potatoes</Portuguese>
+        </Key>
+        <Key ID="STR_SMALL_STORAGE">
+            <Original>Small storage area</Original>
+            <German>Kleiner Lagerbereich</German>
+            <Spanish>Almacén pequeño</Spanish>
+            <Russian>Небольшая платформа склада</Russian>
+            <Italian>Area deposito piccola</Italian>
+            <Chinesesimp>小型货物仓储区</Chinesesimp>
+            <Chinese>小型貨物倉儲區</Chinese>
+            <Turkish>Küçük depo</Turkish>
+            <Portuguese>Depósito pequeno</Portuguese>
+        </Key>
+        <Key ID="STR_LARGE_STORAGE">
+            <Original>Large storage area</Original>
+            <German>Großer Lagerbereich</German>
+            <Spanish>Almacén grande</Spanish>
+            <Russian>Большая платформа склада</Russian>
+            <Italian>Area deposito grande</Italian>
+            <Chinesesimp>大型货物仓储区</Chinesesimp>
+            <Chinese>大型貨物倉儲區</Chinese>
+            <Turkish>Büyük depo</Turkish>
+            <Portuguese>Depósito grande</Portuguese>
+        </Key>
+        <Key ID="STR_RECYCLE_BUILDING">
+            <Original>Salvage Depot</Original>
+            <German>Demontageeinrichtung</German>
+            <Russian>Собрать склад</Russian>
+            <Italian>Edificio smaltimento rifiuti</Italian>
+            <Chinesesimp>回收站</Chinesesimp>
+            <Chinese>回收站</Chinese>
+            <Turkish>Dönüşüm deposu</Turkish>
+            <Portuguese>Centro de desmanche de veículos</Portuguese>
+        </Key>
+        <Key ID="STR_HELI_BUILDING">
+            <Original>Flight Control</Original>
+            <German>Flugkontrolle</German>
+            <Spanish>Torre de Control Aéreo</Spanish>
+            <Russian>Управление полетом</Russian>
+            <Italian>Torre di controllo Aerea</Italian>
+            <Chinesesimp>空管塔台</Chinesesimp>
+            <Chinese>空管塔台</Chinese>
+            <Turkish>Uçuş Kontrol</Turkish>
+            <Portuguese>Controle de tráfego aéreo</Portuguese>
+        </Key>
+        <Key ID="STR_HELI_SLOT">
+            <Original>Helipad</Original>
+            <German>Helikopterlandeplatz</German>
+            <Spanish>Helipuerto</Spanish>
+            <Russian>Верт.площадка</Russian>
+            <Italian>Eliporto</Italian>
+            <Chinesesimp>停机坪</Chinesesimp>
+            <Chinese>停機坪</Chinese>
+            <Turkish>Heliped</Turkish>
+            <Portuguese>Heliporto</Portuguese>
+        </Key>
+        <Key ID="STR_PLANE_SLOT">
+            <Original>Tent Hangar</Original>
+            <German>Zelthangar</German>
+            <Spanish>Hangar de aviones</Spanish>
+            <Russian>Ангар</Russian>
+            <Italian>Hangar Aereo</Italian>
+            <Chinesesimp>机库</Chinesesimp>
+            <Chinese>機庫</Chinese>
+            <Turkish>Çadırdan hangar</Turkish>
+            <Portuguese>Hangar para aeronaves</Portuguese>
+        </Key>
+        <Key ID="STR_BOX_CANTSTORE">
+            <Original>There is no free storage area nearby.</Original>
+            <German>Keine freie Lagerfläche in der Nähe.</German>
+            <Spanish>No hay sitio de almacenamiento cercano</Spanish>
+            <Russian>Рядом с вами нет свободного места</Russian>
+            <Italian>Non c'è un area deposito nelle vicinanze</Italian>
+            <Chinesesimp>这附近没有空闲的仓储区</Chinesesimp>
+            <Chinese>這附近沒有具備足夠空間的倉儲區</Chinese>
+            <Turkish>Yakınlarda boş depo yok</Turkish>
+            <Portuguese>Não há depósito disponível nas proximidades.</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_STORE_CRATE">
+            <Original>-- STORE CRATE</Original>
+            <German>-- KISTE EINLAGERN</German>
+            <Spanish>-- CAJA DE ALMACENAJE</Spanish>
+            <Russian>-- ХРАНЕНИЕ МАГАЗИНА</Russian>
+            <Italian>-- DEPOSITA CASSA</Italian>
+            <Chinesesimp>-- 仓储货箱</Chinesesimp>
+            <Chinese>-- 倉儲貨物</Chinese>
+            <Turkish>-- KUTUYU DEPOLA</Turkish>
+            <Portuguese>-- ARMAZENAR CAIXA NO DEPÓSITO</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_UNSTORE_SUPPLY">
+            <Original>-- UNLOAD SUPPLY CRATE</Original>
+            <German>-- NACHSCHUB ABLADEN</German>
+            <Spanish>-- DESCARGA CAJA DE SUMINISTRO</Spanish>
+            <Russian>-- ЗАГРУЗИТЬ СРОК ПОСТАВКИ</Russian>
+            <Italian>-- SCARICA CASSA RIFORNIMENTI</Italian>
+            <Chinesesimp>-- 卸载补给箱</Chinesesimp>
+            <Chinese>-- 卸載補給箱</Chinese>
+            <Turkish>-- İKMAL KUTUSUNU ÇIKAR</Turkish>
+            <Portuguese>-- DESCARREGAR CAIXA DE SUPRIMENTOS</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_UNSTORE_AMMO">
+            <Original>-- UNLOAD AMMO CRATE</Original>
+            <German>-- MUNITION ABLADEN</German>
+            <Spanish>-- DESCARGA CAJA DE MUNICIÓN</Spanish>
+            <Russian>-- РАЗГРУЗКА БОЕПРИПАСОВ</Russian>
+            <Italian>-- SCARICA CASSA MUNIZIONI</Italian>
+            <Chinesesimp>-- 卸载弹药箱</Chinesesimp>
+            <Chinese>-- 卸載彈藥箱</Chinese>
+            <Turkish>-- MERMİ KUTUSUNU ÇIKAR</Turkish>
+            <Portuguese>-- DESCARREGAR CAIXA DE MUNIÇÃO</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_UNSTORE_FUEL">
+            <Original>-- UNLOAD FUEL CRATE</Original>
+            <German>-- KRAFTSTOFF ABLADEN</German>
+            <Spanish>-- DESCARGA CAJA DE COMBUSTIBLE</Spanish>
+            <Russian>-- РАЗГРУЗКА ТОПЛИВА</Russian>
+            <Italian>-- SCARICA CASSA CARBURANTE</Italian>
+            <Chinesesimp>-- 卸载燃料箱</Chinesesimp>
+            <Chinese>-- 卸載油料箱</Chinese>
+            <Turkish>-- BENZIN KUTUSUNU ÇIKAR</Turkish>
+            <Portuguese>-- DESCARREGAR BARRIS DE COMBUSTÍVEL</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_CRATE_VALUE">
+            <Original>-- CHECK CONTENT</Original>
+            <German>-- INHALT PRÜFEN</German>
+            <Spanish>-- COMPROBAR CONTENIDO</Spanish>
+            <Russian>-- ПРОВЕРИТЬ СОДЕРЖАНИЕ</Russian>
+            <Italian>-- CONTROLLA CARICO</Italian>
+            <Chinesesimp>-- 检查存货</Chinesesimp>
+            <Chinese>-- 檢查存貨</Chinese>
+            <Turkish>-- İÇİNDEKİLER KONTROL ET</Turkish>
+            <Portuguese>-- CHECAR CONTEÚDO</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_CRATE_VALUE_HINT">
+            <Original>Crate contains %1 resources</Original>
+            <German>Kiste beinhaltet %1 Ressourcen</German>
+            <Spanish>La caja contiene %1 recursos</Spanish>
+            <Russian>Ящик содержит %1 ресурсов</Russian>
+            <Italian>La cassa continene %1 risorse</Italian>
+            <Chinesesimp>该货箱装有%1资源</Chinesesimp>
+            <Chinese>該貨箱裝有 %1 資源</Chinese>
+            <Turkish>Kutuda %1 kaynak var</Turkish>
+            <Portuguese>Caixa contém %1 recursos</Portuguese>
+        </Key>
+        <Key ID="STR_VECACTION">
+            <Original>-- Change alignment</Original>
+            <German>-- Ausrichtung ändern</German>
+            <Spanish>-- Cambiar alineación</Spanish>
+            <Russian>-- Изменить выравнивание</Russian>
+            <Italian>-- Cambia allineamento</Italian>
+            <Chinesesimp>-- 更改对齐方案</Chinesesimp>
+            <Chinese>-- 變更對齊方式</Chinese>
+            <Turkish>-- Hizaları değiştir</Turkish>
+            <Portuguese>-- Mudar alinhamento</Portuguese>
+        </Key>
+        <Key ID="STR_CANCEL_ERROR">
+            <Original>Not enough free storage space</Original>
+            <German>Nicht genug Lagerkapazität</German>
+            <Spanish>No hay suficiente espacio disponible</Spanish>
+            <Russian>Недостаточно свободного места для хранения</Russian>
+            <Italian>Non c'è abbastanza spazio disponibile</Italian>
+            <Chinesesimp>没有足够的仓储空间</Chinesesimp>
+            <Chinese>沒有足夠的倉儲空間</Chinese>
+            <Turkish>Yeteri kadar boş alan yok</Turkish>
+            <Portuguese>Não há espaço de armazenamento suficiente</Portuguese>
+        </Key>
+        <Key ID="STR_PREPLACED_ERROR">
+            <Original>You can't recycle preplaced objects</Original>
+            <German>Vorplatzierte Objekte können nicht recycelt werden</German>
+            <Russian>Вы не можете повторно использовать предварительно размещенные объекты</Russian>
+            <Italian>Non puoi riciclare oggetti statici</Italian>
+            <Chinesesimp>你不能回收预置物体</Chinesesimp>
+            <Chinese>你不能回收預置物件</Chinese>
+            <Turkish>Koyulmayan objeleri geri dönüştüremezsiniz</Turkish>
+            <Portuguese>Você não pode reciclar objetos pré inseridos</Portuguese>
+        </Key>
+        <Key ID="STR_NORECBUILDING_ERROR">
+            <Original>Can't recycle:\nNo Salvage Depot in FOB area</Original>
+            <German>Wiederverwerten nicht möglich:\nKeine Demontageeinrichtung im Bereich der FOB</German>
+            <Russian>Невозможно выполнить переработку:\nNo месте аварийного склада в области FOB</Russian>
+            <Italian>Nessun edificio per il riciclaggio presente nell'area</Italian>
+            <Chinesesimp>无法回收：\n前哨区域内没有回收站</Chinesesimp>
+            <Chinese>無法回收：\n前線基地區域內沒有回收站</Chinese>
+            <Turkish>Geri dönüşemez:\nYakınlarda Dönüşüm Deposu yok</Turkish>
+            <Portuguese>Não é possível reciclar:\nNão há centro de desmanche de veículos na área da FOB</Portuguese>
+        </Key>
+        <Key ID="STR_REASSIGN_ZEUS">
+            <Original>-- REASSIGN ZEUS</Original>
+            <German>-- ZEUS NEU ZUWEISEN</German>
+            <Russian>-- РЕАГИРОВАТЬ ZEUS</Russian>
+            <Italian>-- RIASSEGNA ZEUS</Italian>
+            <Chinesesimp>-- 重新分配ZEUS</Chinesesimp>
+            <Chinese>-- 重新分配宙斯</Chinese>
+            <Turkish>-- ZEUSU SEÇ</Turkish>
+            <Portuguese>-- REDESIGNAR ZEUS</Portuguese>
+        </Key>
+        <Key ID="STR_RESOURCE_GLOBAL">
+            <Original>GLOBAL</Original>
+            <German>GESAMT</German>
+            <Russian>ГЛОБАЛЬНЫЙ</Russian>
+            <Italian>GLOBALE</Italian>
+            <Chinesesimp>总览</Chinesesimp>
+            <Chinese>總覽</Chinese>
+            <Turkish>KÜRESEL</Turkish>
+            <Portuguese>GLOBAL</Portuguese>
+        </Key>
+        <Key ID="STR_RESOURCE_GLOBAL_ACTION">
+            <Original>-- Switch resource display</Original>
+            <German>-- Ressourcenanzeige wechseln</German>
+            <Russian>-- Переключение отображения ресурсов</Russian>
+            <Italian>-- Cambia visualizzazione risorse</Italian>
+            <Chinesesimp>-- 切换资源显示</Chinesesimp>
+            <Chinese>-- 切換資源顯示</Chinese>
+            <Turkish>-- Kaynak bölgesini değiştir</Turkish>
+            <Portuguese>-- Alterar painel de recursos</Portuguese>
+        </Key>
+        <Key ID="STR_BLACKLISTED_ITEM_FOUND">
+            <Original>Following items are not allowed:\n%1</Original>
+            <German>Folgende Gegenstände sind nicht erlaubt:\n%1</German>
+            <Russian>Следующие элементы не разрешены:\n%1</Russian>
+            <Italian>Questi elementi non sono ammessi:\n%1</Italian>
+            <Chinesesimp>以下物品已被禁用：\n%1</Chinesesimp>
+            <Chinese>以下品已被禁用：\n%1</Chinese>
+            <Turkish>Şu eşyalar yasaklı:\n%1</Turkish>
+            <Portuguese>Os seguintes itens não são permitidos:\n%1</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_ACTION">
+            <Original>-- Production Settings</Original>
+            <German>-- Produktionseinstellungen</German>
+            <Russian>-- Настройки производства</Russian>
+            <Italian>-- Impostazioni produzione</Italian>
+            <Chinesesimp>-- 产出设定</Chinesesimp>
+            <Chinese>-- 生產設定</Chinese>
+            <Turkish>-- Üretim ayarları</Turkish>
+            <Portuguese>-- Definições de Produção</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_HEADER">
+            <Original>Production Settings</Original>
+            <German>Produktionseinstellungen</German>
+            <Russian>Настройки производства</Russian>
+            <Italian>Impostazioni Produzione</Italian>
+            <Chinesesimp>产出设定</Chinesesimp>
+            <Chinese>生產設定</Chinese>
+            <Turkish>Üretim ayarları</Turkish>
+            <Portuguese>Definições de Produção</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_TYPE">
+            <Original>Sector Type:</Original>
+            <German>Sektortyp:</German>
+            <Russian>Тип сектора:</Russian>
+            <Italian>Tipo Settore:</Italian>
+            <Chinesesimp>战区类型：</Chinesesimp>
+            <Chinese>戰區類型：</Chinese>
+            <Turkish>Sektör türü</Turkish>
+            <Portuguese>Classe do setor:</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_CITY">
+            <Original>City</Original>
+            <German>Stadt</German>
+            <Russian>Город</Russian>
+            <Italian>Città</Italian>
+            <Chinesesimp>城市</Chinesesimp>
+            <Chinese>城市</Chinese>
+            <Turkish>Şehir</Turkish>
+            <Portuguese>Cidade</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_FACTORY">
+            <Original>Factory</Original>
+            <German>Fabrik</German>
+            <Russian>Завод</Russian>
+            <Italian>Fabbrica</Italian>
+            <Chinesesimp>工厂</Chinesesimp>
+            <Chinese>工廠</Chinese>
+            <Turkish>Fabrika</Turkish>
+            <Portuguese>Fábrica</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_PRODUCING">
+            <Original>Producing:</Original>
+            <German>Produziert:</German>
+            <Russian>Производства:</Russian>
+            <Italian>Prodotto:</Italian>
+            <Chinesesimp>正在生产：</Chinesesimp>
+            <Chinese>正在生產：</Chinese>
+            <Turkish>Üretiyor</Turkish>
+            <Portuguese>Produzindo:</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_NOTHING">
+            <Original>Nothing</Original>
+            <German>Nichts</German>
+            <Russian>Ничего</Russian>
+            <Italian>Niente</Italian>
+            <Chinesesimp>无</Chinesesimp>
+            <Chinese>無</Chinese>
+            <Turkish>Hiçbirşey</Turkish>
+            <Portuguese>Nada</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_STORAGE">
+            <Original>Storage:</Original>
+            <German>Lagerbereich:</German>
+            <Russian>Место хранения:</Russian>
+            <Italian>Area Stoccaggio:</Italian>
+            <Chinesesimp>仓储：</Chinesesimp>
+            <Chinese>倉儲：</Chinese>
+            <Turkish>Depo:</Turkish>
+            <Portuguese>Depósito:</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_NOSTORAGE">
+            <Original>Not present</Original>
+            <German>Nicht vorhanden</German>
+            <Russian>нет</Russian>
+            <Italian>Inesistente</Italian>
+            <Chinesesimp>仓储：</Chinesesimp>
+            <Chinese>沒有倉儲物品</Chinese>
+            <Turkish>Depolama yok</Turkish>
+            <Portuguese>Inexistente</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_TIMER">
+            <Original>Time left:</Original>
+            <German>Verbl. Zeit:</German>
+            <Russian>Время вышло:</Russian>
+            <Italian>Tempo rimasto:</Italian>
+            <Chinesesimp>剩余时间：</Chinesesimp>
+            <Chinese>剩餘時間：</Chinese>
+            <Turkish>Kalan süre:</Turkish>
+            <Portuguese>Tempo restante:</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_NOTIMER">
+            <Original>No production</Original>
+            <German>Keine Produktion</German>
+            <Russian>Нет производства</Russian>
+            <Italian>Nessuna produzione:</Italian>
+            <Chinesesimp>无产出</Chinesesimp>
+            <Chinese>沒有產出</Chinese>
+            <Turkish>Üretim yok</Turkish>
+            <Portuguese>Sem produção</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_MINUTES">
+            <Original>%1 minutes</Original>
+            <German>%1 Minuten</German>
+            <Russian>%1 Минут</Russian>
+            <Italian>%1 Minuti</Italian>
+            <Chinesesimp>%1分钟</Chinesesimp>
+            <Chinese>%1 分鐘</Chinese>
+            <Turkish>%1 dakika</Turkish>
+            <Portuguese>%1 minutos</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_FACILITIES">
+            <Original>Facilities available</Original>
+            <German>Verfügbare Einrichtungen</German>
+            <Russian>Услуги доступны</Russian>
+            <Italian>Strutture Disponibili</Italian>
+            <Chinesesimp>可用工厂</Chinesesimp>
+            <Chinese>可用工廠</Chinese>
+            <Turkish>Bölgeler hazır</Turkish>
+            <Portuguese>Instalações disponíveis</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_STORAGEDETAIL">
+            <Original>Stock Overview</Original>
+            <German>Übersicht Lagerbestände</German>
+            <Russian>Обзор запасов</Russian>
+            <Italian>Scorte</Italian>
+            <Chinesesimp>仓储总览</Chinesesimp>
+            <Chinese>倉儲總覽</Chinese>
+            <Turkish>Stok Listesi</Turkish>
+            <Portuguese>Visão geral do armazém</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_CRATE">
+            <Original>%1 Crate</Original>
+            <German>%1 Kiste</German>
+            <Russian>%1 Ящик</Russian>
+            <Italian>%1 Cassa</Italian>
+            <Chinesesimp>%1箱</Chinesesimp>
+            <Chinese>%1 箱</Chinese>
+            <Turkish>%1 Kutu</Turkish>
+            <Portuguese>%1 Caixa</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_CRATES">
+            <Original>%1 Crates</Original>
+            <German>%1 Kisten</German>
+            <Russian>%1 Ящиков</Russian>
+            <Italian>%1 Casse</Italian>
+            <Chinesesimp>%1箱</Chinesesimp>
+            <Chinese>%1 箱</Chinese>
+            <Turkish>%1 Kutular</Turkish>
+            <Portuguese>%1 caixas</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_PRODUCE">
+            <Original>Choose Production</Original>
+            <German>Produktionswahl</German>
+            <Russian>Выбрать продукцию</Russian>
+            <Italian>Seleziona Produzione</Italian>
+            <Chinesesimp>选择产出</Chinesesimp>
+            <Chinese>選擇產出</Chinese>
+            <Turkish>Üretimi seç</Turkish>
+            <Portuguese>Selecione a produção</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_SAVED">
+            <Original>Sector setting saved.</Original>
+            <German>Sektoreinstellung gespeichert.</German>
+            <Russian>Настройки сектора сохранены.</Russian>
+            <Italian>Settaggi settore salvati.</Italian>
+            <Chinesesimp>战区设置已保存。</Chinesesimp>
+            <Chinese>戰區設定已保存。</Chinese>
+            <Turkish>Sektör ayarı kaydedildi.</Turkish>
+            <Portuguese>Definição do setor salva</Portuguese>
+        </Key>
+        <Key ID="STR_SECSTORAGEBUILD_ACTION">
+            <Original>-- Build storage --</Original>
+            <German>-- Lagerfläche bauen --</German>
+            <Russian>-- Создание хранилища --</Russian>
+            <Italian>-- Crea area di stoccaggio --</Italian>
+            <Chinesesimp>-- 建造仓储库 --</Chinesesimp>
+            <Chinese>-- 建造倉儲空間 --</Chinese>
+            <Turkish>-- Depolama aç --</Turkish>
+            <Portuguese>-- Construir depósito --</Portuguese>
+        </Key>
+        <Key ID="STR_SECSUPPLYBUILD_ACTION">
+            <Original>-- Build supply facility --</Original>
+            <German>-- Nachschubeinrichtung bauen --</German>
+            <Russian>-- Построить систему снабжения --</Russian>
+            <Italian>-- Crea impianto approvvigionamento --</Italian>
+            <Chinesesimp>-- 建造补给工厂 --</Chinesesimp>
+            <Chinese>-- 建造補給工廠 --</Chinese>
+            <Turkish>-- İkmal kutusu üretimi kur --</Turkish>
+            <Portuguese>-- Construir fábrica de suprimentos --</Portuguese>
+        </Key>
+        <Key ID="STR_SECAMMOBUILD_ACTION">
+            <Original>-- Build ammo facility --</Original>
+            <German>-- Munitionseinrichtung bauen --</German>
+            <Russian>-- Создать боеприпасы --</Russian>
+            <Italian>-- Crea impianto munizioni --</Italian>
+            <Chinesesimp>-- 建造弹药工厂 --</Chinesesimp>
+            <Chinese>-- 建造彈藥工廠 --</Chinese>
+            <Turkish>-- Mermi kutusu üretimi kur --</Turkish>
+            <Portuguese>-- Construir fábrica de munição --</Portuguese>
+        </Key>
+        <Key ID="STR_SECFUELBUILD_ACTION">
+            <Original>-- Build fuel facility --</Original>
+            <German>-- Kraftstoffeinrichtung bauen --</German>
+            <Russian>-- Построить топливный объект --</Russian>
+            <Italian>-- Crea impianto carburante --</Italian>
+            <Chinesesimp>-- 建造燃料工厂 --</Chinesesimp>
+            <Chinese>-- 建造油料工廠 --</Chinese>
+            <Turkish>-- Benzin kutusu üretimi kur --</Turkish>
+            <Portuguese>-- Construir refinaria de combustível --</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_FACFALSE">
+            <Original>Needed facility not built in sector.</Original>
+            <German>Benötigte Einrichtung nicht vorhanden.</German>
+            <Russian>Необходимый объект не построен в секторе.</Russian>
+            <Italian>Impianto necessario non costruito nel settore.</Italian>
+            <Chinesesimp>该战区内没有所需的工厂。</Chinesesimp>
+            <Chinese>該戰區內沒有所需的工廠。</Chinese>
+            <Turkish>İstenilen üretim sektörde kurulu değil.</Turkish>
+            <Portuguese>É necessária uma fábrica não construída neste setor</Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_FACBUILD_ERROR">
+            <Original>Not enough resources.\n\nYou need:\n%1 Supplies\n%2 Ammo\n%3 Fuel</Original>
+            <German>Nicht genug Ressourcen.\n\nDu benötigst:\n%1 Nachschub\n%2 Munition\n%3 Kraftstoff</German>
+            <Russian>Недостаточно ресурсов.\n\nВам нужно: \n%1 Расходные материалы \n%2 Боеприпасы \n%3 Топливо
+            </Russian>
+            <Italian>Risorse insufficenti.\n\nHai bisogno di:\n%1 approvvigionamenti\n%2 Munizioni\n%3 Carburante
+            </Italian>
+            <Chinesesimp>资源不足。\n\n你需要\n%1补给\n%2弹药\n%3燃料</Chinesesimp>
+            <Chinese>資源不足。\n\n你需要\n%1補給\n%2彈藥\n%3油料</Chinese>
+            <Turkish>Yetersiz kaynak.\n\nLazım olan: \n%1 İkmal \n%2 Mermi\n%3 Benzin</Turkish>
+            <Portuguese>Sem recursos suficientes.\n\nVocê precisa de:\n%1 Suprimentos\n%2 Munição\n%3 Combustível
+            </Portuguese>
+        </Key>
+        <Key ID="STR_PRODUCTION_FACBUILD_SUCCESS">
+            <Original>Facility established.</Original>
+            <German>Einrichtung etabliert.</German>
+            <Russian>Учреждение создано.</Russian>
+            <Italian>Struttura creata.</Italian>
+            <Chinesesimp>工厂已建立。</Chinesesimp>
+            <Chinese>工廠已建立。</Chinese>
+            <Turkish>Üretim kuruldu.</Turkish>
+            <Portuguese>Estrutura criada.</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_AILOGISTICS">
+            <Original>AI Logistics Module</Original>
+            <German>AI Logistik Modul</German>
+            <Russian>Модуль логистики AI</Russian>
+            <Italian>AI Logistica</Italian>
+            <Chinesesimp>AI后勤模块</Chinesesimp>
+            <Chinese>AI 後勤模塊</Chinese>
+            <Turkish>AI Lojistiği</Turkish>
+            <Portuguese>Módulo Logístico automatizado</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_ACTION">
+            <Original>-- Logistic Overview</Original>
+            <German>-- Logistikübersicht</German>
+            <Russian>-- Обзор логистики</Russian>
+            <Italian>-- Vedi Logistica</Italian>
+            <Chinesesimp>-- 后勤总览</Chinesesimp>
+            <Chinese>-- 後勤總覽</Chinese>
+            <Turkish>-- Lojistik</Turkish>
+            <Portuguese>-- Visão Geral da Logística</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_HEADER">
+            <Original>Logistic Overview</Original>
+            <German>Logistikübersicht</German>
+            <Russian>Обзор логистики</Russian>
+            <Italian>Vedi Logistica</Italian>
+            <Chinesesimp>后勤总览</Chinesesimp>
+            <Chinese>後勤總覽</Chinese>
+            <Turkish>Lojistikler</Turkish>
+            <Portuguese>Visão Geral da Logística</Portuguese>
+        </Key>
+        <Key ID="STR_ADD">
+            <Original>Add</Original>
+            <German>Hinzfg</German>
+            <Russian>Добавить</Russian>
+            <Italian>Aggiungi</Italian>
+            <Chinesesimp>添加</Chinesesimp>
+            <Chinese>添加</Chinese>
+            <Turkish>Ekle</Turkish>
+            <Portuguese>Adicionar</Portuguese>
+        </Key>
+        <Key ID="STR_DEL">
+            <Original>Del</Original>
+            <German>Entf</German>
+            <Russian>Удалить</Russian>
+            <Italian>Elimina</Italian>
+            <Chinesesimp>删除</Chinesesimp>
+            <Chinese>刪除</Chinese>
+            <Turkish>Sil</Turkish>
+            <Portuguese>Deletar</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_STATUS">
+            <Original>Status:</Original>
+            <German>Status:</German>
+            <Russian>Статус</Russian>
+            <Italian>Stato:</Italian>
+            <Chinesesimp>状态：</Chinesesimp>
+            <Chinese>狀態：</Chinese>
+            <Turkish>Durum:</Turkish>
+            <Portuguese>Status:</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_STANDBY">
+            <Original>Standby</Original>
+            <German>Bereitschaft</German>
+            <Russian>Ожидание</Russian>
+            <Italian>In Attesa</Italian>
+            <Chinesesimp>等待中</Chinesesimp>
+            <Chinese>等待中</Chinese>
+            <Turkish>Beklemede</Turkish>
+            <Portuguese>Aguardando ordens</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_LOADING">
+            <Original>Loading</Original>
+            <German>Verladen</German>
+            <Russian>Загрузка</Russian>
+            <Italian>Caricamento</Italian>
+            <Chinesesimp>装载中</Chinesesimp>
+            <Chinese>裝載中</Chinese>
+            <Turkish>Yükleniyor</Turkish>
+            <Portuguese>Carregando</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TRAVEL">
+            <Original>On the way</Original>
+            <German>Unterwegs</German>
+            <Russian>В пути</Russian>
+            <Italian>In movimento</Italian>
+            <Chinesesimp>运输中</Chinesesimp>
+            <Chinese>運輸中</Chinese>
+            <Turkish>Yolda</Turkish>
+            <Portuguese>A caminho</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_ABORT">
+            <Original>Aborting mission</Original>
+            <German>Auftragsabbruch</German>
+            <Russian>Прерывание миссии</Russian>
+            <Italian>Termina missione</Italian>
+            <Chinesesimp>放弃任务中</Chinesesimp>
+            <Chinese>放棄任務中</Chinese>
+            <Turkish>İptal ediliyor</Turkish>
+            <Portuguese>Abortando missão</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_NORESSOURCES">
+            <Original>No resources</Original>
+            <German>Keine Ressourcen</German>
+            <Russian>Нет ресурсов</Russian>
+            <Italian>Risorse non avviabili</Italian>
+            <Chinesesimp>资源不足</Chinesesimp>
+            <Chinese>資源不足</Chinese>
+            <Turkish>Kaynak yok</Turkish>
+            <Portuguese>Sem recursos</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_NOSPACE">
+            <Original>No storagespace</Original>
+            <German>Kein Lagerplatz</German>
+            <Russian>Нет места для хранения</Russian>
+            <Italian>Spazio non avviabile</Italian>
+            <Chinesesimp>仓储空间不足</Chinesesimp>
+            <Chinese>倉儲空間不足</Chinese>
+            <Turkish>Depolama yeri yok</Turkish>
+            <Portuguese>Sem espaço no depósito</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_DESTINATION">
+            <Original>Next destination:</Original>
+            <German>Nächster Zielort:</German>
+            <Russian>Следующая цель:</Russian>
+            <Italian>Prossima destinazione:</Italian>
+            <Chinesesimp>下个目的地：</Chinesesimp>
+            <Chinese>下個目的地：</Chinese>
+            <Turkish>Diğer istikamet:</Turkish>
+            <Portuguese>Próximo destino:</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_LOADEDDETAIL">
+            <Original>Current convoy cargo</Original>
+            <German>Aktuelle Konvoiladung</German>
+            <Russian>Текущий состав конвоя</Russian>
+            <Italian>Carico convoglio attuale</Italian>
+            <Chinesesimp>当前车队货物</Chinesesimp>
+            <Chinese>目前車隊貨物</Chinese>
+            <Turkish>Şuanki konvoy kargosu</Turkish>
+            <Portuguese>Comboio de carga atual</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TRUCKCOUNT">
+            <Original>Assigned Trucks</Original>
+            <German>Zugeteilte LKWs</German>
+            <Russian>Назначенные грузовики</Russian>
+            <Italian>Camion Assegnati</Italian>
+            <Chinesesimp>已指派的卡车</Chinesesimp>
+            <Chinese>已指派的卡車</Chinese>
+            <Turkish>Seçili kamyonlar</Turkish>
+            <Portuguese>Veículos em uso</Portuguese>
+        </Key>
+        <Key ID="STR_LOGSTIC_BUYTRUCK">
+            <Original>Assign Truck</Original>
+            <German>LKW zuteilen</German>
+            <Russian>Назначить грузовик</Russian>
+            <Italian>Assegna camion</Italian>
+            <Chinesesimp>指派卡车</Chinesesimp>
+            <Chinese>指派卡車</Chinese>
+            <Turkish>Kamyon seç</Turkish>
+            <Portuguese>Designar Transporte</Portuguese>
+        </Key>
+        <Key ID="STR_LOGSTIC_SELLTRUCK">
+            <Original>Unassign Truck</Original>
+            <German>LKW abziehen</German>
+            <Russian>Отменить передачу</Russian>
+            <Italian>Rimuovi camion</Italian>
+            <Chinesesimp>取消指派卡车</Chinesesimp>
+            <Chinese>取消指派卡車</Chinese>
+            <Turkish>Seçimi iptal et</Turkish>
+            <Portuguese>Dispensar Transporte</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TT_BUYTRUCK">
+            <Original>Costs: 100 supplies and 100 fuel.</Original>
+            <German>Kosten: 100 Nachschub und 100 Kraftstoff.</German>
+            <Russian>Затраты: 100 поставок и 100 единиц топлива.</Russian>
+            <Italian>Costo: 100 approvvigionamenti e 100 carburante.</Italian>
+            <Chinesesimp>花费：100补给和100燃料。</Chinesesimp>
+            <Chinese>花費：100 補給和 100 油料。</Chinese>
+            <Turkish>Maliyeti : 100 ikmal ve 100 benzin</Turkish>
+            <Portuguese>Custa: 100 de suprimento e 100 de combustível.</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TT_SELLTRUCK">
+            <Original>Gives: 50 supplies and 50 fuel.</Original>
+            <German>Erstattet: 50 Nachschub und 50 Kraftstoff.</German>
+            <Russian>Дает: 50 предметов снабжения и 50 единиц топлива.</Russian>
+            <Italian>Rimborso: 50 approvvigionamenti e 50 carburante.</Italian>
+            <Chinesesimp>回收：50补给和50燃料。</Chinesesimp>
+            <Chinese>回收：50 補給和 50 燃料。</Chinese>
+            <Turkish>Veriyor: 50 ikmal ve 50 benzin.</Turkish>
+            <Portuguese>Fornece: 50 de suprimento e 50 de combustível.</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_CONFIRM">
+            <Original>Confirm Mission</Original>
+            <German>Auftrag bestätigen</German>
+            <Russian>Подтвердить миссию</Russian>
+            <Italian>Conferma missione</Italian>
+            <Chinesesimp>执行任务</Chinesesimp>
+            <Chinese>執行任務</Chinese>
+            <Turkish>Onayla</Turkish>
+            <Portuguese>Confirmar Missão</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_CANCEL">
+            <Original>Abort Mission</Original>
+            <German>Auftrag abbrechen</German>
+            <Russian>Отменить миссию</Russian>
+            <Italian>Termina missione</Italian>
+            <Chinesesimp>放弃任务</Chinesesimp>
+            <Chinese>放棄任務</Chinese>
+            <Turkish>İptal et</Turkish>
+            <Portuguese>Abortar Missão</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_CANTAFFORD">
+            <Original>Not enough resources</Original>
+            <German>Nicht genug Ressourcen</German>
+            <Russian>недостаточно ресурсов</Russian>
+            <Italian>Risorse insufficenti</Italian>
+            <Chinesesimp>资源不足</Chinesesimp>
+            <Chinese>資源不足</Chinese>
+            <Turkish>Yetersiz kaynak</Turkish>
+            <Portuguese>Sem recursos suficientes</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_ROUTETITLE">
+            <Original>Mission planning</Original>
+            <German>Auftragsplanung</German>
+            <Russian>Планирование миссии</Russian>
+            <Italian>Pianificazione degli ordini</Italian>
+            <Chinesesimp>任务计划</Chinesesimp>
+            <Chinese>任務計畫</Chinese>
+            <Turkish>Planlama</Turkish>
+            <Portuguese>Planejamento de missão</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_LABELA">
+            <Original>Destination A</Original>
+            <German>Ziel A</German>
+            <Russian>Пункт назначения A</Russian>
+            <Italian>Destinazione A</Italian>
+            <Chinesesimp>地点 A</Chinesesimp>
+            <Chinese>地點 A</Chinese>
+            <Turkish>A istikameti</Turkish>
+            <Portuguese>Destino A</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_LABELB">
+            <Original>Destination B</Original>
+            <German>Ziel B</German>
+            <Russian>Пункт назначения В</Russian>
+            <Italian>Destinazione B</Italian>
+            <Chinesesimp>地点 B</Chinesesimp>
+            <Chinese>地點 B</Chinese>
+            <Turkish>B istikameti</Turkish>
+            <Portuguese>Destino B</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TT_SUPPLY">
+            <Original>Supplies value from here to the other destination. (only whole numbers)</Original>
+            <German>Nachschubmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
+            <Russian>Расставляет стоимость отсюда до другого пункта назначения. (Целые числа)</Russian>
+            <Italian>Valore approvvigionamenti da qui all'altra destinazione. (solo numeri interi)</Italian>
+            <Chinesesimp>从这里运往另一地点的补给数量。（请用整数）</Chinesesimp>
+            <Chinese>從這裡運往另一地點的補給數量。（請用整數）</Chinese>
+            <Turkish>Burdan diğer istikamete gidecek ikmaller. (sadece sayılar)</Turkish>
+            <Portuguese>Valores de suprimento daqui para o outro destino. (apenas valores inteiros)</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TT_AMMO">
+            <Original>Ammo value from here to the other destination. (only whole numbers)</Original>
+            <German>Munitionsmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
+            <Russian>Боеприпасы отсюда до другого места назначения. (Целые числа)</Russian>
+            <Italian>Valore munizioni da qui all'altra destinazione. (solo numeri interi)</Italian>
+            <Chinesesimp>从这里运往另一地点的弹药数量。（请用整数）</Chinesesimp>
+            <Chinese>從這裡運往另一地點的彈藥數量。（請用整數）</Chinese>
+            <Turkish>Burdan diğer istikamete gidecek mermiler. (sadece sayılar)</Turkish>
+            <Portuguese>Valores de munição daqui para o outro destino. (apenas valores inteiros)</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_TT_FUEL">
+            <Original>Fuel value from here to the other destination. (only whole numbers)</Original>
+            <German>Kraftstoffmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
+            <Russian>Топливо отсюда до другого места назначения. (Целые числа)</Russian>
+            <Italian>Valore carburante da qui all'altra destinazione. (solo numeri interi)</Italian>
+            <Chinesesimp>从这里运往另一地点的燃料数量。（请用整数）</Chinesesimp>
+            <Chinese>從這裡運往另一地點的油料數量。（請用整數）</Chinese>
+            <Turkish>Burdan diğer istikamete gidecek benzinler. (sadece sayılar)</Turkish>
+            <Portuguese>Valores de combustível daqui para o outro destino. (apenas valores inteiros)</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_SAVE_ERROR">
+            <Original>Your mission is not possible.</Original>
+            <German>Auftrag nicht möglich.</German>
+            <Russian>Ваша миссия не возможна.</Russian>
+            <Italian>La tua missione non è possibile.</Italian>
+            <Chinesesimp>无法执行你的任务。</Chinesesimp>
+            <Chinese>無法執行你的任務。</Chinese>
+            <Turkish>Bu istikamet imkansız.</Turkish>
+            <Portuguese>Não é possível executar a missão designada.</Portuguese>
+        </Key>
+        <Key ID="STR_LOGISTIC_STANDBY_ERROR">
+            <Original>You can't abort this mission at the moment.</Original>
+            <German>Du kannst diesen Auftrag momentan nicht abbrechen.</German>
+            <Russian>На данный момент вы не можете прервать эту миссию.</Russian>
+            <Italian>Non puoi terminare la missione in questo momento.</Italian>
+            <Chinesesimp>目前你不能放弃此任务。</Chinesesimp>
+            <Chinese>目前你不能放棄此任務。</Chinese>
+            <Turkish>Bu görevi şuan iptal edemezsiniz.</Turkish>
+            <Portuguese>Não é possível abortar esta missão neste momento.</Portuguese>
+        </Key>
 
-		<!-- English adaptations in v0.95, need translations. -->
-		<Key ID="STR_MISSION_DESCRIPTION">
-			<Original>Liberate the region from the enemy oppression! Strategy will be key! Good luck soldiers.</Original>
-			<French>Avec le pouvoir de la Liberté et de la Démocratie votre mission est de libérer Altis de l'oppression de l'OPFOR.</French>
-			<German>Befreie das Gebiet von der feindlichen Unterdrückung mit der Kraft von Freiheit und Demokratie</German>
-			<Spanish>Con el poder de la Libertad y la Democracia, debes liberar Altis de la opresión del OPFOR</Spanish>
-			<Russian>С помощью сил "свободы" и "демократии" вы должны освободить Altis от угнетения OPFOR.</Russian>
-			<Italian>Libera la regione dall'oppressione nemica! La strategia è la chiave! Buona fortuna soldati.</Italian>
-			<Chinesesimp>从敌人手中解放这个地区！战略是制胜关键！士兵们祝你们好运。</Chinesesimp>
-			<Chinese>從敵人手中解放此區域！戰略是致勝關鍵！士兵們，祝好運！</Chinese>
-			<Turkish>Bu bölgeyi düşman etkisinden kurtar! Strateji anahtardır! Bol şanslar askerler.</Turkish>
-			<Portuguese>Libere a região da opressão inimiga! Estratégia será essencial! Boa sorte infantaria.</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE1">
-			<Original>1. Introduction</Original>
-			<French>1. Introduction</French>
-			<German>1. Einführung</German>
-			<Spanish>1. Introducción</Spanish>
-			<Russian>1. Введение</Russian>
-			<Italian>1. Introduzione</Italian>
-			<Chinesesimp>1. 介绍</Chinesesimp>
-			<Chinese>1. 介紹</Chinese>
-			<Turkish>1. Giriş</Turkish>
-			<Portuguese>1. Introdução</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT1">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			Hello gentlemen and welcome to the region, enemy forces have surprised us with a brutal and overwhelming offensive. They now have complete control of the region but with your efforts, that won't last long.&lt;br/&gt; &lt;br/&gt;
-			Our primary objective is simple: liberate the region from enemy control!&lt;br/&gt; &lt;br/&gt;
-			The road to victory will be long and dangerous. You will have to retake many sectors and acquire the necessary resources to improve the quantity and quality of friendly forces engaged in this campaign.&lt;br/&gt; &lt;br/&gt;
-			Moreover, enemy forces will most certainly react to our advance. You will have to engage in secondary operations to weaken a foe that fights with higher numbers and better equipment than you do.&lt;br/&gt; &lt;br/&gt;
-			In your efforts you will need the support of the local population, so always double-check what you're firing at!&lt;br/&gt; &lt;br/&gt;
-			Questions? HQ out.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Hallo die Herren und Willkommen im Kampfgebiet, der Feind hat uns mit einer brutalen und überwältigenden Offensive überrascht. Er hat jetzt die totale Kontrolle, aber Dank Ihres Einsatzes wird das nicht von Dauer sein.&lt;br/&gt; &lt;br/&gt;
-			Unser Primärziel ist einfach: Befreie das Gebiet von der Feindkontrolle!&lt;br/&gt; &lt;br/&gt;
-			Die Straße zum Sieg wird lang und gefährlich sein. Sie werden viele Sektoren zurück erobern müssen und sich die nötigen Ressourcen beschaffen, um Quantität und Qualität unserer Truppen zu verbessern.&lt;br/&gt; &lt;br/&gt;
-			Außerdem werden die Feindkräfte zeitnah auf unsere Fortschritte reagieren. Sie werden Sekundärziele bestreiten müssen, um den Feind zu schwächen, der uns in Truppenstärke und in Qualität der Ausrüstung überlegen ist.&lt;br/&gt; &lt;br/&gt;
-			In Ihren Anstrengungen wird es nötig sein die lokale Bevölkerung zu unterstützen. Achten Sie also stets darauf auf wen Sie schießen!&lt;br/&gt; &lt;br/&gt;
-			Fragen? HQ Ende.
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			Gentili signori e benvenuti nella regione, le forze nemiche ci hanno sorpreso con un'offensiva brutale e schiacciante. Ora hanno il controllo completo ma con i tuoi sforzi, non durerà a lungo.&lt;br/&gt; &lt;br/&gt;
-			Il nostro obiettivo primario è semplice: liberare la regione dal controllo nemico!&lt;br/&gt; &lt;br/&gt;
-			La strada per la vittoria sarà lunga e pericolosa. Dovrai riprendere molti settori e acquisire le risorse necessarie per migliorare la quantità e la qualità delle forze amiche impegnate in questa campagna.&lt;br/&gt; &lt;br/&gt;
-			Inoltre, le forze nemiche risponderanno certamente alla nostra offensiva. Dovrai impegnarti in operazioni secondarie per indebolire un nemico che combatte con numeri più elevati e attrezzature migliori di te.&lt;br/&gt; &lt;br/&gt;
-			Avrai bisogno del sostegno della popolazione locale, quindi controlla sempre quello a cui stai sparando!&lt;br/&gt; &lt;br/&gt;
-			Ci sono domande? HQ chiudo.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Приветствую Воины и добро пожаловать на фронт, вражеские силы удивили нас сильным и ожесточенным наступлением. Теперь вся территория под их контролем, но с вашими усилиями это не на долго.&lt;br/&gt; &lt;br/&gt;
-			Наша главная задача проста: освободить регион от вражеского контроля!&lt;br/&gt; &lt;br/&gt;
-			Путь к победе будет долгим и опасным. Вам нужно будет вернуть многие сектора и получить необходимые ресурсы для улучшения количества и качества дружественных сил, участвующих в этой кампании.&lt;br/&gt; &lt;br/&gt;
-			Более того, вражеские силы наверняка отреагируют на наше продвижение. Вам придется заняться второстепенными операциями, чтобы ослабить врага, которых становится все больше и с лучшим снаряжением, чем у вас..&lt;br/&gt; &lt;br/&gt;
-			В ваших интересах поддержка местного населения, поэтому всегда перепроверяйте то, куда вы стреляете!&lt;br/&gt; &lt;br/&gt;
-			Вопросы?&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			同志们辛苦了，欢迎来到这个地区，敌军以迅雷之势对我们造成了严重的打击。他们现已取得了本地的控制权，但相信在你的努力下，一切很快将会有所改善。&lt;br/&gt; &lt;br/&gt;
-			我们的主要任务很简单：从敌人手中夺回这个地区！&lt;br/&gt; &lt;br/&gt;
-			通往胜利的漫漫长路将会极其艰难。你们需要重夺大量战区，并为增强奋战中的友军质量与数量而获取的必要资源。&lt;br/&gt; &lt;br/&gt;
-			在此之上，敌人对我们的进攻绝不会视而不见。你们将必须通过次要行动去削弱有着比你更多更强装备的敌军。&lt;br/&gt; &lt;br/&gt;
-			你们行动的成败离不开当地人口的支持，因此开火前一定要再三确认目标！&lt;br/&gt; &lt;br/&gt;
-			还有问题么？指挥部通话完毕。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;br/&gt;&lt;br/&gt;
-			歡迎各位來到這裡，敵軍已經已迅雷之姿對我們造成了嚴重的打擊，並奪下了本地的控制權。但相信在你的加入與努力之下，一切都很將有首改善。&lt;br/&gt; &lt;br/&gt;
-			我們的任務非常簡單：從敵人手中奪回這塊地方！&lt;br/&gt; &lt;br/&gt;
-			這條路會非常艱辛，你們需要奪回大量的戰區，並為了重建而需獲取必要的資源。&lt;br/&gt; &lt;br/&gt;
-			在此同時，敵人絕對不會對我們的進攻視而不見，只要我們對他們越具威脅，他們將越派出強力的部隊來嘗試殲滅我們，所以我們必須透過完成次要目標來降低威脅度。&lt;br/&gt; &lt;br/&gt;
-			最終，這次行動的成敗離不開當地民心的支持，所以開火前一定要再三確認！&lt;br/&gt; &lt;br/&gt;
-			還有任何問題嗎？指揮部通話完畢！&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Turkish>&lt;br/&gt;&lt;br/&gt;
-			Beyler ve bayanlar buraya hoşgeldiniz, düşman kuvvetleri bizi yıkıcı ve üstün güç ile karşıladılar. Şimdi bütün alanı hakimiyet altına aldılar ve siz geldiniz ki uzun süre böyle devam etmeyecektir.&lt;br/&gt; &lt;br/&gt;
-			İlk görevimiz basit; Bu bölgeyi düşman kontrolü altından kurtar!&lt;br/&gt; &lt;br/&gt;
-			Kazanmanın yolu uzun ve tehlikeli. Almanız gereken bir sürü sektor ve kaynaklar var. Bu kaynakları kullanarak bu adayı almaya çalışan dost birliklerimize destek çıkacaksınız.&lt;br/&gt; &lt;br/&gt;
-			Ve dahası düşman bizim gelişmemize takiben onlarda gelişecektir. İkincil görevlere giderek düşmanların gelişmesini önleyecek ve yeni mühimmatlar elde edeceksiniz.&lt;br/&gt; &lt;br/&gt;
-			Yerli halka da bir o kadar dikkat edin! Sıkmadan önce 2 kere kontrol edin!&lt;br/&gt; &lt;br/&gt;
-			Sorusu olan? Bağlantı kapandı. &lt;br/&gt; &lt;br/&gt;</Turkish>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Olá senhores, sejam bem-vindos à região. Forças inimigas nos surpreenderam com uma ofensiva brutal e absurda. Eles possuem agora controle completo sobre a região, porém com seus esforços, tal controle não irá durar por muito tempo.&lt;br/&gt; &lt;br/&gt;
-			Nosso objetivo primário é simples: Liberar a região do controle inimigo!&lt;br/&gt; &lt;br/&gt;
-			O caminho para vitória será longo e perigoso. Você terá que retomar dezenas de setores e adquirir os recursos necessários para desenvolver a quantidade e qualidade das forças aliadas engajadas nesta campanha.&lt;br/&gt; &lt;br/&gt;
-			Além disso, as forças inimigas certamente irão reagir aos nossos avanços. Você deverá engajar em operações secundárias para enfraquecer um inimigo que combate em maior número e com melhores equipamentos que você.&lt;br/&gt; &lt;br/&gt;
-			Em sua campanha, você precisará do apoio da população local, portanto, sempre confirme no que está disparando e em quem!&lt;br/&gt; &lt;br/&gt;
-			Perguntas? Quartel General, câmbio. QRT.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE2">
-			<Original>2. Starting the campaign!</Original>
-			<French>2. Débuter la campagne</French>
-			<German>2. Starten der Kampagne</German>
-			<Spanish>2. Comenzando la campaña</Spanish>
-			<Russian>2. С чего начать</Russian>
-			<Italian>2 .Inizio della Campagna</Italian>
-			<Chinesesimp>2. 开始战役！</Chinesesimp>
-			<Chinese>1. 開始戰役！</Chinese>
-			<Turkish>2. Göreve başlamak</Turkish>
-			<Portuguese>2. Iniciando a campanha!</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT2">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			You begin the campaign either onboard the USS Freedom, or at Chimera base, safe zones the enemy won't dare to attack. Your first choice is to choose where you want to deploy. At first you can only deploy at your starting position but as you progress, more options will become available such as Forward Operating Bases (FOB) and mobile respawns.&lt;br/&gt; &lt;br/&gt;
-			At your starting position you can choose your equipment from a complete Arsenal. You will also find your first FOB packaged inside a container, the Spartan-01 helicopter and a few other small transport helicopters.&lt;br/&gt; &lt;br/&gt;
-			You will have to ferry that container with the Spartan-01 (or choose to start with the first FOB already built). You can deploy this first FOB wherever you want (as long as you're 1km from the starting position and 300m from any sector), so it's up to you to choose the right place to start your campaign offensive.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Sie beginnen die Kampagne entweder an Bord der USS Freedom oder in der Chimera Basis, wobei es sich jeweils um eine sichere Zone handelt, die der Feind nicht wagen würde anzugreifen. Ihre erste Entscheidung ist es, zu wählen, wo sie eingesetzt werden wollen. Zuerst können sie nur an Ihrer Startposition einsetzen, aber je weiter Sie voran schreiten, umso mehr Möglichkeiten, wie Forward Operating Bases (FOB) und mobile Respawns, werden Ihnen offen stehen.&lt;br/&gt; &lt;br/&gt;
-			An Ihrer Startposition können Sie Ihre Ausrüstung aus einem kompletten Arsenal wählen. Außerdem finden Sie hier auch Ihre erste FOB verpackt in einem Container, den Spartan-01 Helikopter und ein paar kleine Transport-Helikopter&lt;br/&gt; &lt;br/&gt;
-			Sie werden diesen Container mit dem Spartan-01 verlegen müssen (oder Sie entscheiden sich, mit einer ersten, bereits gebauten FOB zu starten). Sie können diese erste FOB aufstellen, wo Sie wollen (solange sie 1km von der Startposition und 300m von einem Sektor entfernt ist), also liegt es an Ihnen, den richtigen Platz für den Start Ihrer Offensive zu finden.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			La campagna partirà dalla USS Freedom, o dalla base Chimera, sono zone sicure che il nemico non oserà attaccare. Prima di tutto bisogna scegliere dove schierarsi. All'inizio ci si può solo schierare nelle posizioni citate prima, ma mentre si progredisce, saranno disponibili ulteriori opzioni quali FOB e respawn mobili.&lt;br/&gt; &lt;br/&gt;
-			Nella posizione iniziale puoi scegliere la tua attrezzatura da un completo Arsenale. Troverete anche la prima FOB imballata all'interno di un container, l'elicottero Spartan-01 e qualche altro piccolo elicottero da trasporto.&lt;br/&gt; &lt;br/&gt;
-			Dovrete trasportare quel container con lo Spartan-01 (o scegliere di iniziare con la prima FOB già costruita). Puoi costruire la FOB dove vuoi (finché sei a 1 km dalla posizione iniziale e 300 metri da qualsiasi settore), quindi stà a voi scegliere il posto giusto per iniziare l'offensiva della vostra campagna.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Вы начинаете кампанию либо на борту Авионосца, либо на базе Химеры, в безопасных зонах, которые враг не посмеет атаковать. Ваш первый выбор - выбрать, где вы хотите развернуться. Сначала вы можете развертывать только в начальной позиции, но по мере продвижения вперед будут доступны дополнительные опции, такие как Forward Operating Bases (FOB) и мобильные респавны.&lt;br/&gt; &lt;br/&gt;
-			На стартовой позиции вы можете выбрать свое снаряжение из полного арсенала. Вы также найдете свой первый FOB, упакованный в контейнер, вертолет Spartan-01 и несколько других небольших транспортных вертолетов.&lt;br/&gt; &lt;br/&gt;
-			Вам придется переправить этот контейнер с помощью Spartan-01 (или начать с первого уже построенного FOB). Вы можете развернуть этот первый FOB везде, где хотите (пока вы в 1 км от стартовой позиции и 300 м от любого сектора), поэтому вам решать, какое место выбрать для начала наступления в вашей кампании.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			自由号航母或奇美拉基地——敌人绝不敢招惹的安全地带，将作为你作战的出发点。你的首个选择就是部署地点。一开始你仅能在出发点部署，但随着进度的深入，前进基地（前哨）和机动复活点等选项将会开启。&lt;br/&gt; &lt;br/&gt;
-			你可以在开始地点从军火库中选择你的装备。你也会在这里找到自己被打包在部署柜里的首个前哨、斯巴达1号直升机以及一些其它小型运输直升机。&lt;br/&gt; &lt;br/&gt;
-			你必须通过斯巴达1号来吊运前哨部署柜（或在游戏开始设置中开启部署起始前哨）。你可以将第一个前哨部署在任何想放置的地方（只要你在距离出发点1公里和战区300米之外的地方），因此，发起进攻的地点完全取决于你的选择。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;br/&gt;&lt;br/&gt;
-			起始的作戰基地，這裡是敵人絕對不敢招惹的安全地帶，也會是我們這次反攻號角的第一個音符。這裡會是你的作戰出發點，而你首先要進行的就是佈署地點。一開始你僅能在起始作戰基地佈署，但隨著戰線的深入，前線基地和機動復活點將會被啟用。&lt;br/&gt; &lt;br/&gt;
-			你可以在開始地點從軍火庫中自訂你的裝備，你也會在這裡找到已經被打包好的前線基地貨櫃、代號「斯巴達一號」的大型運輸直升機與其他空中載具。&lt;br/&gt; &lt;br/&gt;
-			你必須透過斯巴達一號來吊掛你的前線基地貨櫃進行佈署（或是在遊戲設定中選擇佈署起始前線基地）。你可以將第一個前線基地放置在任何你想放置的位置（只要距離起始作戰基地一公里、戰區三百公尺之外），因此，何時、何地發起進攻，將會全權由你掌握。&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Turkish>Görevinize USS Freedom'da başlayacaksınız veya Chimera Bölgesinde yani düşmanların saldıramayacağı güvenli bölgelerde. İlk işiniz nereye atlayacağınız olacaktır, siz bölgeleri aldıkça yeni FOB'ler ve mobil spawn merkezleri de açacaksınız.&lt;br/&gt; &lt;br/&gt;
-			Başladığınızda Arsenal (Cephanelik) den istediğiniz ekipmanı seçebilirsiniz. Bir FOB Konteynırı, SPARTAN-01 helikopteri ve birkaç taşıma helikopterine de ayrıca sahipsiniz.&lt;br/&gt; &lt;br/&gt;
-			SPARTAN-01 ile FOB Konteynırını istediğiniz yere götürüp bir FOB Bölgesi (başlangıç noktasından 1km diğer sektörlerden 300mt uzakta olmanız gerekli) açabilirsiniz ve saldırmaya o FOB'den devam edebilirsiniz.&lt;br/&gt; &lt;br/&gt;</Turkish>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Você iniciará a campanha abordo do porta-aviões USS Fredom ou na base operacional Chimera, instalações que o inimigo não se atreverá a atacar. Sua primeira escolha será definir onde irá mobilizar. Primeiramente somente poderá mobilizar na sua posição inicial, entretanto, conforme progredir, mais alternativas se tornarão disponíveis, como a Base de Operações Avançadas (FOB) e os respawns móveis.&lt;br/&gt; &lt;br/&gt;
-			Em sua posição inicial, você poderá escolher seu equipamento através de um arsenal completo. Você terá à sua disposição sua primeira FOB transportável, dentro de um contêiner. Também estará disponível o transporte aéreo de callsign Spartan-01 e mais alguns helicópteros de transporte.&lt;br/&gt; &lt;br/&gt;
-			Você deverá mover o mencionado contêiner utilizando a Spartan-01 (ou escolha começar com a primeira FOB já construída). Você poderá mobilizar esta FOB para onde desejar (desde que esteja a 1km do ponto inicial e a 300 metros de qualquer setor). Assim, depende apenas de você escolher o local ideal para iniciar sua campanha ofensiva.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE3">
-			<Original>3. Objective</Original>
-			<French>3. Objectif</French>
-			<German>3. Ziele</German>
-			<Spanish>3. Objetivo</Spanish>
-			<Russian>3. Цели и задачи</Russian>
-			<Italian>3. Obiettivi</Italian>
-			<Chinesesimp>3. 目标</Chinesesimp>
-			<Chinese>3. 目標</Chinese>
-			<Turkish>3. Objektifler</Turkish>
-			<Portuguese>3. Objetivo</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT3">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			The primary objective of this campaign is to remove enemy forces from the region entirely. To achieve this, you will have to liberate ALL major cities within the region! This is the only victory condition for the campaign but those cities are tough nuts to crack with only limited resources at your disposal and a well established enemy force. &lt;br/&gt; &lt;br/&gt;
-			To succeed, you will have to capture large number of different sectors, each with their own use.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Das Primärziel dieser Kampagne ist es, die Feindkräfte in dieser Region vollständig zu entfernen. Um dies zu erreichen, werden Sie ALLE Großstädte innerhalb dieser Region befreien müssen! Dies ist die einzige Bedingung zum Sieg, aber diese Städte sind schwer zu knacken, in Anbetracht unserer wenigen Ressourcen und einer gut aufgestellten Feindmacht.&lt;br/&gt; &lt;br/&gt;
-			Um das zu erreichen, werden Sie eine große Anzahl von verschiedensten Sektoren einnehmen, jeder mit seinen spezifischen Eigenschaften.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			L'obiettivo primario di questa campagna è di eliminare interamente le forze nemiche dalla regione. Per raggiungere questo obiettivo, dovrai liberare TUTTE le grandi città della regione! Questa è l'unica condizione di vittoria per la campagna, ma quste città sono difficili da liberare in quanto dovrete aver a disposizione numerose risorse e fronteggiare una forza nemica consolidata. &lt;br/&gt; &lt;br/&gt;
-			Per vincere, dovrai catturare un gran numero di settori diversi, ognuno con il proprio uso.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Основная цель этой кампании - полностью устранить силы противника из этого региона. Чтобы добиться этого, вам нужно будет освободить ВСЕ крупные города в регионе! Но эти города будут для вас крепкими орешками, их получится раскусить только ограничив поступление в них подкреплений, вражеские силы в них очень хорошо организованы. &lt;br/&gt; &lt;br/&gt;
-			Чтобы добиться успеха, вам нужно будет захватить большое количество различных секторов, каждый со своим собственным использованием.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			本战役的主要目标是彻底将敌军赶出这个地区。要达成这点，你必须解放本地区的所有主要城市！这虽是战役唯一的胜利条件，但在有限的进攻资源下这些城市极其棘手，并驻扎着大量敌军。&lt;br/&gt; &lt;br/&gt;
-			要想成功，你必须占领足够多不同的战区，而这些战区各有功效。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;br/&gt;&lt;br/&gt;
-			作戰的最終目標是徹底將敵軍趕出這個地區，要達到這個目的，你必須解放本地區的所有主要城市！雖然這是作戰的唯一勝利條件，但在資源有限的情況下進攻這些防禦良好、又駐紮大量守軍的城市根本是天方夜譚。&lt;br/&gt; &lt;br/&gt;
-			想要成功，你必須佔領各式各樣不同功效的戰區。&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			O objetivo primário desta campanha é remover completamente as forças inimigas da região. Para alçancar tal objetivo, você deverá liberar TODAS as principais cidades dentro da região! Esta é a única condição de vitória para a campanha, porém essas cidades serão difíceis de pacificar com recursos limitados à sua disposição. Além disso, as forças inimigas estão muito bem instaladas no território. &lt;br/&gt; &lt;br/&gt;
-			Para lograr êxito, você deverá capturar uma extensa quantidade de setores, cada um com sua própria base de recursos.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
+        <!-- English adaptations in v0.95, need translations. -->
+        <Key ID="STR_MISSION_DESCRIPTION">
+            <Original>Liberate the region from the enemy oppression! Strategy will be key! Good luck soldiers.
+            </Original>
+            <French>Avec le pouvoir de la Liberté et de la Démocratie votre mission est de libérer Altis de l'oppression
+                de l'OPFOR.
+            </French>
+            <German>Befreie das Gebiet von der feindlichen Unterdrückung mit der Kraft von Freiheit und Demokratie
+            </German>
+            <Spanish>Con el poder de la Libertad y la Democracia, debes liberar Altis de la opresión del OPFOR</Spanish>
+            <Russian>С помощью сил "свободы" и "демократии" вы должны освободить Altis от угнетения OPFOR.</Russian>
+            <Italian>Libera la regione dall'oppressione nemica! La strategia è la chiave! Buona fortuna soldati.
+            </Italian>
+            <Chinesesimp>从敌人手中解放这个地区！战略是制胜关键！士兵们祝你们好运。</Chinesesimp>
+            <Chinese>從敵人手中解放此區域！戰略是致勝關鍵！士兵們，祝好運！</Chinese>
+            <Turkish>Bu bölgeyi düşman etkisinden kurtar! Strateji anahtardır! Bol şanslar askerler.</Turkish>
+            <Portuguese>Libere a região da opressão inimiga! Estratégia será essencial! Boa sorte infantaria.
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE1">
+            <Original>1. Introduction</Original>
+            <French>1. Introduction</French>
+            <German>1. Einführung</German>
+            <Spanish>1. Introducción</Spanish>
+            <Russian>1. Введение</Russian>
+            <Italian>1. Introduzione</Italian>
+            <Chinesesimp>1. 介绍</Chinesesimp>
+            <Chinese>1. 介紹</Chinese>
+            <Turkish>1. Giriş</Turkish>
+            <Portuguese>1. Introdução</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT1">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                Hello gentlemen and welcome to the region, enemy forces have surprised us with a brutal and overwhelming
+                offensive. They now have complete control of the region but with your efforts, that won't last long.&lt;br/&gt;
+                &lt;br/&gt;
+                Our primary objective is simple: liberate the region from enemy control!&lt;br/&gt; &lt;br/&gt;
+                The road to victory will be long and dangerous. You will have to retake many sectors and acquire the
+                necessary resources to improve the quantity and quality of friendly forces engaged in this campaign.&lt;br/&gt;
+                &lt;br/&gt;
+                Moreover, enemy forces will most certainly react to our advance. You will have to engage in secondary
+                operations to weaken a foe that fights with higher numbers and better equipment than you do.&lt;br/&gt;
+                &lt;br/&gt;
+                In your efforts you will need the support of the local population, so always double-check what you're
+                firing at!&lt;br/&gt; &lt;br/&gt;
+                Questions? HQ out.&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Hallo die Herren und Willkommen im Kampfgebiet, der Feind hat uns mit einer brutalen und überwältigenden
+                Offensive überrascht. Er hat jetzt die totale Kontrolle, aber Dank Ihres Einsatzes wird das nicht von
+                Dauer sein.&lt;br/&gt; &lt;br/&gt;
+                Unser Primärziel ist einfach: Befreie das Gebiet von der Feindkontrolle!&lt;br/&gt; &lt;br/&gt;
+                Die Straße zum Sieg wird lang und gefährlich sein. Sie werden viele Sektoren zurück erobern müssen und
+                sich die nötigen Ressourcen beschaffen, um Quantität und Qualität unserer Truppen zu verbessern.&lt;br/&gt;
+                &lt;br/&gt;
+                Außerdem werden die Feindkräfte zeitnah auf unsere Fortschritte reagieren. Sie werden Sekundärziele
+                bestreiten müssen, um den Feind zu schwächen, der uns in Truppenstärke und in Qualität der Ausrüstung
+                überlegen ist.&lt;br/&gt; &lt;br/&gt;
+                In Ihren Anstrengungen wird es nötig sein die lokale Bevölkerung zu unterstützen. Achten Sie also stets
+                darauf auf wen Sie schießen!&lt;br/&gt; &lt;br/&gt;
+                Fragen? HQ Ende.
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                Gentili signori e benvenuti nella regione, le forze nemiche ci hanno sorpreso con un'offensiva brutale e
+                schiacciante. Ora hanno il controllo completo ma con i tuoi sforzi, non durerà a lungo.&lt;br/&gt; &lt;br/&gt;
+                Il nostro obiettivo primario è semplice: liberare la regione dal controllo nemico!&lt;br/&gt; &lt;br/&gt;
+                La strada per la vittoria sarà lunga e pericolosa. Dovrai riprendere molti settori e acquisire le
+                risorse necessarie per migliorare la quantità e la qualità delle forze amiche impegnate in questa
+                campagna.&lt;br/&gt; &lt;br/&gt;
+                Inoltre, le forze nemiche risponderanno certamente alla nostra offensiva. Dovrai impegnarti in
+                operazioni secondarie per indebolire un nemico che combatte con numeri più elevati e attrezzature
+                migliori di te.&lt;br/&gt; &lt;br/&gt;
+                Avrai bisogno del sostegno della popolazione locale, quindi controlla sempre quello a cui stai sparando!&lt;br/&gt;
+                &lt;br/&gt;
+                Ci sono domande? HQ chiudo.&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Приветствую Воины и добро пожаловать на фронт, вражеские силы удивили нас сильным и ожесточенным
+                наступлением. Теперь вся территория под их контролем, но с вашими усилиями это не на долго.&lt;br/&gt;
+                &lt;br/&gt;
+                Наша главная задача проста: освободить регион от вражеского контроля!&lt;br/&gt; &lt;br/&gt;
+                Путь к победе будет долгим и опасным. Вам нужно будет вернуть многие сектора и получить необходимые
+                ресурсы для улучшения количества и качества дружественных сил, участвующих в этой кампании.&lt;br/&gt;
+                &lt;br/&gt;
+                Более того, вражеские силы наверняка отреагируют на наше продвижение. Вам придется заняться
+                второстепенными операциями, чтобы ослабить врага, которых становится все больше и с лучшим снаряжением,
+                чем у вас..&lt;br/&gt; &lt;br/&gt;
+                В ваших интересах поддержка местного населения, поэтому всегда перепроверяйте то, куда вы стреляете!&lt;br/&gt;
+                &lt;br/&gt;
+                Вопросы?&lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                同志们辛苦了，欢迎来到这个地区，敌军以迅雷之势对我们造成了严重的打击。他们现已取得了本地的控制权，但相信在你的努力下，一切很快将会有所改善。&lt;br/&gt; &lt;br/&gt;
+                我们的主要任务很简单：从敌人手中夺回这个地区！&lt;br/&gt; &lt;br/&gt;
+                通往胜利的漫漫长路将会极其艰难。你们需要重夺大量战区，并为增强奋战中的友军质量与数量而获取的必要资源。&lt;br/&gt; &lt;br/&gt;
+                在此之上，敌人对我们的进攻绝不会视而不见。你们将必须通过次要行动去削弱有着比你更多更强装备的敌军。&lt;br/&gt; &lt;br/&gt;
+                你们行动的成败离不开当地人口的支持，因此开火前一定要再三确认目标！&lt;br/&gt; &lt;br/&gt;
+                还有问题么？指挥部通话完毕。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;br/&gt;&lt;br/&gt;
+                歡迎各位來到這裡，敵軍已經已迅雷之姿對我們造成了嚴重的打擊，並奪下了本地的控制權。但相信在你的加入與努力之下，一切都很將有首改善。&lt;br/&gt; &lt;br/&gt;
+                我們的任務非常簡單：從敵人手中奪回這塊地方！&lt;br/&gt; &lt;br/&gt;
+                這條路會非常艱辛，你們需要奪回大量的戰區，並為了重建而需獲取必要的資源。&lt;br/&gt; &lt;br/&gt;
+                在此同時，敵人絕對不會對我們的進攻視而不見，只要我們對他們越具威脅，他們將越派出強力的部隊來嘗試殲滅我們，所以我們必須透過完成次要目標來降低威脅度。&lt;br/&gt; &lt;br/&gt;
+                最終，這次行動的成敗離不開當地民心的支持，所以開火前一定要再三確認！&lt;br/&gt; &lt;br/&gt;
+                還有任何問題嗎？指揮部通話完畢！&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Turkish>&lt;br/&gt;&lt;br/&gt;
+                Beyler ve bayanlar buraya hoşgeldiniz, düşman kuvvetleri bizi yıkıcı ve üstün güç ile karşıladılar.
+                Şimdi bütün alanı hakimiyet altına aldılar ve siz geldiniz ki uzun süre böyle devam etmeyecektir.&lt;br/&gt;
+                &lt;br/&gt;
+                İlk görevimiz basit; Bu bölgeyi düşman kontrolü altından kurtar!&lt;br/&gt; &lt;br/&gt;
+                Kazanmanın yolu uzun ve tehlikeli. Almanız gereken bir sürü sektor ve kaynaklar var. Bu kaynakları
+                kullanarak bu adayı almaya çalışan dost birliklerimize destek çıkacaksınız.&lt;br/&gt; &lt;br/&gt;
+                Ve dahası düşman bizim gelişmemize takiben onlarda gelişecektir. İkincil görevlere giderek düşmanların
+                gelişmesini önleyecek ve yeni mühimmatlar elde edeceksiniz.&lt;br/&gt; &lt;br/&gt;
+                Yerli halka da bir o kadar dikkat edin! Sıkmadan önce 2 kere kontrol edin!&lt;br/&gt; &lt;br/&gt;
+                Sorusu olan? Bağlantı kapandı. &lt;br/&gt; &lt;br/&gt;
+            </Turkish>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Olá senhores, sejam bem-vindos à região. Forças inimigas nos surpreenderam com uma ofensiva brutal e
+                absurda. Eles possuem agora controle completo sobre a região, porém com seus esforços, tal controle não
+                irá durar por muito tempo.&lt;br/&gt; &lt;br/&gt;
+                Nosso objetivo primário é simples: Liberar a região do controle inimigo!&lt;br/&gt; &lt;br/&gt;
+                O caminho para vitória será longo e perigoso. Você terá que retomar dezenas de setores e adquirir os
+                recursos necessários para desenvolver a quantidade e qualidade das forças aliadas engajadas nesta
+                campanha.&lt;br/&gt; &lt;br/&gt;
+                Além disso, as forças inimigas certamente irão reagir aos nossos avanços. Você deverá engajar em
+                operações secundárias para enfraquecer um inimigo que combate em maior número e com melhores
+                equipamentos que você.&lt;br/&gt; &lt;br/&gt;
+                Em sua campanha, você precisará do apoio da população local, portanto, sempre confirme no que está
+                disparando e em quem!&lt;br/&gt; &lt;br/&gt;
+                Perguntas? Quartel General, câmbio. QRT.&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE2">
+            <Original>2. Starting the campaign!</Original>
+            <French>2. Débuter la campagne</French>
+            <German>2. Starten der Kampagne</German>
+            <Spanish>2. Comenzando la campaña</Spanish>
+            <Russian>2. С чего начать</Russian>
+            <Italian>2 .Inizio della Campagna</Italian>
+            <Chinesesimp>2. 开始战役！</Chinesesimp>
+            <Chinese>1. 開始戰役！</Chinese>
+            <Turkish>2. Göreve başlamak</Turkish>
+            <Portuguese>2. Iniciando a campanha!</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT2">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                You begin the campaign either onboard the USS Freedom, or at Chimera base, safe zones the enemy won't
+                dare to attack. Your first choice is to choose where you want to deploy. At first you can only deploy at
+                your starting position but as you progress, more options will become available such as Forward Operating
+                Bases (FOB) and mobile respawns.&lt;br/&gt; &lt;br/&gt;
+                At your starting position you can choose your equipment from a complete Arsenal. You will also find your
+                first FOB packaged inside a container, the Spartan-01 helicopter and a few other small transport
+                helicopters.&lt;br/&gt; &lt;br/&gt;
+                You will have to ferry that container with the Spartan-01 (or choose to start with the first FOB already
+                built). You can deploy this first FOB wherever you want (as long as you're 1km from the starting
+                position and 300m from any sector), so it's up to you to choose the right place to start your campaign
+                offensive.&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Sie beginnen die Kampagne entweder an Bord der USS Freedom oder in der Chimera Basis, wobei es sich
+                jeweils um eine sichere Zone handelt, die der Feind nicht wagen würde anzugreifen. Ihre erste
+                Entscheidung ist es, zu wählen, wo sie eingesetzt werden wollen. Zuerst können sie nur an Ihrer
+                Startposition einsetzen, aber je weiter Sie voran schreiten, umso mehr Möglichkeiten, wie Forward
+                Operating Bases (FOB) und mobile Respawns, werden Ihnen offen stehen.&lt;br/&gt; &lt;br/&gt;
+                An Ihrer Startposition können Sie Ihre Ausrüstung aus einem kompletten Arsenal wählen. Außerdem finden
+                Sie hier auch Ihre erste FOB verpackt in einem Container, den Spartan-01 Helikopter und ein paar kleine
+                Transport-Helikopter&lt;br/&gt; &lt;br/&gt;
+                Sie werden diesen Container mit dem Spartan-01 verlegen müssen (oder Sie entscheiden sich, mit einer
+                ersten, bereits gebauten FOB zu starten). Sie können diese erste FOB aufstellen, wo Sie wollen (solange
+                sie 1km von der Startposition und 300m von einem Sektor entfernt ist), also liegt es an Ihnen, den
+                richtigen Platz für den Start Ihrer Offensive zu finden.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                La campagna partirà dalla USS Freedom, o dalla base Chimera, sono zone sicure che il nemico non oserà
+                attaccare. Prima di tutto bisogna scegliere dove schierarsi. All'inizio ci si può solo schierare nelle
+                posizioni citate prima, ma mentre si progredisce, saranno disponibili ulteriori opzioni quali FOB e
+                respawn mobili.&lt;br/&gt; &lt;br/&gt;
+                Nella posizione iniziale puoi scegliere la tua attrezzatura da un completo Arsenale. Troverete anche la
+                prima FOB imballata all'interno di un container, l'elicottero Spartan-01 e qualche altro piccolo
+                elicottero da trasporto.&lt;br/&gt; &lt;br/&gt;
+                Dovrete trasportare quel container con lo Spartan-01 (o scegliere di iniziare con la prima FOB già
+                costruita). Puoi costruire la FOB dove vuoi (finché sei a 1 km dalla posizione iniziale e 300 metri da
+                qualsiasi settore), quindi stà a voi scegliere il posto giusto per iniziare l'offensiva della vostra
+                campagna.&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Вы начинаете кампанию либо на борту Авионосца, либо на базе Химеры, в безопасных зонах, которые враг не
+                посмеет атаковать. Ваш первый выбор - выбрать, где вы хотите развернуться. Сначала вы можете
+                развертывать только в начальной позиции, но по мере продвижения вперед будут доступны дополнительные
+                опции, такие как Forward Operating Bases (FOB) и мобильные респавны.&lt;br/&gt; &lt;br/&gt;
+                На стартовой позиции вы можете выбрать свое снаряжение из полного арсенала. Вы также найдете свой первый
+                FOB, упакованный в контейнер, вертолет Spartan-01 и несколько других небольших транспортных вертолетов.&lt;br/&gt;
+                &lt;br/&gt;
+                Вам придется переправить этот контейнер с помощью Spartan-01 (или начать с первого уже построенного
+                FOB). Вы можете развернуть этот первый FOB везде, где хотите (пока вы в 1 км от стартовой позиции и 300
+                м от любого сектора), поэтому вам решать, какое место выбрать для начала наступления в вашей кампании.&lt;br/&gt;
+                &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                自由号航母或奇美拉基地——敌人绝不敢招惹的安全地带，将作为你作战的出发点。你的首个选择就是部署地点。一开始你仅能在出发点部署，但随着进度的深入，前进基地（前哨）和机动复活点等选项将会开启。&lt;br/&gt;
+                &lt;br/&gt;
+                你可以在开始地点从军火库中选择你的装备。你也会在这里找到自己被打包在部署柜里的首个前哨、斯巴达1号直升机以及一些其它小型运输直升机。&lt;br/&gt; &lt;br/&gt;
+                你必须通过斯巴达1号来吊运前哨部署柜（或在游戏开始设置中开启部署起始前哨）。你可以将第一个前哨部署在任何想放置的地方（只要你在距离出发点1公里和战区300米之外的地方），因此，发起进攻的地点完全取决于你的选择。&lt;br/&gt;
+                &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;br/&gt;&lt;br/&gt;
+                起始的作戰基地，這裡是敵人絕對不敢招惹的安全地帶，也會是我們這次反攻號角的第一個音符。這裡會是你的作戰出發點，而你首先要進行的就是佈署地點。一開始你僅能在起始作戰基地佈署，但隨著戰線的深入，前線基地和機動復活點將會被啟用。&lt;br/&gt;
+                &lt;br/&gt;
+                你可以在開始地點從軍火庫中自訂你的裝備，你也會在這裡找到已經被打包好的前線基地貨櫃、代號「斯巴達一號」的大型運輸直升機與其他空中載具。&lt;br/&gt; &lt;br/&gt;
+                你必須透過斯巴達一號來吊掛你的前線基地貨櫃進行佈署（或是在遊戲設定中選擇佈署起始前線基地）。你可以將第一個前線基地放置在任何你想放置的位置（只要距離起始作戰基地一公里、戰區三百公尺之外），因此，何時、何地發起進攻，將會全權由你掌握。&lt;br/&gt;
+                &lt;br/&gt;
+            </Chinese>
+            <Turkish>Görevinize USS Freedom'da başlayacaksınız veya Chimera Bölgesinde yani düşmanların saldıramayacağı
+                güvenli bölgelerde. İlk işiniz nereye atlayacağınız olacaktır, siz bölgeleri aldıkça yeni FOB'ler ve
+                mobil spawn merkezleri de açacaksınız.&lt;br/&gt; &lt;br/&gt;
+                Başladığınızda Arsenal (Cephanelik) den istediğiniz ekipmanı seçebilirsiniz. Bir FOB Konteynırı,
+                SPARTAN-01 helikopteri ve birkaç taşıma helikopterine de ayrıca sahipsiniz.&lt;br/&gt; &lt;br/&gt;
+                SPARTAN-01 ile FOB Konteynırını istediğiniz yere götürüp bir FOB Bölgesi (başlangıç noktasından 1km
+                diğer sektörlerden 300mt uzakta olmanız gerekli) açabilirsiniz ve saldırmaya o FOB'den devam
+                edebilirsiniz.&lt;br/&gt; &lt;br/&gt;
+            </Turkish>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Você iniciará a campanha abordo do porta-aviões USS Fredom ou na base operacional Chimera, instalações
+                que o inimigo não se atreverá a atacar. Sua primeira escolha será definir onde irá mobilizar.
+                Primeiramente somente poderá mobilizar na sua posição inicial, entretanto, conforme progredir, mais
+                alternativas se tornarão disponíveis, como a Base de Operações Avançadas (FOB) e os respawns móveis.&lt;br/&gt;
+                &lt;br/&gt;
+                Em sua posição inicial, você poderá escolher seu equipamento através de um arsenal completo. Você terá à
+                sua disposição sua primeira FOB transportável, dentro de um contêiner. Também estará disponível o
+                transporte aéreo de callsign Spartan-01 e mais alguns helicópteros de transporte.&lt;br/&gt; &lt;br/&gt;
+                Você deverá mover o mencionado contêiner utilizando a Spartan-01 (ou escolha começar com a primeira FOB
+                já construída). Você poderá mobilizar esta FOB para onde desejar (desde que esteja a 1km do ponto
+                inicial e a 300 metros de qualquer setor). Assim, depende apenas de você escolher o local ideal para
+                iniciar sua campanha ofensiva.&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE3">
+            <Original>3. Objective</Original>
+            <French>3. Objectif</French>
+            <German>3. Ziele</German>
+            <Spanish>3. Objetivo</Spanish>
+            <Russian>3. Цели и задачи</Russian>
+            <Italian>3. Obiettivi</Italian>
+            <Chinesesimp>3. 目标</Chinesesimp>
+            <Chinese>3. 目標</Chinese>
+            <Turkish>3. Objektifler</Turkish>
+            <Portuguese>3. Objetivo</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT3">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                The primary objective of this campaign is to remove enemy forces from the region entirely. To achieve
+                this, you will have to liberate ALL major cities within the region! This is the only victory condition
+                for the campaign but those cities are tough nuts to crack with only limited resources at your disposal
+                and a well established enemy force. &lt;br/&gt; &lt;br/&gt;
+                To succeed, you will have to capture large number of different sectors, each with their own use.&lt;br/&gt;
+                &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Das Primärziel dieser Kampagne ist es, die Feindkräfte in dieser Region vollständig zu entfernen. Um
+                dies zu erreichen, werden Sie ALLE Großstädte innerhalb dieser Region befreien müssen! Dies ist die
+                einzige Bedingung zum Sieg, aber diese Städte sind schwer zu knacken, in Anbetracht unserer wenigen
+                Ressourcen und einer gut aufgestellten Feindmacht.&lt;br/&gt; &lt;br/&gt;
+                Um das zu erreichen, werden Sie eine große Anzahl von verschiedensten Sektoren einnehmen, jeder mit
+                seinen spezifischen Eigenschaften.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                L'obiettivo primario di questa campagna è di eliminare interamente le forze nemiche dalla regione. Per
+                raggiungere questo obiettivo, dovrai liberare TUTTE le grandi città della regione! Questa è l'unica
+                condizione di vittoria per la campagna, ma quste città sono difficili da liberare in quanto dovrete aver
+                a disposizione numerose risorse e fronteggiare una forza nemica consolidata. &lt;br/&gt; &lt;br/&gt;
+                Per vincere, dovrai catturare un gran numero di settori diversi, ognuno con il proprio uso.&lt;br/&gt;
+                &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Основная цель этой кампании - полностью устранить силы противника из этого региона. Чтобы добиться
+                этого, вам нужно будет освободить ВСЕ крупные города в регионе! Но эти города будут для вас крепкими
+                орешками, их получится раскусить только ограничив поступление в них подкреплений, вражеские силы в них
+                очень хорошо организованы. &lt;br/&gt; &lt;br/&gt;
+                Чтобы добиться успеха, вам нужно будет захватить большое количество различных секторов, каждый со своим
+                собственным использованием.&lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                本战役的主要目标是彻底将敌军赶出这个地区。要达成这点，你必须解放本地区的所有主要城市！这虽是战役唯一的胜利条件，但在有限的进攻资源下这些城市极其棘手，并驻扎着大量敌军。&lt;br/&gt; &lt;br/&gt;
+                要想成功，你必须占领足够多不同的战区，而这些战区各有功效。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;br/&gt;&lt;br/&gt;
+                作戰的最終目標是徹底將敵軍趕出這個地區，要達到這個目的，你必須解放本地區的所有主要城市！雖然這是作戰的唯一勝利條件，但在資源有限的情況下進攻這些防禦良好、又駐紮大量守軍的城市根本是天方夜譚。&lt;br/&gt;
+                &lt;br/&gt;
+                想要成功，你必須佔領各式各樣不同功效的戰區。&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                O objetivo primário desta campanha é remover completamente as forças inimigas da região. Para alçancar
+                tal objetivo, você deverá liberar TODAS as principais cidades dentro da região! Esta é a única condição
+                de vitória para a campanha, porém essas cidades serão difíceis de pacificar com recursos limitados à sua
+                disposição. Além disso, as forças inimigas estão muito bem instaladas no território. &lt;br/&gt; &lt;br/&gt;
+                Para lograr êxito, você deverá capturar uma extensa quantidade de setores, cada um com sua própria base
+                de recursos.&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
 
-		</Key>
-		<Key ID="STR_TUTO_TITLE4">
-			<Original>4. Sectors</Original>
-			<French>4. Secteurs</French>
-			<German>4. Sektoren</German>
-			<Spanish>4. Sectores</Spanish>
-			<Russian>4. Зоны</Russian>
-			<Italian>4. Settori</Italian>
-			<Chinesesimp>4. 战区</Chinesesimp>
-			<Chinese>4. 戰區</Chinese>
-			<Turkish>4. Sektörler</Turkish>
-			<Portuguese>4. Setores</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT4">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			Sectors are split into 5 different types:&lt;br/&gt; &lt;br/&gt;
-			- Points of Interest (PoI): Generally small to medium sized villages/towns. While strategically unimportant, these places are where the citizens of the region live and as such are key in obtaining their trust and sympathy.&lt;br/&gt; &lt;br/&gt;
-			- Factories: Across the region you will find civilian factories under enemy control. These factories are specialized at creating one of the three resources (Supplies, Ammo, and Fuel), but can later be upgraded to produce all 3. As such they are a very strategic first target!&lt;br/&gt; &lt;br/&gt;
-			- Military Bases: Home to large amounts of highly equipped enemy forces, these installations are heavily defended and will require large and well co-ordinated assaults if you have any hope in capturing them! Capturing these bases will enable us to deploy stronger assets in the region and are critical to your success.&lt;br/&gt; &lt;br/&gt;
-			- Radio Towers (RT): When under enemy control, RTs will be used to call in reinforcements when a nearby sector is attacked by our own forces. The reaction time of the reinforcements will depend on the distance between the tower and the sector. When under friendly control, the towers will give useful map intel on hostile troop movements in the vicinity by intercepting their radio communications.&lt;br/&gt; &lt;br/&gt;
-			- Major Cities: There are several major cities in the region. When all are under friendly control, we will most certainly have beaten back the enemy to a point where they cannot re-establish control. This is your primary objective.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Sektoren sind in 5 unterschiedliche Typen eingeteilt:&lt;br/&gt; &lt;br/&gt;
-			- Point of Interest (PoI): Für gewöhnlich kleine- bis mittelgroße Dörfer/Städte. Jeder PoI, den Sie kontrollieren kann aufgewertet werden (nach Bau einer Lagerfläche), um uns mit den drei Arten von Ressourcen zu versorgen, die gebraucht werden, um militärische Ausrüstung zu produzieren.&lt;br/&gt; &lt;br/&gt;
-			- Fabriken: Verteilt über das Gebiet, sind zivile Fabriken unter der Kontrolle des Feindes. Nehmen Sie diese ein, da sie nur eine Lagerfläche brauchen, um dann jede der drei Arten von Ressourcen zu produzieren, ohne sie aufwerten zu müssen. Als solches sind Fabriken ein wertvolles, strategisches, erstes Ziel!&lt;br/&gt; &lt;br/&gt;
-			- Militär Basen: Diese beherbergen eine große Anzahl von bestens ausgestatteten Feindkräften. Sie werden stark verteidigt und erfordern einen großen und gut koordinierten Angriff, falls sie überhaupt irgendwelche Hoffnungen haben, diese einnehmen zu können.&lt;br/&gt; &lt;br/&gt;
-			- Funktürme (FT): Unter Feindkontrolle werden FT genutzt, um Verstärkungen anzufordern, wenn ein Sektor in der Nähe von unseren Kräften angegriffen wird. Die Zeit, bis die Verstärkung eintrifft, hängt von der Entfernung zwischen Turm und Sektor ab. Unter unserer Kontrolle geben FT Aufschluß über Feindbewegung in der Nähe, indem sie ihre Funksprüche abfangen.&lt;br/&gt; &lt;br/&gt;
-			- Großstädte: Es gibt mehrere große Städte in dem Gebiet. Wenn alle unter unserer Kontrolle sind, haben wir den Feind soweit zu einem Punkt zurückgeschlagen, von dem aus er sich nicht wieder neu formieren und die Kontrolle zurückerlangen kann. Dies ist Ihr Hauptziel.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			I settori sono divisi in 5 tipi diversi:&lt;br/&gt; &lt;br/&gt;
-			- Punti di interesse (PDI): generalmente piccoli e medi villaggi, ogni PDI che controlli può essere aggiornato (dopo la costruzione di una zona di stoccaggio) per fornire uno dei tre tipi di risorse necessari per continuare a produrre forze militari e armamenti.&lt;br/&gt; &lt;br/&gt;
-			- Fabbriche: In tutta la regione troverete le fabbriche civili sotto il controllo nemico. Catturatele, in quanto hanno solo bisogno di una zona di archiviazione e possono quindi produrre una delle tre risorse, senza aggiornamento. In quanto Fabbriche sono un primo obiettivo strategico!&lt;br/&gt; &lt;br/&gt;
-			- Basi Militari: Sono piene di grandi quantità di forze armate altamente equipaggiate, queste installazioni sono fortemente difese e richiedono assalti grandi e ben coordinati per avere qualche speranza di catturarle!&lt;br/&gt; &lt;br/&gt;
-			- Torri Radio (TR): Quando sotto controllo nemico, le TR saranno utilizzate per chiamare i rinforzi quando un settore vicino viene attaccato dalle vostre forze. Il tempo di reazione dipenderà dalla distanza tra la torre e il settore. Se conquistate, le torri offriranno utili mappature su movimenti di truppe ostili nelle vicinanze intercettando le loro comunicazioni radio.&lt;br/&gt; &lt;br/&gt;
-			- Città Principali: Ci sono diverse città principali nella regione. Quando sarannno tutte sotto controllo, certamente avremo battuto il nemico in maniera per la quale non riuscirà ristabilire il controllo. Questo è il tuo obiettivo primario.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Секторы разбиты на 5 различных типов:&lt;br/&gt; &lt;br/&gt;
-			- Точки интереса (PoI): Вообще, от небольших до средних деревень / городов каждый контролируемый вами PoI может быть модернизирован (после создания зоны хранения), чтобы обеспечить один из трех типов ресурсов, которые вам понадобятся для продолжения производства вооруженных сил и вооружений.&lt;br/&gt; &lt;br/&gt;
-			- Заводы: Во всем регионе вы найдете гражданские заводы под контролем противника. Захватите их, поскольку они нуждаются только в области хранения, и затем могут производить один из трех ресурсов без обновления. Стратегически они являются первоочередной целью!&lt;br/&gt; &lt;br/&gt;
-			- Военные базы: Военные базы: полные персонала, базы будут приносить большое количество боеприпасов которые будут полезны для обновления огневой мощи. Однако эти сооружения в значительной степени защищены и потребуют больших и хорошо скоординированных усилий!&lt;br/&gt; &lt;br/&gt;
-			- Радиовышки (RT): Когда под контролем противника, RT будет использоваться для вызова подкреплений, когда соседний сектор атакуют наши собственные силы. Время реакции будет зависеть от расстояния между башней и сектором. Когда под дружественным контролем, башни дадут разведданные о передвижениях войск в окрестностях, перехватив их радиосвязь.&lt;br/&gt; &lt;br/&gt;
-			- Крупные города: В регионе есть несколько крупных городов. Когда все находятся под дружественным контролем, мы, наверняка, отбили врага до такой степени, что он не сможет восстановить контроль. Это ваша основная цель.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			战区分为5种不同类型：&lt;br/&gt; &lt;br/&gt;
-			- 兴趣点（PoI）：一般都是小、中型村庄/小镇，你可以升级处于己方控制下的每个PoI（在建造完仓储区后），并从三种用于生产军需品和部队的资源类型中选择一项来生产&lt;br/&gt; &lt;br/&gt;
-			- 工厂：敌军控制中的民用工厂散布在地区的各处。由于只需为这些工厂设立仓储区，即可从三种资源中任选其一进行生产， 由此带来战略地位令它们成为了必争之地！&lt;br/&gt; &lt;br/&gt;
-			- 军事基地：有着大量高度武装的敌军力量驻扎地，这类设施防守严密，只有投入同样强大且配合良好的进攻才有可能攻陷它们！&lt;br/&gt; &lt;br/&gt;
-			- 无线电塔（RT）：敌军控制下的RT将会为附近受到我军部队攻击的战区呼叫增援。敌军增援反应时间取决于无线电塔与战区间的距离。友军控制下的无线电塔能够通过通讯监听获取附近敌军部队的动向。&lt;br/&gt; &lt;br/&gt;
-			- 主要城市：地区内有多个主要城市。当所有城市均处于友军控制下时，我们便可以确信敌军已被彻底击溃。这就是你的主要目标。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;br/&gt;&lt;br/&gt;
-			戰區可以被分為五種不同的類型：&lt;br/&gt; &lt;br/&gt;
-			- 興趣點（PoI）：一般都是小、中型村莊/小鎮，你可以升級楚瑜己方控制下的每個PoI（在建造完倉儲區後），並從三種用來生產軍需品和部隊的資源類型中選擇一種來生產。&lt;br/&gt; &lt;br/&gt;
-			- 工場：敵軍控制的民用工廠散布在各個地方，由於只要為這些工廠設立倉儲區，就能從三種資源任選一種進行生產，這使得他們的戰略價值不言而喻，也使他們成為了兵家必爭之地！&lt;br/&gt; &lt;br/&gt;
-			- 軍事基地：有著大量強大武裝的敵軍駐紮地，這類設施防守嚴謹，只有在投入毫不遜色的武力與良好的戰術決策才有可能攻陷它們！&lt;br/&gt; &lt;br/&gt;
-			- 無線電塔（RT）：敵軍控制下的無線電塔將為附近受我軍部隊攻擊的戰區呼叫增援，增援的反應時間取決於無線電塔與戰區的距離。友軍所控制的無線電塔則能被用來監聽周遭設施並藉以取得敵軍部隊的最新動向。&lt;br/&gt; &lt;br/&gt;
-			- 主要城市：地區內有多個主要城市，當所有城市都被我軍攻略時，才是真正解放這個地區的時候，而這也是就是你的主要目標！&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Os setores estão divididos em 5 tipos distintos:&lt;br/&gt; &lt;br/&gt;
-			- Pontos de interesse: Geralmente vilarejos/cidades de proporção pequena para média. Enquanto não tão importantes estratégicamente, esses locais são onde os cidadãos desta região vivem e dessa forma, é a chave para obter sua confiança e simpatia.&lt;br/&gt; &lt;br/&gt;
-			- Fábricas: Em toda a região, você encontrará fábricas civis sob controle inimigo. Estas fábricas são especializadas no desenvolvimento de um dos três tipos de recursos (Suprimentos, Munição e Combustível), no entanto podem ser aprimorada para produzir todas as três classes de recursos, dessa forma, são alvos estratégicos e devem ser prioridade em seus esforços!&lt;br/&gt; &lt;br/&gt;
-			- Bases Militares: Lar de uma vasta quantidade de forças inimigas bem equipadas, essas instalações são fortemente protegidas e requerem uma grande e bem coordenada força de assalto para de capturá-la. Ao capturar essas bases, será possível disponibilizar maiores recursos na região, que serão críticos para o seu sucesso.&lt;br/&gt; &lt;br/&gt;
-			- Torres de Rádio: Quando sob domínio inimigo, as torres de rádio serão utilizadas para solicitar reforços quando um setor próximo estiver sendo atacado pela Coalizão. O tempo de reação dependerá da distância entre a torre e o setor. Quando estiver sob controle aliado, as torres fornecerão inteligência sobre a movimentação das tropas inimigas na proximidade. Isto será possível pois as torres interceptarão as frequências inimigas.&lt;br/&gt; &lt;br/&gt;
-			- Grandes Cidades: Existem dezenas de grandes cidades na região. Quando estiverem sob controle da Coalizão, certamente não será possível ao inimigo retomar seu controle. Este é seu objetivo primário.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE5">
-			<Original>5. Resources</Original>
-			<French>5. Ressources</French>
-			<German>5. Ressourcen</German>
-			<Spanish>5. Recursos</Spanish>
-			<Russian>5. Ресурсы</Russian>
-			<Italian>5. Risorse</Italian>
-			<Chinesesimp>5. 资源</Chinesesimp>
-			<Chinese>5. 资源</Chinese>
-			<Turkish>5. Kaynaklar</Turkish>
-			<Portuguese>5. Recursos</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT5">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			In this campaign you have to manage, store and protect three types of resources:&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;SUPPLIES:&lt;/t&gt; These are the most essential. Without supplies, you will be unable to deploy additional soldiers or requisition any military hardware. As such, HQ recommends prioritising these first!&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;AMMUNITION:&lt;/t&gt; Used to stock armed vehicles such as APCs and MBTs as well as elite (and heavily armed) soldiers.&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;FUEL:&lt;/t&gt; Every vehicle needs fuel, some being more thirsty than others.&lt;br/&gt; &lt;br/&gt;
-			You may come across all three resources in any sector but for a considerable and constant supply, you must capture Factory sectors! Once captured, factories require a storage area (scroll menu action) and then they can immediately begin producing their intended resource. If you can afford it, any factory can be upgraded to produce the other two resources as well. &lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			In dieser Kampagne müssen Sie drei Arten von Ressourcen verwalten, einlagern und beschützen:&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;NACHSCHUB:&lt;/t&gt; Diese sind von essenzieller Bedeutung. Ohne Nachschu können Sie weder Soldaten rekrutieren, noch militärisches Gerät anfordern. Daher empfiehlt HQ diese zu bevorzugen!&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;MUNITION:&lt;/t&gt; Werden für bewaffnete Fahrzeuge wie Spz und Kpz, sowie für Elite (schwerbewaffnete) Soldaten benötigt.&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;KRAFTSTOFF:&lt;/t&gt; Jedes Fahrzeug benötigt Kraftstoff. Einige sind durstiger, als andere.&lt;br/&gt; &lt;br/&gt;
-			In den Sektoren können Sie durchaus alle drei Arten von Ressourcen finden, aber für einen signifikanten und konstanten Nachschub, müssen Sie PoI und Fabriken einnehmen. Nach Übernahme benötigen beide Lagerflächen (Scroll-Menü) und der PoI benötigt zusätzlich noch ein Fabrikgebäude (wieder Scroll-Menü). Alle drei Arten von Fabriken können in ein und dem selben PoI gebaut werden, jedoch müssen Sie eine erste und einzige Abgabe dafür bereitstellen! Das sind 50 von der Ressource, die nachher von der Fabrik produziert werden soll und je 100 der anderen beiden Ressourcen.&lt;br/&gt;&lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			In questa campagna è necessario gestire, memorizzare e proteggere tre tipi di risorse:&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;APPROVVIGIONAMENTI:&lt;/t&gt; Questi sono i più essenziali. Senza approvvigionamenti, non sarete in grado di distribuire soldati o richiedere qualsiasi hardware militare. In quanto tale, HQ raccomanda di dare priorità a queste risorse per prime!&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;MUNIZIONI:&lt;/t&gt; Utilizzate per lo stoccaggio di veicoli armati come APC e MBT, nonché soldati di élite (e pesantemente armati).&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;CARBURANTE:&lt;/t&gt; Ogni veicolo ha bisogno di carburante, alcuni hanno più sete di altri.&lt;br/&gt; &lt;br/&gt;
-			Puoi incontrare tutte e tre le risorse in qualsiasi settore, ma per una fornitura considerevole e costante, devi catturare i PDI e le Fabbriche! Una volta catturati, entrambi richiedono un'area di stoccaggio (menu rotellina) e poi un PDI richiederà anche la costruzione di strutture (nuovamente, menu rotellina). Tutte e tre le strutture possono essere costruite in qualsiasi PDI ma dovete fornire un costo iniziale per impostare queste strutture! Costo 50 della risorsa specifica e 100 delle altre due.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			В этой кампании вы должны управлять, хранить и защищать три типа ресурсов:&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;ОБЕСПЕЧЕНИЕ:&lt;/t&gt; Это самое важное. Без расходных материалов вы не сможете развернуть дополнительных солдат или реквизировать любую военную технику. Таким образом, HQ рекомендует расставить приоритеты первым!&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;БОЕПРИПАСЫ:&lt;/t&gt; Используется для оснащения вооруженных автомобилей, а также элитных (и хорошо вооруженных) солдат.&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;ТОПЛИВО:&lt;/t&gt; Каждому транспортному средству нужно топливо,некоторым требуется больше, чем другим.&lt;br/&gt; &lt;br/&gt;
-			Вы можете встретить все три ресурса в любом секторе, но для значительного и постоянного снабжения вы должны захватывать сектора PoI и Заводы! После захвата оба требуют области хранения (действие меню прокрутки), а затем PoI также потребует создания объекта (опять же, действие в меню прокрутки). Все три объекта могут быть построены в любом одном PoI, но вы должны заплатить первоначальную стоимость, чтобы настроить эти объекты! Это 50 конкретных ресурсов и 100 других двух.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			这个战役中你必须管理、囤积并保护三种资源：&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;补给：&lt;/t&gt;最关键的物资。没有补给，你将无法部署更多步兵或军事资源。因此，指挥部建议优先谋取此类资源！&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;弹药：&lt;/t&gt;用于采购步战车（APC）和主战坦克（MBT）等装甲载具，亦用于武装精英（且重装）士兵。&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;燃料：&lt;/t&gt;载具离不了燃料，更不用说胃口极大的那些。&lt;br/&gt; &lt;br/&gt;
-			你能在任意战区中找到以上三种资源，但想要稳定而高效的补给就需要你去占领PoI和工厂战区了！两者在占领后都需要一个仓储区（用滚轮动作菜单建立），而PoI还需要建立额外资源生产设施（依旧是滚轮动作菜单）。一个PoI能够同时容纳全部三种设施，但你必须先行投资才能将这些设施建立起来！建造设施需要消耗50点指定资源以及100点另外两种资源。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>&lt;br/&gt;&lt;br/&gt;
-			在這次作戰中你必須管理、囤積與保護三種資源：&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;補給：&lt;/t&gt;最關鍵的物資。一旦沒有補給，你將無法佈署更多士兵或其餘軍事資源，因此，指揮部建議優先謀取這項資源！&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;彈藥：&lt;/t&gt;用來採購步兵戰車（APC）和主戰坦克（MBT）等裝甲載具，同時也被用於招募武裝菁英的重裝士兵。&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;油料：&lt;/t&gt;載具的必需品，任何載具都需要油料，尤其是那些「大胃王」的大型載具們。&lt;br/&gt; &lt;br/&gt;
-			在作戰過程中你或許能在任意戰區內搜刮到以上三種資源，但是為了解放這個區域，你勢必需要更穩定而有效的補給線，這時候你就需要去佔領興趣點(PoI)和工廠了！兩者都能在占領後建立一個倉儲區（用滾輪動作選單來建立），而興趣點還需要額外建立資源生產設施（依舊是滾輪動作選單)。一個PoI能夠同時建立三種生產設施，但你必須先投資才能全數建立起來！建造設施需要 50 點對應的資源與其餘兩個資源各 100 點。&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Nesta campanha você deverá gerir, estocar e proteger três tipos de recursos.:&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#00ff00'&gt;SUPRIMENTOS:&lt;/t&gt; Este é o recurso essencial. Sem suprimentos, será impossível mobilizar infantaria adicional ou requisitar equipamentos militares. Desse modo, o QG recomenda priorizar estes recursos!&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ff0000'&gt;MUNIÇÃO:&lt;/t&gt; Utilizada para abastecer veículos blindados armados, bem como soldados de elite de equipamento bélico pesado.&lt;br/&gt; &lt;br/&gt;
-			&lt;t color='#ffff00'&gt;COMBUSTÍVEL:&lt;/t&gt; Todo veículo precisa de combustível, alguns consomem mais que outros.&lt;br/&gt; &lt;br/&gt;
-			Você cruzará com todos os três tipos de recursos dispersos pelos setores, porém para adquirir uma quantidade considerável e abastecimento constante, você deverá capturar setores com fábricas/refinarias. Uma vez capturadas, as fábricas precisarão de um depósito (use o scroll do mouse) e então poderão imediatamente iniciar a produção do recurso pretendido. Se puder arcar com os custos, as fábricas poderão ser aprimoradas para produzir os demais recursos. &lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE6">
-			<Original>6. Alert Level</Original>
-			<French>6. Niveau d'alerte</French>
-			<German>6. Alarmstatus</German>
-			<Spanish>6. Nivel de alerta</Spanish>
-			<Russian>6. Уровень тревоги</Russian>
-			<Italian>6. Livello di Allerta</Italian>
-			<Chinesesimp>6. 警戒等级</Chinesesimp>
-			<Chinese>6. 威脅度</Chinese>
-			<Turkish>6. Uyarı Seviyesi</Turkish>
-			<Portuguese>6. Nível de Alerta</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT6">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			The enemy won't let you liberate all of its brand new territory without a reaction. When you begin the campaign, hostile forces will only be composed of the garrisons inside military bases. However as you become more threatening by liberating more and more sectors, they will start calling in more reinforcements and equipment to counter you.&lt;br/&gt; &lt;br/&gt;
-			To limit the enemies operational capabilities, you will have to fulfill secondary objectives that will consist of destroying their logistical bases and raiding their convoys. This is not required to win the campaign but if you ignore the alert level for too long, you're in for quite a lot of resistance.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Der Feind wird nicht untätig dabei zusehen, wie wir alles in seinem brandneuen Territorium nach und nach befreien. Zu Beginn der Kampagne setzen sich die Feindkräfte lediglich aus den Garnisonen innerhalb der Militär Basen zusammen. Wie auch immer, sobald wir für den Feind mehr und mehr zu einer Bedrohnung werden, während wir mehr und mehr Sektoren einnehmen, wird er anfangen, Unterstützung und Ausrüstung anzufordern, um uns zu bekämpfen.&lt;br/&gt; &lt;br/&gt;
-			Um den Feind in seinem militärischen Handlungsspielraum einzuschränken, müssen Sie Sekundärziele erfüllen, die aus Suchen und Zerstören von Logistic Basen, Konvoiüberfällen und Suchen und Retten von Kriegsgefangenen bestehen. Dies ist zwar keine Bedingung für den Erfolg der Kampagne, aber wenn Sie das Bedrohungsniveau zu lange ignorieren, stoßen Sie bald auf recht viel Widerstand.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			Il nemico non ti permetterà di liberare tutto il suo nuovo territorio senza una reazione. Quando inizierai la campagna, le forze ostili saranno composte solo dalle guarnigioni all'interno delle basi militari. Tuttavia, quando diventerete più minacciosi , inizieranno a chiamare più rinforzi e attrezzature per contrastarvi.&lt;br/&gt; &lt;br/&gt;
-			Per limitare la capacità offensiva dei nemici, dovrete compiere missioni secondarie che consistono nel distruggere le basi logistiche e raidare i loro convogli. Questo non è richiesto per vincere la campagna, ma se ignorate troppo il livello di allarta, sarate pronti a contrastare la risposta?.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			OPFOR не будут сидеть сложа руки, пока вы будете освобождать все зоны, они будут реагировать на ваши действия. Когда вы начнёте кампанию, враждебные силы будут состоять только из гарнизонов внутри военных баз. Однако, как только вы начнёте овобождать больше и больше зон, OPFOR начнёт вызывать больше подкреплений, отряды и технику для борьбы с вами.&lt;br/&gt; &lt;br/&gt;
-			Чтобы ограничить оперативные возможности OPFOR, вы должны будете выполнять дополнительные задачи, которые будут состоять в уничтожении баз снабжения врага. Это не обязательно, для того, чтобы выиграть кампанию, но если вы будете игнорировать уровень тревоги слишком долго, у вас могут быть большие неприятности.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			敌人不可能拱手让出刚刚获得的新领地。战役刚开始时，敌军部队仅由本地军事基地驻扎部队构成，但战区解放的增多你产生的威胁也将逐渐加大，因此他们会开始增派更多、更好的增援和装备来对付你。&lt;br/&gt; &lt;br/&gt;
-			要想遏制住敌人的作战能力，你必须完成摧毁对方后勤基地和劫掠对方补给车队的次要任务。这并非战役的胜利条件，但忽视警戒等级的提高将会大大增加敌人抵抗的强度。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>&lt;br/&gt;&lt;br/&gt;
-			敵人不可能任你為所欲為。作戰剛開始時，敵軍部隊僅由本地軍事基地的駐紮部隊構成，但解放的戰區越多將使你對他們的威脅度也越來越高，而這也將促他們派出更多、更好與更強的部隊與人手來對付你。&lt;br/&gt; &lt;br/&gt;
-			想要遏制住敵人的作戰能力，你必須透過摧毀敵方前線基地、掠奪對方補給車隊等次要任務來破壞他們對你的威脅度評估。次要任務並非這次作戰的必要項目，但坐視警戒度的提升將大大地提升敵人的抵抗強度！&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			O inimigo não irá permitir a conquista de seu território sem uma reação. Quando iniciar sua campanha, forças hostis serão apenas compostas por guarnições dentro de bases militares. No entanto, ao liberar mais setores, as forças inimigas chamarão mais reforços e equipamentos para tentar te combater.&lt;br/&gt; &lt;br/&gt;
-			Para limitar a capacidade operacional das forças de oposição, você deverá cumprir objetivos secundários que consistem na destruição de bases logísticas e no assalto aos comboios inimigos. Isto não é obrigatório para lograr êxito na campanha, todavia se o nível de alerta for ignorado por muito tempo, você enfrentará uma forte resistência inimiga.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE7">
-			<Original>7. Construction</Original>
-			<French>7. Construction</French>
-			<German>7. Konstruktion</German>
-			<Spanish>7. Construcción</Spanish>
-			<Russian>7. Строительство</Russian>
-			<Italian>7. Construzioni</Italian>
-			<Chinesesimp>7. 建造</Chinesesimp>
-			<Chinese>7. 建造</Chinese>
-			<Turkish>7. İnşa etmek</Turkish>
-			<Portuguese>7. Construção</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT7">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			To help you succeed in your endeavors, you have a construction capability at every FOB that allows you to deploy infantry, vehicles, defenses, fortifications and so on to your specific location.&lt;br/&gt; &lt;br/&gt;
-			Although infantry, vehicles and defenses will cost resources, fortifications such as structures, sandbags and walls will not.&lt;br/&gt; &lt;br/&gt;
-			The construction system will be available when you are within 100 meters of any FOB.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Hilfe zum Erfolg Ihrer Bemühungen bieten die Bauoptionen an den einzelnen FOBs, die es Ihnen ermöglichen, Infantrie, Fahrzeuge, Verteidigungsanlagen, Befestigungsanlagen und so weiter, an der jeweiligen Position zu bauen.&lt;br/&gt; &lt;br/&gt;
-			Obgleich Infantrie, Fahrzeuge und Verteidigungsanlagen Ressourcen benötigen, braucht man zum Bau von Befestigungsanlagen wie Gebäuden, Sandsäcken und Wänden keine.&lt;br/&gt; &lt;br/&gt;
-			Die Bauoptionen werden in einem Bereich vom 100 Metern um eine FOB herum verfügbar.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			Per aiutarti a riuscire nella tua missione, ogni FOB ti permette di creare fanteria, veicoli, difese, fortificazioni e così via nella posizione specifica.&lt;br/&gt; &lt;br/&gt;
-			Anche se la fanteria, i veicoli e le difese costano risorse, le fortificazioni come strutture, sandbags e muri non lo faranno.&lt;br/&gt; &lt;br/&gt;
-			Il sistema di costruzione sarà disponibile quando si è a 100 metri da qualsiasi FOB.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Чтобы помочь вам добиться успеха в ваших начинаниях, у вас есть возможность строительства на каждом FOB, что позволяет вам развертывать пехоту, транспортные средства, оборонительные сооружения, укрепления и т.д. В вашем конкретном месте.&lt;br/&gt; &lt;br/&gt;
-			Хотя пехота, транспортные средства и средства защиты будут стоить ресурсов, тогда как укрепления, конструкции, мешки с песком и стены бесплатны.&lt;br/&gt; &lt;br/&gt;
-			Система строительства будет доступна, если вы находитесь дальше 100 метров от любого FOB.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			为了帮助你走向成功，每个前哨都拥有能让你在限定范围内部署步兵、载具、防御、工事等军备的建造能力。&lt;br/&gt; &lt;br/&gt;
-			步兵、载具和防御设备需要消耗资源，但建筑、沙袋、墙体等工事是完全免费的。&lt;br/&gt; &lt;br/&gt;
-			你可以在前哨100米半径范围内启用建造系统。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>
-			&lt;br/&gt;&lt;br/&gt;
-			為了協助你成功解放這裡，指揮部允許你在每個前線基地周遭限定的範圍內佈署步兵、載具、防禦工事等軍備設施與建造工事。&lt;br/&gt; &lt;br/&gt;
-			步兵、載具和防禦設備（如固定式武器）需要消耗資源，但建築、沙包、掩體等工事是完全免費的。&lt;br/&gt; &lt;br/&gt;
-			你可以在前線基地半徑 100 公尺內使用建造系統。&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Para auxiliar no sucesso de sua iniciativa, você terá a capacidade de construir em todas suas bases avançadas, que o permitirá mobilizar infantaria, veículos, defesas, fortificações e etc para sua localidade.&lt;br/&gt; &lt;br/&gt;
-			Embora infantaria, veículos e defesas exijam recursos para seu desenvolvimento, fortificações como estruturas, sacos de areia e muros não terão custo.&lt;br/&gt; &lt;br/&gt;
-			O sistema de construção estará disponível quando você estiver a 100 metros de qualquer FOB.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE4">
+            <Original>4. Sectors</Original>
+            <French>4. Secteurs</French>
+            <German>4. Sektoren</German>
+            <Spanish>4. Sectores</Spanish>
+            <Russian>4. Зоны</Russian>
+            <Italian>4. Settori</Italian>
+            <Chinesesimp>4. 战区</Chinesesimp>
+            <Chinese>4. 戰區</Chinese>
+            <Turkish>4. Sektörler</Turkish>
+            <Portuguese>4. Setores</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT4">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                Sectors are split into 5 different types:&lt;br/&gt; &lt;br/&gt;
+                - Points of Interest (PoI): Generally small to medium sized villages/towns. While strategically
+                unimportant, these places are where the citizens of the region live and as such are key in obtaining
+                their trust and sympathy.&lt;br/&gt; &lt;br/&gt;
+                - Factories: Across the region you will find civilian factories under enemy control. These factories are
+                specialized at creating one of the three resources (Supplies, Ammo, and Fuel), but can later be upgraded
+                to produce all 3. As such they are a very strategic first target!&lt;br/&gt; &lt;br/&gt;
+                - Military Bases: Home to large amounts of highly equipped enemy forces, these installations are heavily
+                defended and will require large and well co-ordinated assaults if you have any hope in capturing them!
+                Capturing these bases will enable us to deploy stronger assets in the region and are critical to your
+                success.&lt;br/&gt; &lt;br/&gt;
+                - Radio Towers (RT): When under enemy control, RTs will be used to call in reinforcements when a nearby
+                sector is attacked by our own forces. The reaction time of the reinforcements will depend on the
+                distance between the tower and the sector. When under friendly control, the towers will give useful map
+                intel on hostile troop movements in the vicinity by intercepting their radio communications.&lt;br/&gt;
+                &lt;br/&gt;
+                - Major Cities: There are several major cities in the region. When all are under friendly control, we
+                will most certainly have beaten back the enemy to a point where they cannot re-establish control. This
+                is your primary objective.&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Sektoren sind in 5 unterschiedliche Typen eingeteilt:&lt;br/&gt; &lt;br/&gt;
+                - Point of Interest (PoI): Für gewöhnlich kleine- bis mittelgroße Dörfer/Städte. Jeder PoI, den Sie
+                kontrollieren kann aufgewertet werden (nach Bau einer Lagerfläche), um uns mit den drei Arten von
+                Ressourcen zu versorgen, die gebraucht werden, um militärische Ausrüstung zu produzieren.&lt;br/&gt;
+                &lt;br/&gt;
+                - Fabriken: Verteilt über das Gebiet, sind zivile Fabriken unter der Kontrolle des Feindes. Nehmen Sie
+                diese ein, da sie nur eine Lagerfläche brauchen, um dann jede der drei Arten von Ressourcen zu
+                produzieren, ohne sie aufwerten zu müssen. Als solches sind Fabriken ein wertvolles, strategisches,
+                erstes Ziel!&lt;br/&gt; &lt;br/&gt;
+                - Militär Basen: Diese beherbergen eine große Anzahl von bestens ausgestatteten Feindkräften. Sie werden
+                stark verteidigt und erfordern einen großen und gut koordinierten Angriff, falls sie überhaupt
+                irgendwelche Hoffnungen haben, diese einnehmen zu können.&lt;br/&gt; &lt;br/&gt;
+                - Funktürme (FT): Unter Feindkontrolle werden FT genutzt, um Verstärkungen anzufordern, wenn ein Sektor
+                in der Nähe von unseren Kräften angegriffen wird. Die Zeit, bis die Verstärkung eintrifft, hängt von der
+                Entfernung zwischen Turm und Sektor ab. Unter unserer Kontrolle geben FT Aufschluß über Feindbewegung in
+                der Nähe, indem sie ihre Funksprüche abfangen.&lt;br/&gt; &lt;br/&gt;
+                - Großstädte: Es gibt mehrere große Städte in dem Gebiet. Wenn alle unter unserer Kontrolle sind, haben
+                wir den Feind soweit zu einem Punkt zurückgeschlagen, von dem aus er sich nicht wieder neu formieren und
+                die Kontrolle zurückerlangen kann. Dies ist Ihr Hauptziel.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                I settori sono divisi in 5 tipi diversi:&lt;br/&gt; &lt;br/&gt;
+                - Punti di interesse (PDI): generalmente piccoli e medi villaggi, ogni PDI che controlli può essere
+                aggiornato (dopo la costruzione di una zona di stoccaggio) per fornire uno dei tre tipi di risorse
+                necessari per continuare a produrre forze militari e armamenti.&lt;br/&gt; &lt;br/&gt;
+                - Fabbriche: In tutta la regione troverete le fabbriche civili sotto il controllo nemico. Catturatele,
+                in quanto hanno solo bisogno di una zona di archiviazione e possono quindi produrre una delle tre
+                risorse, senza aggiornamento. In quanto Fabbriche sono un primo obiettivo strategico!&lt;br/&gt; &lt;br/&gt;
+                - Basi Militari: Sono piene di grandi quantità di forze armate altamente equipaggiate, queste
+                installazioni sono fortemente difese e richiedono assalti grandi e ben coordinati per avere qualche
+                speranza di catturarle!&lt;br/&gt; &lt;br/&gt;
+                - Torri Radio (TR): Quando sotto controllo nemico, le TR saranno utilizzate per chiamare i rinforzi
+                quando un settore vicino viene attaccato dalle vostre forze. Il tempo di reazione dipenderà dalla
+                distanza tra la torre e il settore. Se conquistate, le torri offriranno utili mappature su movimenti di
+                truppe ostili nelle vicinanze intercettando le loro comunicazioni radio.&lt;br/&gt; &lt;br/&gt;
+                - Città Principali: Ci sono diverse città principali nella regione. Quando sarannno tutte sotto
+                controllo, certamente avremo battuto il nemico in maniera per la quale non riuscirà ristabilire il
+                controllo. Questo è il tuo obiettivo primario.&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Секторы разбиты на 5 различных типов:&lt;br/&gt; &lt;br/&gt;
+                - Точки интереса (PoI): Вообще, от небольших до средних деревень / городов каждый контролируемый вами
+                PoI может быть модернизирован (после создания зоны хранения), чтобы обеспечить один из трех типов
+                ресурсов, которые вам понадобятся для продолжения производства вооруженных сил и вооружений.&lt;br/&gt;
+                &lt;br/&gt;
+                - Заводы: Во всем регионе вы найдете гражданские заводы под контролем противника. Захватите их,
+                поскольку они нуждаются только в области хранения, и затем могут производить один из трех ресурсов без
+                обновления. Стратегически они являются первоочередной целью!&lt;br/&gt; &lt;br/&gt;
+                - Военные базы: Военные базы: полные персонала, базы будут приносить большое количество боеприпасов
+                которые будут полезны для обновления огневой мощи. Однако эти сооружения в значительной степени защищены
+                и потребуют больших и хорошо скоординированных усилий!&lt;br/&gt; &lt;br/&gt;
+                - Радиовышки (RT): Когда под контролем противника, RT будет использоваться для вызова подкреплений,
+                когда соседний сектор атакуют наши собственные силы. Время реакции будет зависеть от расстояния между
+                башней и сектором. Когда под дружественным контролем, башни дадут разведданные о передвижениях войск в
+                окрестностях, перехватив их радиосвязь.&lt;br/&gt; &lt;br/&gt;
+                - Крупные города: В регионе есть несколько крупных городов. Когда все находятся под дружественным
+                контролем, мы, наверняка, отбили врага до такой степени, что он не сможет восстановить контроль. Это
+                ваша основная цель.&lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                战区分为5种不同类型：&lt;br/&gt; &lt;br/&gt;
+                - 兴趣点（PoI）：一般都是小、中型村庄/小镇，你可以升级处于己方控制下的每个PoI（在建造完仓储区后），并从三种用于生产军需品和部队的资源类型中选择一项来生产&lt;br/&gt; &lt;br/&gt;
+                - 工厂：敌军控制中的民用工厂散布在地区的各处。由于只需为这些工厂设立仓储区，即可从三种资源中任选其一进行生产， 由此带来战略地位令它们成为了必争之地！&lt;br/&gt; &lt;br/&gt;
+                - 军事基地：有着大量高度武装的敌军力量驻扎地，这类设施防守严密，只有投入同样强大且配合良好的进攻才有可能攻陷它们！&lt;br/&gt; &lt;br/&gt;
+                - 无线电塔（RT）：敌军控制下的RT将会为附近受到我军部队攻击的战区呼叫增援。敌军增援反应时间取决于无线电塔与战区间的距离。友军控制下的无线电塔能够通过通讯监听获取附近敌军部队的动向。&lt;br/&gt;
+                &lt;br/&gt;
+                - 主要城市：地区内有多个主要城市。当所有城市均处于友军控制下时，我们便可以确信敌军已被彻底击溃。这就是你的主要目标。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;br/&gt;&lt;br/&gt;
+                戰區可以被分為五種不同的類型：&lt;br/&gt; &lt;br/&gt;
+                - 興趣點（PoI）：一般都是小、中型村莊/小鎮，你可以升級楚瑜己方控制下的每個PoI（在建造完倉儲區後），並從三種用來生產軍需品和部隊的資源類型中選擇一種來生產。&lt;br/&gt; &lt;br/&gt;
+                - 工場：敵軍控制的民用工廠散布在各個地方，由於只要為這些工廠設立倉儲區，就能從三種資源任選一種進行生產，這使得他們的戰略價值不言而喻，也使他們成為了兵家必爭之地！&lt;br/&gt; &lt;br/&gt;
+                - 軍事基地：有著大量強大武裝的敵軍駐紮地，這類設施防守嚴謹，只有在投入毫不遜色的武力與良好的戰術決策才有可能攻陷它們！&lt;br/&gt; &lt;br/&gt;
+                - 無線電塔（RT）：敵軍控制下的無線電塔將為附近受我軍部隊攻擊的戰區呼叫增援，增援的反應時間取決於無線電塔與戰區的距離。友軍所控制的無線電塔則能被用來監聽周遭設施並藉以取得敵軍部隊的最新動向。&lt;br/&gt;
+                &lt;br/&gt;
+                - 主要城市：地區內有多個主要城市，當所有城市都被我軍攻略時，才是真正解放這個地區的時候，而這也是就是你的主要目標！&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Os setores estão divididos em 5 tipos distintos:&lt;br/&gt; &lt;br/&gt;
+                - Pontos de interesse: Geralmente vilarejos/cidades de proporção pequena para média. Enquanto não tão
+                importantes estratégicamente, esses locais são onde os cidadãos desta região vivem e dessa forma, é a
+                chave para obter sua confiança e simpatia.&lt;br/&gt; &lt;br/&gt;
+                - Fábricas: Em toda a região, você encontrará fábricas civis sob controle inimigo. Estas fábricas são
+                especializadas no desenvolvimento de um dos três tipos de recursos (Suprimentos, Munição e Combustível),
+                no entanto podem ser aprimorada para produzir todas as três classes de recursos, dessa forma, são alvos
+                estratégicos e devem ser prioridade em seus esforços!&lt;br/&gt; &lt;br/&gt;
+                - Bases Militares: Lar de uma vasta quantidade de forças inimigas bem equipadas, essas instalações são
+                fortemente protegidas e requerem uma grande e bem coordenada força de assalto para de capturá-la. Ao
+                capturar essas bases, será possível disponibilizar maiores recursos na região, que serão críticos para o
+                seu sucesso.&lt;br/&gt; &lt;br/&gt;
+                - Torres de Rádio: Quando sob domínio inimigo, as torres de rádio serão utilizadas para solicitar
+                reforços quando um setor próximo estiver sendo atacado pela Coalizão. O tempo de reação dependerá da
+                distância entre a torre e o setor. Quando estiver sob controle aliado, as torres fornecerão inteligência
+                sobre a movimentação das tropas inimigas na proximidade. Isto será possível pois as torres interceptarão
+                as frequências inimigas.&lt;br/&gt; &lt;br/&gt;
+                - Grandes Cidades: Existem dezenas de grandes cidades na região. Quando estiverem sob controle da
+                Coalizão, certamente não será possível ao inimigo retomar seu controle. Este é seu objetivo primário.&lt;br/&gt;
+                &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE5">
+            <Original>5. Resources</Original>
+            <French>5. Ressources</French>
+            <German>5. Ressourcen</German>
+            <Spanish>5. Recursos</Spanish>
+            <Russian>5. Ресурсы</Russian>
+            <Italian>5. Risorse</Italian>
+            <Chinesesimp>5. 资源</Chinesesimp>
+            <Chinese>5. 资源</Chinese>
+            <Turkish>5. Kaynaklar</Turkish>
+            <Portuguese>5. Recursos</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT5">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                In this campaign you have to manage, store and protect three types of resources:&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;SUPPLIES:&lt;/t&gt; These are the most essential. Without supplies, you will be
+                unable to deploy additional soldiers or requisition any military hardware. As such, HQ recommends
+                prioritising these first!&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;AMMUNITION:&lt;/t&gt; Used to stock armed vehicles such as APCs and MBTs as
+                well as elite (and heavily armed) soldiers.&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;FUEL:&lt;/t&gt; Every vehicle needs fuel, some being more thirsty than others.&lt;br/&gt;
+                &lt;br/&gt;
+                You may come across all three resources in any sector but for a considerable and constant supply, you
+                must capture Factory sectors! Once captured, factories require a storage area (scroll menu action) and
+                then they can immediately begin producing their intended resource. If you can afford it, any factory can
+                be upgraded to produce the other two resources as well. &lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                In dieser Kampagne müssen Sie drei Arten von Ressourcen verwalten, einlagern und beschützen:&lt;br/&gt;
+                &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;NACHSCHUB:&lt;/t&gt; Diese sind von essenzieller Bedeutung. Ohne Nachschu
+                können Sie weder Soldaten rekrutieren, noch militärisches Gerät anfordern. Daher empfiehlt HQ diese zu
+                bevorzugen!&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;MUNITION:&lt;/t&gt; Werden für bewaffnete Fahrzeuge wie Spz und Kpz, sowie für
+                Elite (schwerbewaffnete) Soldaten benötigt.&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;KRAFTSTOFF:&lt;/t&gt; Jedes Fahrzeug benötigt Kraftstoff. Einige sind
+                durstiger, als andere.&lt;br/&gt; &lt;br/&gt;
+                In den Sektoren können Sie durchaus alle drei Arten von Ressourcen finden, aber für einen signifikanten
+                und konstanten Nachschub, müssen Sie PoI und Fabriken einnehmen. Nach Übernahme benötigen beide
+                Lagerflächen (Scroll-Menü) und der PoI benötigt zusätzlich noch ein Fabrikgebäude (wieder Scroll-Menü).
+                Alle drei Arten von Fabriken können in ein und dem selben PoI gebaut werden, jedoch müssen Sie eine
+                erste und einzige Abgabe dafür bereitstellen! Das sind 50 von der Ressource, die nachher von der Fabrik
+                produziert werden soll und je 100 der anderen beiden Ressourcen.&lt;br/&gt;&lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                In questa campagna è necessario gestire, memorizzare e proteggere tre tipi di risorse:&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;APPROVVIGIONAMENTI:&lt;/t&gt; Questi sono i più essenziali. Senza
+                approvvigionamenti, non sarete in grado di distribuire soldati o richiedere qualsiasi hardware militare.
+                In quanto tale, HQ raccomanda di dare priorità a queste risorse per prime!&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;MUNIZIONI:&lt;/t&gt; Utilizzate per lo stoccaggio di veicoli armati come APC e
+                MBT, nonché soldati di élite (e pesantemente armati).&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;CARBURANTE:&lt;/t&gt; Ogni veicolo ha bisogno di carburante, alcuni hanno più
+                sete di altri.&lt;br/&gt; &lt;br/&gt;
+                Puoi incontrare tutte e tre le risorse in qualsiasi settore, ma per una fornitura considerevole e
+                costante, devi catturare i PDI e le Fabbriche! Una volta catturati, entrambi richiedono un'area di
+                stoccaggio (menu rotellina) e poi un PDI richiederà anche la costruzione di strutture (nuovamente, menu
+                rotellina). Tutte e tre le strutture possono essere costruite in qualsiasi PDI ma dovete fornire un
+                costo iniziale per impostare queste strutture! Costo 50 della risorsa specifica e 100 delle altre due.&lt;br/&gt;
+                &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                В этой кампании вы должны управлять, хранить и защищать три типа ресурсов:&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;ОБЕСПЕЧЕНИЕ:&lt;/t&gt; Это самое важное. Без расходных материалов вы не сможете
+                развернуть дополнительных солдат или реквизировать любую военную технику. Таким образом, HQ рекомендует
+                расставить приоритеты первым!&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;БОЕПРИПАСЫ:&lt;/t&gt; Используется для оснащения вооруженных автомобилей, а
+                также элитных (и хорошо вооруженных) солдат.&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;ТОПЛИВО:&lt;/t&gt; Каждому транспортному средству нужно топливо,некоторым
+                требуется больше, чем другим.&lt;br/&gt; &lt;br/&gt;
+                Вы можете встретить все три ресурса в любом секторе, но для значительного и постоянного снабжения вы
+                должны захватывать сектора PoI и Заводы! После захвата оба требуют области хранения (действие меню
+                прокрутки), а затем PoI также потребует создания объекта (опять же, действие в меню прокрутки). Все три
+                объекта могут быть построены в любом одном PoI, но вы должны заплатить первоначальную стоимость, чтобы
+                настроить эти объекты! Это 50 конкретных ресурсов и 100 других двух.&lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                这个战役中你必须管理、囤积并保护三种资源：&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;补给：&lt;/t&gt;最关键的物资。没有补给，你将无法部署更多步兵或军事资源。因此，指挥部建议优先谋取此类资源！&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;弹药：&lt;/t&gt;用于采购步战车（APC）和主战坦克（MBT）等装甲载具，亦用于武装精英（且重装）士兵。&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;燃料：&lt;/t&gt;载具离不了燃料，更不用说胃口极大的那些。&lt;br/&gt; &lt;br/&gt;
+                你能在任意战区中找到以上三种资源，但想要稳定而高效的补给就需要你去占领PoI和工厂战区了！两者在占领后都需要一个仓储区（用滚轮动作菜单建立），而PoI还需要建立额外资源生产设施（依旧是滚轮动作菜单）。一个PoI能够同时容纳全部三种设施，但你必须先行投资才能将这些设施建立起来！建造设施需要消耗50点指定资源以及100点另外两种资源。&lt;br/&gt;
+                &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>&lt;br/&gt;&lt;br/&gt;
+                在這次作戰中你必須管理、囤積與保護三種資源：&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;補給：&lt;/t&gt;最關鍵的物資。一旦沒有補給，你將無法佈署更多士兵或其餘軍事資源，因此，指揮部建議優先謀取這項資源！&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;彈藥：&lt;/t&gt;用來採購步兵戰車（APC）和主戰坦克（MBT）等裝甲載具，同時也被用於招募武裝菁英的重裝士兵。&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;油料：&lt;/t&gt;載具的必需品，任何載具都需要油料，尤其是那些「大胃王」的大型載具們。&lt;br/&gt; &lt;br/&gt;
+                在作戰過程中你或許能在任意戰區內搜刮到以上三種資源，但是為了解放這個區域，你勢必需要更穩定而有效的補給線，這時候你就需要去佔領興趣點(PoI)和工廠了！兩者都能在占領後建立一個倉儲區（用滾輪動作選單來建立），而興趣點還需要額外建立資源生產設施（依舊是滾輪動作選單)。一個PoI能夠同時建立三種生產設施，但你必須先投資才能全數建立起來！建造設施需要
+                50 點對應的資源與其餘兩個資源各 100 點。&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Nesta campanha você deverá gerir, estocar e proteger três tipos de recursos.:&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#00ff00'&gt;SUPRIMENTOS:&lt;/t&gt; Este é o recurso essencial. Sem suprimentos, será
+                impossível mobilizar infantaria adicional ou requisitar equipamentos militares. Desse modo, o QG
+                recomenda priorizar estes recursos!&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ff0000'&gt;MUNIÇÃO:&lt;/t&gt; Utilizada para abastecer veículos blindados armados, bem
+                como soldados de elite de equipamento bélico pesado.&lt;br/&gt; &lt;br/&gt;
+                &lt;t color='#ffff00'&gt;COMBUSTÍVEL:&lt;/t&gt; Todo veículo precisa de combustível, alguns consomem
+                mais que outros.&lt;br/&gt; &lt;br/&gt;
+                Você cruzará com todos os três tipos de recursos dispersos pelos setores, porém para adquirir uma
+                quantidade considerável e abastecimento constante, você deverá capturar setores com fábricas/refinarias.
+                Uma vez capturadas, as fábricas precisarão de um depósito (use o scroll do mouse) e então poderão
+                imediatamente iniciar a produção do recurso pretendido. Se puder arcar com os custos, as fábricas
+                poderão ser aprimoradas para produzir os demais recursos. &lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE6">
+            <Original>6. Alert Level</Original>
+            <French>6. Niveau d'alerte</French>
+            <German>6. Alarmstatus</German>
+            <Spanish>6. Nivel de alerta</Spanish>
+            <Russian>6. Уровень тревоги</Russian>
+            <Italian>6. Livello di Allerta</Italian>
+            <Chinesesimp>6. 警戒等级</Chinesesimp>
+            <Chinese>6. 威脅度</Chinese>
+            <Turkish>6. Uyarı Seviyesi</Turkish>
+            <Portuguese>6. Nível de Alerta</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT6">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                The enemy won't let you liberate all of its brand new territory without a reaction. When you begin the
+                campaign, hostile forces will only be composed of the garrisons inside military bases. However as you
+                become more threatening by liberating more and more sectors, they will start calling in more
+                reinforcements and equipment to counter you.&lt;br/&gt; &lt;br/&gt;
+                To limit the enemies operational capabilities, you will have to fulfill secondary objectives that will
+                consist of destroying their logistical bases and raiding their convoys. This is not required to win the
+                campaign but if you ignore the alert level for too long, you're in for quite a lot of resistance.&lt;br/&gt;
+                &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Der Feind wird nicht untätig dabei zusehen, wie wir alles in seinem brandneuen Territorium nach und nach
+                befreien. Zu Beginn der Kampagne setzen sich die Feindkräfte lediglich aus den Garnisonen innerhalb der
+                Militär Basen zusammen. Wie auch immer, sobald wir für den Feind mehr und mehr zu einer Bedrohnung
+                werden, während wir mehr und mehr Sektoren einnehmen, wird er anfangen, Unterstützung und Ausrüstung
+                anzufordern, um uns zu bekämpfen.&lt;br/&gt; &lt;br/&gt;
+                Um den Feind in seinem militärischen Handlungsspielraum einzuschränken, müssen Sie Sekundärziele
+                erfüllen, die aus Suchen und Zerstören von Logistic Basen, Konvoiüberfällen und Suchen und Retten von
+                Kriegsgefangenen bestehen. Dies ist zwar keine Bedingung für den Erfolg der Kampagne, aber wenn Sie das
+                Bedrohungsniveau zu lange ignorieren, stoßen Sie bald auf recht viel Widerstand.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                Il nemico non ti permetterà di liberare tutto il suo nuovo territorio senza una reazione. Quando
+                inizierai la campagna, le forze ostili saranno composte solo dalle guarnigioni all'interno delle basi
+                militari. Tuttavia, quando diventerete più minacciosi , inizieranno a chiamare più rinforzi e
+                attrezzature per contrastarvi.&lt;br/&gt; &lt;br/&gt;
+                Per limitare la capacità offensiva dei nemici, dovrete compiere missioni secondarie che consistono nel
+                distruggere le basi logistiche e raidare i loro convogli. Questo non è richiesto per vincere la
+                campagna, ma se ignorate troppo il livello di allarta, sarate pronti a contrastare la risposta?.&lt;br/&gt;
+                &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                OPFOR не будут сидеть сложа руки, пока вы будете освобождать все зоны, они будут реагировать на ваши
+                действия. Когда вы начнёте кампанию, враждебные силы будут состоять только из гарнизонов внутри военных
+                баз. Однако, как только вы начнёте овобождать больше и больше зон, OPFOR начнёт вызывать больше
+                подкреплений, отряды и технику для борьбы с вами.&lt;br/&gt; &lt;br/&gt;
+                Чтобы ограничить оперативные возможности OPFOR, вы должны будете выполнять дополнительные задачи,
+                которые будут состоять в уничтожении баз снабжения врага. Это не обязательно, для того, чтобы выиграть
+                кампанию, но если вы будете игнорировать уровень тревоги слишком долго, у вас могут быть большие
+                неприятности.&lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                敌人不可能拱手让出刚刚获得的新领地。战役刚开始时，敌军部队仅由本地军事基地驻扎部队构成，但战区解放的增多你产生的威胁也将逐渐加大，因此他们会开始增派更多、更好的增援和装备来对付你。&lt;br/&gt;
+                &lt;br/&gt;
+                要想遏制住敌人的作战能力，你必须完成摧毁对方后勤基地和劫掠对方补给车队的次要任务。这并非战役的胜利条件，但忽视警戒等级的提高将会大大增加敌人抵抗的强度。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>&lt;br/&gt;&lt;br/&gt;
+                敵人不可能任你為所欲為。作戰剛開始時，敵軍部隊僅由本地軍事基地的駐紮部隊構成，但解放的戰區越多將使你對他們的威脅度也越來越高，而這也將促他們派出更多、更好與更強的部隊與人手來對付你。&lt;br/&gt;
+                &lt;br/&gt;
+                想要遏制住敵人的作戰能力，你必須透過摧毀敵方前線基地、掠奪對方補給車隊等次要任務來破壞他們對你的威脅度評估。次要任務並非這次作戰的必要項目，但坐視警戒度的提升將大大地提升敵人的抵抗強度！&lt;br/&gt;
+                &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                O inimigo não irá permitir a conquista de seu território sem uma reação. Quando iniciar sua campanha,
+                forças hostis serão apenas compostas por guarnições dentro de bases militares. No entanto, ao liberar
+                mais setores, as forças inimigas chamarão mais reforços e equipamentos para tentar te combater.&lt;br/&gt;
+                &lt;br/&gt;
+                Para limitar a capacidade operacional das forças de oposição, você deverá cumprir objetivos secundários
+                que consistem na destruição de bases logísticas e no assalto aos comboios inimigos. Isto não é
+                obrigatório para lograr êxito na campanha, todavia se o nível de alerta for ignorado por muito tempo,
+                você enfrentará uma forte resistência inimiga.&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE7">
+            <Original>7. Construction</Original>
+            <French>7. Construction</French>
+            <German>7. Konstruktion</German>
+            <Spanish>7. Construcción</Spanish>
+            <Russian>7. Строительство</Russian>
+            <Italian>7. Construzioni</Italian>
+            <Chinesesimp>7. 建造</Chinesesimp>
+            <Chinese>7. 建造</Chinese>
+            <Turkish>7. İnşa etmek</Turkish>
+            <Portuguese>7. Construção</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT7">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                To help you succeed in your endeavors, you have a construction capability at every FOB that allows you
+                to deploy infantry, vehicles, defenses, fortifications and so on to your specific location.&lt;br/&gt;
+                &lt;br/&gt;
+                Although infantry, vehicles and defenses will cost resources, fortifications such as structures,
+                sandbags and walls will not.&lt;br/&gt; &lt;br/&gt;
+                The construction system will be available when you are within 100 meters of any FOB.&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Hilfe zum Erfolg Ihrer Bemühungen bieten die Bauoptionen an den einzelnen FOBs, die es Ihnen
+                ermöglichen, Infantrie, Fahrzeuge, Verteidigungsanlagen, Befestigungsanlagen und so weiter, an der
+                jeweiligen Position zu bauen.&lt;br/&gt; &lt;br/&gt;
+                Obgleich Infantrie, Fahrzeuge und Verteidigungsanlagen Ressourcen benötigen, braucht man zum Bau von
+                Befestigungsanlagen wie Gebäuden, Sandsäcken und Wänden keine.&lt;br/&gt; &lt;br/&gt;
+                Die Bauoptionen werden in einem Bereich vom 100 Metern um eine FOB herum verfügbar.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                Per aiutarti a riuscire nella tua missione, ogni FOB ti permette di creare fanteria, veicoli, difese,
+                fortificazioni e così via nella posizione specifica.&lt;br/&gt; &lt;br/&gt;
+                Anche se la fanteria, i veicoli e le difese costano risorse, le fortificazioni come strutture, sandbags
+                e muri non lo faranno.&lt;br/&gt; &lt;br/&gt;
+                Il sistema di costruzione sarà disponibile quando si è a 100 metri da qualsiasi FOB.&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Чтобы помочь вам добиться успеха в ваших начинаниях, у вас есть возможность строительства на каждом FOB,
+                что позволяет вам развертывать пехоту, транспортные средства, оборонительные сооружения, укрепления и
+                т.д. В вашем конкретном месте.&lt;br/&gt; &lt;br/&gt;
+                Хотя пехота, транспортные средства и средства защиты будут стоить ресурсов, тогда как укрепления,
+                конструкции, мешки с песком и стены бесплатны.&lt;br/&gt; &lt;br/&gt;
+                Система строительства будет доступна, если вы находитесь дальше 100 метров от любого FOB.&lt;br/&gt;
+                &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                为了帮助你走向成功，每个前哨都拥有能让你在限定范围内部署步兵、载具、防御、工事等军备的建造能力。&lt;br/&gt; &lt;br/&gt;
+                步兵、载具和防御设备需要消耗资源，但建筑、沙袋、墙体等工事是完全免费的。&lt;br/&gt; &lt;br/&gt;
+                你可以在前哨100米半径范围内启用建造系统。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>
+                &lt;br/&gt;&lt;br/&gt;
+                為了協助你成功解放這裡，指揮部允許你在每個前線基地周遭限定的範圍內佈署步兵、載具、防禦工事等軍備設施與建造工事。&lt;br/&gt; &lt;br/&gt;
+                步兵、載具和防禦設備（如固定式武器）需要消耗資源，但建築、沙包、掩體等工事是完全免費的。&lt;br/&gt; &lt;br/&gt;
+                你可以在前線基地半徑 100 公尺內使用建造系統。&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Para auxiliar no sucesso de sua iniciativa, você terá a capacidade de construir em todas suas bases
+                avançadas, que o permitirá mobilizar infantaria, veículos, defesas, fortificações e etc para sua
+                localidade.&lt;br/&gt; &lt;br/&gt;
+                Embora infantaria, veículos e defesas exijam recursos para seu desenvolvimento, fortificações como
+                estruturas, sacos de areia e muros não terão custo.&lt;br/&gt; &lt;br/&gt;
+                O sistema de construção estará disponível quando você estiver a 100 metros de qualquer FOB.&lt;br/&gt;
+                &lt;br/&gt;
+            </Portuguese>
 
-		</Key>
-		<Key ID="STR_TUTO_TITLE8">
-			<Original>8. Deploying another FOB</Original>
-			<French>8. Déployer une autre FOB</French>
-			<German>8. Errichtung einer weiteren FOB</German>
-			<Spanish>8. Desplegar otra FOB</Spanish>
-			<Russian>8. Развёртывание новой FOB</Russian>
-			<Italian>8. Costruire un'altra FOB</Italian>
-			<Chinesesimp>8. 部署更多前哨</Chinesesimp>
-			<Chinese>8. 部署更多前線基地</Chinese>
-			<Turkish>8. Başka bir FOB kurmak</Turkish>
-			<Portuguese>8. Instalando outra FOB</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT8">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			To build a brand new FOB, go to the construction menu and then the logistics tab and build a FOB container or a FOB truck (the same thing, only with wheels). Then you can position the FOB container/truck where you want to deploy your shiny new FOB. However, be aware that you can't build a FOB within 1km of your starting position, within 300m of any sector, or within 2km of any other FOB.&lt;br/&gt; &lt;br/&gt;
-			That would simply be redundant!&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Um eine brandneue FOB zu bauen, öffnen Sie das Baumenü und unter dem Reiter Logistik bauen Sie einen FOB Container oder einen FOB Lastwagen (dasselbe, bloß mit Rädern). Dann können Sie den FOB Container/Lastwagen an die Position Ihrer Wahl bringen und Ihre niegelnagelneue FOB aufbauen. Beachten Sie, das Sie keine FOB innerhalb von 1km von der Startposition, von 300m von einem Sektor und von 2km von einer anderen FOB aufbauen können.&lt;br/&gt; &lt;br/&gt;
-			Das wäre einfach unnötig!&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			Per costruire una nuova FOB, vai nel menu di costruzione e poi alla scheda logistica e costruisci un contenitore FOB o un camion FOB (la stessa cosa, solo con ruote). Quindi è possibile posizionare il contenitore / camion FOB. Tuttavia, tenere presente che non è possibile costruire un FOB entro 1 km dalla posizione iniziale, ed entro 300 metri da qualsiasi settore, o entro 2 km da qualsiasi altra FOB.&lt;br/&gt; &lt;br/&gt;
-			Sarebbe semplicemente ridondante!&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Чтобы построить совершенно новый FOB, перейдите в меню конструирования, а затем вкладку логистики и постройте контейнер FOB или грузовик FOB (то же самое, только с колесами). Затем вы можете разместить контейнер / грузовик FOB, где вы хотите развернуть свой новый новый FOB. Однако имейте в виду, что вы не можете построить FOB в пределах 1 км от начальной позиции, в пределах 300 м от любого сектора или в пределах 2 км от любого другого FOB.&lt;br/&gt; &lt;br/&gt;
-			Это было бы просто излишним!&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			要建立一个新前哨，打开建造菜单的后勤面板并建造一个前哨部署柜或前哨部署车（一样的东西，只是多了轮子罢了）。然后你就可以将前哨部署柜/车安置到想部署的地方了。注意，你不能在距离出发点1公里内、战区300米内和其它前哨2公里内部署前哨。&lt;br/&gt; &lt;br/&gt;
-			因为搞那么多前哨实在太多余了！&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>&lt;br/&gt;&lt;br/&gt;
-			要建立一个新的前線基地，打開建造選單的後勤面板，並建立一個前線基地貨櫃或前線基地載具（一樣的東西，只是多個輪子）。然後你就能帶著前線基地貨櫃或前線基地車到任何你想佈署的位置進行佈署了。注意，你不能在起始作戰基地 1 公里內、戰區 300 公尺内，或是其它前線基地 2 公里内部署前線基地。&lt;br/&gt; &lt;br/&gt;
-			因為這麼多前線基地實在是太多餘了！&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Para construir uma nova FOB, acesse o menu de construção, selecione a aba de logística e então construir FOB no conteiner ou uma FOB transportável (é a mesma coisa, mas com rodas). Em seguida, poderá posicionar sua linda e nova FOB (transportável ou no conteiner) onde desejar. No entanto, esteja ciente de que não poderá construir a FOB dentro de 1km da sua posição inicial, dentro de 300 metros de qualquer setor ou dentro de 2km de outra FOB.&lt;br/&gt; &lt;br/&gt;
-			Seria simplesmente redundante!&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE9">
-			<Original>9. Secondary Objectives</Original>
-			<French>9. Missions secondaires</French>
-			<German>9. Sekundäre Ziele</German>
-			<Spanish>9. Objetivos secundarios</Spanish>
-			<Russian>9. Дополнительные задания</Russian>
-			<Italian>9. Obiettivi Secondari</Italian>
-			<Chinesesimp>9. 次要目标</Chinesesimp>
-			<Chinese>9. 次要目標</Chinese>
-			<Turkish>9. İkincil Objektifler</Turkish>
-			<Portuguese>9. Objetivos Secundários</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT9">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			When you capture sectors, sometimes the few hostiles forces remaining will surrender. You can then capture those prisoners and take them back to a nearby FOB to be interrogated.&lt;br/&gt; &lt;br/&gt;
-			That interrogation, executed in the utmost respect of the Geneva Convention, will allow you to obtain information which can be used to reveal the rough position of an enemy logistics base, enemy convoy or friendly search and rescue.&lt;br/&gt; &lt;br/&gt;
-			After going there you will need to find the exact position of your target, then use any means at your disposal to complete your objective. Succeeding at this task will be rewarded, reducing the alert level consequently and with it the efficiency of all hostile forces.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Nach Befreiung eines Sektors, werden sich manchmal ein paar der verbliebenen Feindkräfte ergeben. Sie können sie gefangen nehmen und zu einer nahegelegenen FOB bringen, um sie zu verhören.&lt;br/&gt; &lt;br/&gt;
-			Dieses Verhör wird unter höchster Rücksichtnahme auf die Genfer Konventionen durchgeführt und bringt Ihnen präzise Informationen, die dazu genutzt werden können, um die ungefähre Lage einer feindlichen Logistik Basis zu bestimmen, feindliche Konvois aufzuspühren oder auch die ungefähre Position von Kriegsgefangenen zu ermitteln.&lt;br/&gt; &lt;br/&gt;
-			Wenn sie dort angekommen sind, müssen Sie die exakte Position Ihres Ziels herausfinden, dann setzen Sie alle Ihnen zur Verfügung stehenden Mittel ein, um das Einsatzziel zu erreichen. Ein erfolgreicher Einsatz wird mit Verringerung des Bedrohungsniveaus und damit der Effektivität der feindlichen Streitkräfte belohnt.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			Quando catturi i settori, talvolta le forze ostili che restano si arrenderanno. Quindi puoi catturare quei prigionieri e riportarli in una FOB vicina per interrogarli.&lt;br/&gt; &lt;br/&gt;
-			Questa interrogazione, eseguita nel più grande rispetto della Convenzione di Ginevra, ti permetterà di ottenere informazioni precise che possano essere utilizzate per rivelare la posizione rudimentale di una base logistica nemica, di un convoglio nemico o di un salvataggio.&lt;br/&gt; &lt;br/&gt;
-			Dopo essere andato lì dovrai trovare la posizione esatta del tuo bersaglio, quindi utilizzare qualsiasi mezzo a tua disposizione per completare il tuo obiettivo. Eseguire questo compito sarà premiato, riducendo così il livello di allarme e con essa l'efficienza di tutte le forze ostili.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Когда вы захватываете сектора, иногда несколько оставшихся сил противника будут сдаваться. Затем вы можете захватить этих пленных и отвезти их в соседний ФОБ для допроса.&lt;br/&gt; &lt;br/&gt;
-			Этот допрос, выполненный в полном уважении Женевской конвенции, позволит вам получить точную информацию, которая может быть использована для выявления грубой позиции базы материально-технического обеспечения противника, конвоя противника или дружественного поиска и спасения.&lt;br/&gt; &lt;br/&gt;
-			Побывав там, вам нужно будет найти точное положение вашей цели, а затем использовать любые имеющиеся в вашем распоряжении средства для достижения своей цели. Достижение этой цели будет вознаграждено, следовательно, будет уменьшаться уровень оповещения, а вместе с ним и эффективность всех враждебных сил.&lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			有时候当你占领战区时，一些敌军残部会选择投降。你可以将他们抓到就近的前哨去审问。&lt;br/&gt; &lt;br/&gt;
-			这种在完全遵照日内瓦公约的情况下进行的审问，能为你提供用于揭示敌军后勤基地大致位置、补给车队或友军搜索与营救任务的准确情报。&lt;br/&gt; &lt;br/&gt;
-			之后你就需要找到目标的准确位置，并不惜一切代价完成目标。任务的成功带来的奖励将导致警戒等级下降，并进而削弱所有敌军部队的战斗力。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>&lt;br/&gt;&lt;br/&gt;
-			有时候當你占領戰區時，一些敵軍殘兵會選擇投降。你可以將他們抓到任何一個前線基地（不包含起始作戰基地）進行審問。&lt;br/&gt; &lt;br/&gt;
-			審問後獲得的情資將能用來定位出敵方前線基地或補給車隊的大致位置、或是換取搜索與營救友軍的準確情報。&lt;br/&gt; &lt;br/&gt;
-			之後你必須找到這些目標的精確位置並不惜代價完成任務。任務成功的獎勵將降低敵方的警界度，並進而削弱所有敵軍的戰鬥能力。&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Quando você capturar setores, em algumas situações as forças hostis remanescentes se renderão. Você poderá capturar os prisioneiros e levá-los para a FOB mais próxima para serem interrogados.&lt;br/&gt; &lt;br/&gt;
-			O interrogatório, executado em observância à Convenção de Genebra, o permitirá a obtenção de informações que podem ser empregadas para revelar a posição aproximada da base de logística inimiga, comboio inimigo ou operações de busca e resgate de forças aliadas.&lt;br/&gt; &lt;br/&gt;
-			Após chegar na área de operações, você precisará identificar a localização exata do seu alvo, e então fazer uso dos meios necessários à sua disposição para concluir seu objetivo. Ao lograr êxito em sua tarefa, serão recompensados, reduzindo o nível de alerta  reducing the alert level inimigo e consequentemente a eficiência de todas as forças hostis.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TITLE10">
-			<Original>10. Commanding</Original>
-			<French>10. Commandement</French>
-			<German>10. Oberkommando</German>
-			<Spanish>10. Comandancia</Spanish>
-			<Russian>10. Командование</Russian>
-			<Italian>10. Comando</Italian>
-			<Chinesesimp>10. 指挥</Chinesesimp>
-			<Chinese>10. 指挥</Chinese>
-			<Turkish>10. Komuta etmek</Turkish>
-			<Portuguese>10. Comandando</Portuguese>
-		</Key>
-		<Key ID="STR_TUTO_TEXT10">
-			<Original>&lt;br/&gt;&lt;br/&gt;
-			When a player uses the Commander role, they get access to the Zeus interface by pressing the corresponding key (Y by default). This interface allows the commanding of friendly forces in 3D or map view.&lt;br/&gt; &lt;br/&gt;
-			Moreover the commander gets additional build options that will allow them to obtain crewed vehicles or entire pre-made squads.&lt;br/&gt; &lt;br/&gt;
-			This role is now mandatory, as it provides direct access to the management of production sectors and AI logistics. Given that you are positioned by a FOB, you will see the options "Production Settings" and "Logistic Overview".&lt;br/&gt; &lt;br/&gt; The first enables the ability to decide which Factory produces which specific resources, as well as a detailed current overview.&lt;br/&gt; &lt;br/&gt; The latter allows you to command an AI logitical convoy, where you may "Add" logistical groups, purchase any amount of trucks per group and command them to move specific amounts of resources across the region for you.&lt;br/&gt; &lt;br/&gt;
-			</Original>
-			<German>&lt;br/&gt;&lt;br/&gt;
-			Wenn ein Spieler die Rolle des Commanders übernimmt, bekommt er spezifischen Zugang zum Zeus-Interface, wenn er die entsprechende Taste dafür drückt (default Z). Dieses Interface erlaubt das Kommandieren befreundeter Einheiten in der 3D- und Kartenansicht.&lt;br/&gt; &lt;br/&gt;
-			Darüber hinaus hat der Commander erweiterte Bauoptionen, die es ihm ermöglichen, Fahrzeuge mit Besatzung oder auch komplette vorgefertigte Squads zu bauen.&lt;br/&gt; &lt;br/&gt;
-			Die Rolle des Commanders ist nun zwingend erforderlich, da sie direkten Zugang zum Management von Produktionssektoren und KI-Logistik bietet. Dafür hat man an einer FOB die Optionen "Produktionseinstellungen" und "Logistikübersicht".&lt;br/&gt; &lt;br/&gt; Ersteres gewährt sowohl die Möglichkeit zu entscheiden, welcher PoI oder welche Fabrik welche Ressourcen produzieren soll, als auch einen detaillierten aktuellen Überblick.&lt;br/&gt; &lt;br/&gt; Letzteres erlaubt es, einen KI-Logistik-Konvoi zu befehligen, wobei man Logistik-Gruppen hinzufügen, eine beliebige Anzahl an Lkw pro Gruppe kaufen und diese dann befehligen kann, eine bestimmte Anzahl an Ressourcen quer über die Gesammte Region zu verfahren.&lt;br/&gt; &lt;br/&gt;
-			</German>
-			<Italian>&lt;br/&gt;&lt;br/&gt;
-			Quando un giocatore usa il ruolo del comandante, ottierrà l'accesso all'interfaccia di Zeus premendo il tasto corrispondente (Y per impostazione predefinita). Questa interfaccia consente il comando di forze amiche in visualizzazione 3D o mappa.&lt;br/&gt; &lt;br/&gt;
-			Inoltre il comandante ottiene ulteriori opzioni di costruzione che consentiranno loro di ottenere veicoli con equipaggio o intere squadre pre-fatte.&lt;br/&gt; &lt;br/&gt;
-			Questo ruolo è ora obbligatorio in quanto fornisce accesso diretto alla gestione dei settori produttivi e alla logistica AI. Dato che sei posizionato da una FOB, vedrai le opzioni "Impostazioni di produzione" e "Panoramica logistica".&lt;br/&gt; &lt;br/&gt; Il primo consente di decidere quali PDI o Fabbriche producono  risorse specifiche, così come una panoramica corrente dettagliata.&lt;br/&gt; &lt;br/&gt; Quest'ultimo ti permette di comandare un convoglio logistico di AI, dove puoi "aggiungere" gruppi logistici, acquistare qualsiasi quantità di camion per gruppo e mandarli a spostare determinate risorse in tutta la regione per te.&lt;br/&gt; &lt;br/&gt;
-			</Italian>
-			<Russian>&lt;br/&gt;&lt;br/&gt;
-			Когда игрок использует роль Commander, он получает специальный доступ к интерфейсу Zeus, нажав соответствующую клавишу (по умолчанию Y). Этот интерфейс позволяет управлять дружественными силами в трехмерном режиме или в режиме карты. &lt;br/&gt; &lt;br/&gt;
-			Кроме того, командир получает дополнительные варианты сборки, которые позволят ему создавать технику с экипажем или готовые отряды. &lt;br/&gt; &lt;br/&gt;
-			Эта роль в настоящее время является обязательной, поскольку она обеспечивает прямой доступ к управлению производственными секторами и логистикой ИИ. Учитывая, что вы позиционируетесь по FOB, вы увидите варианты «Настройки производства» и «Обзор логистики». &lt;br/&gt; &lt;br/&gt; Первое позволяет определить, какой PoI или Factory создает конкретные ресурсы, а также подробный текущий обзор.&lt;br/&gt; &lt;br/&gt; Последний позволяет вам управлять логическим конвоем AI, в котором вы можете «Добавить» логистические группы, приобрести любое количество грузовиков на группу и приказать им перемещать определенные объемы ресурсов в регионе для вас. &lt;br/&gt; &lt;br/&gt;
-			</Russian>
-			<Chinesesimp>&lt;br/&gt;&lt;br/&gt;
-			当一名玩家扮演指挥官角色时，他将会得到按指定按键（默认为Y）打开宙斯（Zeus）界面的权限。该界面让玩家可以在3D或地图视角中指挥友军部队。&lt;br/&gt; &lt;br/&gt;
-			除此以外，指挥官还有额外的建造选项，让他可以招募有乘员的载具或一整个预设的AI班组。&lt;br/&gt; &lt;br/&gt;
-			现阶段由于该角色有着战区产出管理和AI后勤的直接权限，因此必须有玩家进行操作。当处于前哨范围内时，你将会看到“产出设置”和“后勤总览”两个选项。&lt;br/&gt; &lt;br/&gt;前者有着指定PoI和工厂资源产出类型，以及查看总览细目的功能。&lt;br/&gt; &lt;br/&gt;后者则让你能够指挥AI后勤车队，其中你可以“添加”后勤组、为后勤组购买任意数量的卡车，以及指挥他们在这个地区中往来运输指定资源。&lt;br/&gt; &lt;br/&gt;
-			</Chinesesimp>
-			<Chinese>&lt;br/&gt;&lt;br/&gt;
-			當一名玩家扮演指揮官角色時，他將會得到使用宙斯功能的權限，該介面讓玩家可以在 3D 或地圖視角中指揮友軍部隊。&lt;br/&gt; &lt;br/&gt;
-			除此之外，指揮官還有額外的建築選項，讓他可以招募載有友軍單位的載具或一整個預設的 AI 班級。&lt;br/&gt; &lt;br/&gt;
-			現階段由於該角色有著戰區產出管理與AI後勤管理的直接權限，因此必須有玩家進行操作。當處於前線基地的範圍內時，你將會看到「產出設定」和「後勤總覽」兩個選項。&lt;br/&gt; &lt;br/&gt;
-			前者有著指定PoI和工廠資源產出類型，以及察看總覽細項的功能。&lt;br/&gt; &lt;br/&gt;後者則讓你能夠指揮 AI 車隊，其中你可以「添增」後勤單位、為後勤單位購買任意數量的卡車，並指揮他們在指定區域之間來往進行運輸物資。&lt;br/&gt; &lt;br/&gt;
-			</Chinese>
-			<Portuguese>&lt;br/&gt;&lt;br/&gt;
-			Quando um jogador assume a função de comandante, ele recebem acesso à interface Zeus ao pressionar a tecla correspondente (a tecla padrão é 'Y'). Essa interface permite o comando de forças aliadas na plataforma 3D ou através do mapa.&lt;br/&gt; &lt;br/&gt;
-			Ademais, o comandante recebe opções adicionais de construção que o permitirão obter veículos tripulados ou grupos predeterminados.&lt;br/&gt; &lt;br/&gt;
-			Tal função é agora obrigatória, pois possibilita acesso direto à gestão dos setores de produção e logísticas automatizadas. Quando estiver posicionado numa FOB, você poderá observar as opções "Configuração de Produção" e "Visão Geral de Logística".&lt;br/&gt; &lt;br/&gt; A primeira habilita a capacidade de decidir que fabrica/refinaria irá produzir qual recurso específico, bem como uma visão geral detalhada sobre o serviço.&lt;br/&gt; &lt;br/&gt; O último permite a você comandar o sistema automatizado de comboio logístico, onde você poderá "adicionar" grupos logísticos, adquirir quantos transportes desejar e os comandar para transportar quantidades específicas de recursos através do território.&lt;br/&gt; &lt;br/&gt;
-			</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_ARSENALUSEPRESET">
-			<Original>Arsenal mode</Original>
-			<German>Arsenalmodus</German>
-			<Italian>Modalità Arsenale</Italian>
-			<Chinesesimp>军火库模式</Chinesesimp>
-			<Chinese>軍火庫模式</Chinese>
-			<Turkish>Ekipman(Arsenal) modu</Turkish>
-			<Portuguese>Modo do Arsenal</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_NORESTRICTIONS">
-			<Original>No restrictions</Original>
-			<German>Keine Einschränkungen</German>
-			<Italian>Senza Restrizioni</Italian>
-			<Chinesesimp>无限制</Chinesesimp>
-			<Chinese>無限制</Chinese>
-			<Turkish>Kısıtlama yok</Turkish>
-			<Portuguese>Sem restrições</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_USEPRESET">
-			<Original>Use preset from config</Original>
-			<German>Benutze Preset aus Konfiguration</German>
-			<Italian>Usa il file config.sqf</Italian>
-			<Chinesesimp>使用配置文件中的预设内容</Chinesesimp>
-			<Chinese>使用設定文件中的預設內容</Chinese>
-			<Turkish>config.sqf kullan</Turkish>
-			<Portuguese>Usar predefinição de config.sqf</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_CRATE_PUSH">
-			<Original>-- PUSH CRATE</Original>
-			<German>-- KISTE SCHIEBEN</German>
-			<Italian>-- SPINGI CASSA</Italian>
-			<Chinesesimp>-- 推货箱</Chinesesimp>
-			<Chinese>-- 推貨物</Chinese>
-			<Turkish>-- KUTUYU İTTİR</Turkish>
-			<Portuguese>-- EMPURRAR CAIXA --</Portuguese>
-		</Key>
-		<Key ID="STR_ACTION_SORT_STORAGE">
-			<Original>-- STACK AND SORT</Original>
-			<German>-- STAPELN UND SORTIEREN</German>
-			<Italian>--	IMPILA E ORDINA</Italian>
-			<Chinesesimp>-- 排列并分类</Chinesesimp>
-			<Chinese>-- 排列並分類</Chinese>
-			<Turkish>-- SIRALA VE DÜZENLE</Turkish>
-			<Portuguese>-- ORDENAR E CLASSIFICAR --</Portuguese>
-		</Key>
-		<!-- Added or changed in v0.96 -->
-		<Key ID="STR_PARAMS_SUPPMOD">
-			<Original>BI Support Module System access</Original>
-			<German>BI Support Module System Zugriff</German>
-			<Italian>Accesso Modulo Di Supporto BI</Italian>
-			<Chinesesimp>BI支援模块系统权限</Chinesesimp>
-			<Chinese>BI支援模塊系統權限</Chinese>
-			<Portuguese>Acesso ao Módulo de Suporte da Bohemia Interactive</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_COMMANDER">
-			<Original>Commander only</Original>
-			<German>Nur Kommandant</German>
-			<Italian>Solo per il Comandante</Italian>
-			<Chinesesimp>仅指挥官</Chinesesimp>
-			<Chinese>僅指揮官</Chinese>
-			<Turkish>Sadece komutan</Turkish>
-			<Portuguese>Apenas comandante</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_WHITELISTONLY">
-			<Original>Whitelisted only</Original>
-			<German>Nur Whitelist</German>
-			<Italian>Con Whitelist</Italian>
-			<Chinesesimp>仅白名单</Chinesesimp>
-			<Chinese>僅白名單</Chinese>
-			<Turkish>Sadece beyaz listedekiler</Turkish>
-			<Portuguese>Apenas quem está na lista de permissão</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_EVERYONE">
-			<Original>Everyone</Original>
-			<German>Jeder</German>
-			<Italian>Tutti</Italian>
-			<Chinesesimp>所有人</Chinesesimp>
-			<Chinese>所有人</Chinese>
-			<Turkish>Herkes</Turkish>
-			<Portuguese>Todos</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_EXTENDED_OPTIONS_ACTIONMENU">
-			<Original>-- Extended Options --</Original>
-			<German>-- Erweiterte Optionen --</German>
-			<Italian>-- Opzioni Avanzate --</Italian>
-			<Chinesesimp>-- 扩展选项 --</Chinesesimp>
-			<Chinese>-- 擴增選項 --</Chinese>
-			<Turkish>-- Gelişmiş Ayarlar --</Turkish>
-			<Portuguese>-- Opções Avançadas --</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_EXTENDED_OPTIONS">
-			<Original>Extended Options</Original>
-			<German>Erweiterte Optionen</German>
-			<Italian>Opzioni Avanzate</Italian>
-			<Chinesesimp>扩展选项</Chinesesimp>
-			<Chinese>擴增選項</Chinese>
-			<Turkish>Gelişmiş Ayarlar</Turkish>
-			<Portuguese>Opções Avançadas</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_DISABLED">
-			<Original>- disabled -</Original>
-			<German>- deaktiviert -</German>
-			<Italian>- disabilitato -</Italian>
-			<Chinesesimp>- 已禁用 -</Chinesesimp>
-			<Chinese>- 已禁用 -</Chinese>
-			<Turkish>- kapalı -</Turkish>
-			<Portuguese>- desativado -</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_SQUAD_MANAGEMENT">
-			<Original>Squad Management</Original>
-			<German>Truppmanagement</German>
-			<Italian>Gestione Squadra</Italian>
-			<Chinesesimp>班组管理</Chinesesimp>
-			<Chinese>班級管理</Chinese>
-			<Turkish>Tim Yönetimi</Turkish>
-			<Portuguese>Gestão de equipe</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_JOIN">
-			<Original>Join</Original>
-			<German>Beitreten</German>
-			<Italian>Unisciti</Italian>
-			<Chinesesimp>加入</Chinesesimp>
-			<Chinese>加入</Chinese>
-			<Turkish>Katıl</Turkish>
-			<Portuguese>Se juntar</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_CREATE">
-			<Original>Create</Original>
-			<German>Erstellen</German>
-			<Italian>Crea</Italian>
-			<Chinesesimp>创建</Chinesesimp>
-			<Chinese>建立</Chinese>
-			<Turkish>Yarat</Turkish>
-			<Portuguese>Criar</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_RENAME">
-			<Original>Rename</Original>
-			<German>Umbenennen</German>
-			<Italian>Rinomina</Italian>
-			<Chinesesimp>重命名</Chinesesimp>
-			<Chinese>重新命名</Chinese>
-			<Turkish>Yeniden Adlandır</Turkish>
-			<Portuguese>Renomear</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_LEADER">
-			<Original>Leader</Original>
-			<German>Anführer</German>
-			<Italian>Capo Squadra</Italian>
-			<Chinesesimp>班长</Chinesesimp>
-			<Chinese>班長</Chinese>
-			<Turkish>Lider</Turkish>
-			<Portuguese>Líder</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_CANCEL">
-			<Original>Cancel</Original>
-			<German>Abbrechen</German>
-			<Italian>Cancella</Italian>
-			<Chinesesimp>取消</Chinesesimp>
-			<Chinese>取消</Chinese>
-			<Turkish>İptal</Turkish>
-			<Portuguese>Cancelar</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_CHOOSE">
-			<Original>Choose</Original>
-			<German>Wählen</German>
-			<Italian>Scegli</Italian>
-			<Chinesesimp>选择</Chinesesimp>
-			<Chinese>選擇</Chinese>
-			<Turkish>Seç</Turkish>
-			<Portuguese>Selecionar</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_PLATOON_SQUAD_AWARENESS">
-			<Original>Platoon and Squad Awareness</Original>
-			<German>Sichthilfen und Kartenmarkierungen</German>
-			<Italian>Indicatori di Mappa</Italian>
-			<Chinesesimp>班排警戒</Chinesesimp>
-			<Chinese>班排警戒</Chinese>
-			<Turkish>Platon ve Tim Farkındalığı</Turkish>
-			<Portuguese>Indicador de grupo no mapa</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_SHOW_PLATOON_OVERLAY">
-			<Original>Show platoon overlay: </Original>
-			<German>Platoon Overlay: </German>
-			<Italian>Indicatore Plotone: </Italian>
-			<Chinesesimp>显示排界面：</Chinesesimp>
-			<Chinese>顯示排介面：</Chinese>
-			<Turkish>Platonu ekranda göster: </Turkish>
-			<Portuguese>Mostrar indicador de pelotão:</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_ACTIVE">
-			<Original>active</Original>
-			<German>aktiv</German>
-			<Italian>attivo</Italian>
-			<Chinesesimp>启用</Chinesesimp>
-			<Chinese>啟用</Chinese>
-			<Turkish>aktif</Turkish>
-			<Portuguese>Ativo</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_SHOW_PLAYER_NAMETAGS">
-			<Original>Show player nametags: </Original>
-			<German>Spielernamen: </German>
-			<Italian>Indicatore Nomi:  </Italian>
-			<Chinesesimp>显示玩家铭牌：</Chinesesimp>
-			<Chinese>顯示玩家名牌：</Chinese>
-			<Turkish>Oyuncu isimlerini göster: </Turkish>
-			<Portuguese>Mostrar nome dos jogadores</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_YES">
-			<Original>Yes</Original>
-			<German>Ja</German>
-			<Italian>Si</Italian>
-			<Chinesesimp>是</Chinesesimp>
-			<Chinese>是</Chinese>
-			<Turkish>Evet</Turkish>
-			<Portuguese>Sim</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_NO">
-			<Original>No</Original>
-			<German>Nein</German>
-			<Italian>No</Italian>
-			<Chinesesimp>否</Chinesesimp>
-			<Chinese>否</Chinese>
-			<Turkish>Evet</Turkish>
-			<Portuguese>Não</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_ADJUST_VIEW_DISTANCE">
-			<Original>Adjust View Distance</Original>
-			<German>Sichtweite ändern</German>
-			<Italian>Aggiusta Distanza Visiva</Italian>
-			<Chinesesimp>调整视距</Chinesesimp>
-			<Chinese>調整視距</Chinese>
-			<Turkish>Görüş Mesafesi</Turkish>
-			<Portuguese>Ajustar distância de visão</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_VIEW_DISTANCE">
-			<Original>View Distance</Original>
-			<German>Sichtweite</German>
-			<Italian>Distanza Visuale</Italian>
-			<Chinesesimp>视野距离</Chinesesimp>
-			<Chinese>視野距離</Chinese>
-			<Turkish>Görüş Mesafesi</Turkish>
-			<Portuguese>Distância de visão</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_INFANTRY">
-			<Original>Infantry</Original>
-			<German>Infanterie</German>
-			<Italian>Fanteria</Italian>
-			<Chinesesimp>步兵</Chinesesimp>
-			<Chinese>步兵</Chinese>
-			<Turkish>Kara Askeri</Turkish>
-			<Portuguese>Infantaria</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_VEHICLES">
-			<Original>Vehicles</Original>
-			<German>Fahrzeuge</German>
-			<Italian>Veicoli</Italian>
-			<Chinesesimp>载具</Chinesesimp>
-			<Chinese>載具</Chinese>
-			<Turkish>Araçlar</Turkish>
-			<Portuguese>Veículos</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_OBJECTS">
-			<Original>Objects</Original>
-			<German>Objekte</German>
-			<Italian>Oggetti</Italian>
-			<Chinesesimp>物体</Chinesesimp>
-			<Chinese>物件</Chinese>
-			<Turkish>Objeler</Turkish>
-			<Portuguese>Objetos</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_ADJUST_VIEW_DISTANCE_TO_KEEP_FPS_ABOVE">
-			<Original>Adjust view distance to keep FPS above</Original>
-			<German>Automatische Sichtweite für FPS über</German>
-			<Italian>Aggiusta distanza in base agli FPS</Italian>
-			<Chinesesimp>动态调整视距令FPS高于</Chinesesimp>
-			<Chinese>自動調整視距並確保 FPS 高於</Chinese>
-			<Turkish>Görüş mesafesini ayarlarak FPS'i yüksek tutun</Turkish>
-			<Portuguese>Ajustar distância de visão para manter FPS acima de</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_ADJUST_TERRAIN_DETAILS">
-			<Original>Adjust Terrain Details</Original>
-			<German>Landschaftdetails</German>
-			<Italian>Aggiusta Dettagli Terreno</Italian>
-			<Chinesesimp>调整地形细节</Chinesesimp>
-			<Chinese>調整地形細節</Chinese>
-			<Turkish>Yer Detayı Ayarı</Turkish>
-			<Portuguese>Ajustar detalhes do terreno</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_VERY_LOW">
-			<Original>Very Low</Original>
-			<German>Sehr niedrig</German>
-			<Italian>Molto Basso</Italian>
-			<Chinesesimp>极低</Chinesesimp>
-			<Chinese>極低</Chinese>
-			<Turkish>Çok Düşük</Turkish>
-			<Portuguese>Muito baixo</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_LOW">
-			<Original>Low</Original>
-			<German>Niedrig</German>
-			<Italian>Basso</Italian>
-			<Chinesesimp>低</Chinesesimp>
-			<Chinese>低</Chinese>
-			<Turkish>Düşük</Turkish>
-			<Portuguese>Baixo</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_NORMAL">
-			<Original>Normal</Original>
-			<German>Normal</German>
-			<Italian>Normale</Italian>
-			<Chinesesimp>正常</Chinesesimp>
-			<Chinese>正常</Chinese>
-			<Turkish>Normal</Turkish>
-			<Portuguese>Normal</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_HIGH">
-			<Original>High</Original>
-			<German>Hoch</German>
-			<Italian>Alto</Italian>
-			<Chinesesimp>高</Chinesesimp>
-			<Chinese>高</Chinese>
-			<Turkish>Yüksek</Turkish>
-			<Portuguese>Alto</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_SHOW_TEAMMATES_ON_MAP">
-			<Original>Show teammates on map: </Original>
-			<German>Truppmitglieder auf Karte:</German>
-			<Italian>Mostra compagni in mappa:</Italian>
-			<Chinesesimp>在地图上显示友军：</Chinesesimp>
-			<Chinese>在地圖上顯示友軍單位：</Chinese>
-			<Turkish>Dostları haritada göster: </Turkish>
-			<Portuguese>Mostrar membros da equipe no mapa:</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_INVEHICLE_SOUND_VOLUME">
-			<Original>In-Vehicle Sound Volume</Original>
-			<German>Fahrzeug Innenlautstärke</German>
-			<Italian>Suono veicolo a bordo</Italian>
-			<Chinesesimp>载具内音量</Chinesesimp>
-			<Chinese>載具內音量</Chinese>
-			<Turkish>Araç-içi Ses</Turkish>
-			<Portuguese>Volume do som dentro do veículo</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_TEST">
-			<Original>Test</Original>
-			<German>Test</German>
-			<Italian>Test</Italian>
-			<Chinesesimp>测试</Chinesesimp>
-			<Chinese>測試</Chinese>
-			<Turkish>Test</Turkish>
-			<Portuguese>Teste</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_RESPAWN">
-			<Original>Respawn</Original>
-			<German>Respawn</German>
-			<Italian>Riapparizione</Italian>
-			<Chinesesimp>重生</Chinesesimp>
-			<Chinese>重生</Chinese>
-			<Turkish>Yeniden Doğ</Turkish>
-			<Portuguese>Respawn</Portuguese>
-		</Key>
-		<Key ID="STR_GREUH_REPLACE_NEAREST_AI">
-			<Original>Replace nearest AI</Original>
-			<German>Ersetze nächste KI</German>
-			<Italian>Rimpiazza AI</Italian>
-			<Chinesesimp>就近附身AI</Chinesesimp>
-			<Chinese>就近附身 AI</Chinese>
-			<Turkish>En yakındaki AI ile değiş</Turkish>
-			<Portuguese>Substituir IA mais próxima</Portuguese>
-		</Key>
-		<Key ID="STR_CR_KILLMSG">
-			<Original>A civilian named %1 was killed!</Original>
-			<German>Ein Zivilist mit Namen %1 wurde getötet!</German>
-			<Italian>Un civile di nome %1 è stato ucciso!</Italian>
-			<Chinesesimp>一个名叫%1的平民被击杀了！</Chinesesimp>
-			<Chinese>一個名叫 %1 的平民被擊殺了！</Chinese>
-			<Turkish>%1 ismindeki sivil öldürüldü!</Turkish>
-			<Portuguese>Um civil de nome %1 foi morto!</Portuguese>
-		</Key>
-		<Key ID="STR_CR_VEHICLEMSG">
-			<Original>A civilian's vehicle was seized!</Original>
-			<German>Ein Zivilfahrzeug wurde beschlagnahmt!</German>
-			<Italian>Un veicolo civile è stato confiscato!</Italian>
-			<Chinesesimp>一辆平民载具被强征了！</Chinesesimp>
-			<Chinese>一輛平民載具備強徵了！</Chinese>
-			<Turkish>Bir sivil aracı ele geçirildi!</Turkish>
-			<Portuguese>Um veículo de civil foi tomado!</Portuguese>
-		</Key>
-		<Key ID="STR_CR_BUILDINGMSG">
-			<Original>Civilians are complaining about %1 lost buildings.</Original>
-			<German>Die Zivilisten beklagen sich über %1 verlorene Gebäude.</German>
-			<Italian>Civili si lamentano della perdita di %1 edifici.</Italian>
-			<Chinesesimp>平民们对%1建筑的损坏有所怨言。</Chinesesimp>
-			<Chinese>平民們對 %1 的建築物戰損有所怨言。</Chinese>
-			<Turkish>Siviller %1 kadar yıkılan binaları hakkında konuşuyorlar.</Turkish>
-			<Portuguese>Civis estão reclamando sobre %1 construções destruídas</Portuguese>
-		</Key>
-		<Key ID="STR_CR_HEALMSG">
-			<Original>Civilian named %1 is thankful for your help.</Original>
-			<German>Der Zivilist %1 ist dankbar für die Hilfe.</German>
-			<Italian>Il civile di nome %1 ti ringrazia per l'aiuto.</Italian>
-			<Portuguese>Um civil chamado %1 agradeceu sua ajuda.</Portuguese>
-			<Chinese>平民 %1 感謝你的幫助。</Chinese>
-		</Key>
-		<Key ID="STR_PARAM_CR_BUILDING">
-			<Original>Civil Reputation penalty for buildings if building is</Original>
-			<German>Ziviles Ansehen sinkt, wenn Gebäude</German>
-			<Italian>Penalità nella reputazione coi civili , se l'edeficio è</Italian>
-			<Chinesesimp>当建筑_____时，民间声望会降低</Chinesesimp>
-			<Chinese>當建築物＿＿時，民間聲望會降低。</Chinese>
-			<Turkish>Şu türdeki binalara ceza verilince, ceza uygulanır</Turkish>
-			<Portuguese>Penalidade na reputação civil se a construção estiver</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_CR_DAMAGED">
-			<Original>damaged</Original>
-			<German>beschädigt</German>
-			<Italian>danneggiato</Italian>
-			<Chinesesimp>受损</Chinesesimp>
-			<Chinese>受損</Chinese>
-			<Turkish>zarar görmüş</Turkish>
-			<Portuguese>Danificada</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_CR_DESTROYED">
-			<Original>fully destroyed</Original>
-			<German>komplett zerstört</German>
-			<Italian>completamente distrutto</Italian>
-			<Chinesesimp>完全损毁</Chinesesimp>
-			<Chinese>完全損毀</Chinese>
-			<Turkish>tamamen yokedilmiş</Turkish>
-			<Portuguese>Totalmente destruída</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_RESTART_TITLE">
-			<Original>SERVER RESTART NOTIFICATION</Original>
-			<German>SERVER RESTART HINWEIS</German>
-			<Italian>NOTIFICA RESTART SERVER</Italian>
-			<Turkish>SERVER YENİDEN BAŞLATMA BİLDİRİMİ</Turkish>
-			<Chinesesimp>服务器重启提醒</Chinesesimp>
-			<Chinese>伺服器重啟提醒</Chinese>
-			<Portuguese>NOTIFICAÇÃO DE REINÍCIO DO SERVIDOR</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_RESTART_SECOND">
-			<Original>The server will restart in less than 60 seconds!</Original>
-			<German>Server Restart in weniger als 60 Sekunden!</German>
-			<Italian>Il server si riavvierà tra meno di 60 secodni!</Italian>
-			<Turkish>SERVER 60 SANİYE İÇİNDE YENİDEN BAŞLATILACAK!</Turkish>
-			<Chinesesimp>服务器将在60秒内重启！</Chinesesimp>
-			<Chinese>伺服器將在 60 秒內重啟！</Chinese>
-			<Portuguese>O servidor irá reiniciar em menos de 60 segundos!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_RESTART_FIVE">
-			<Original>The server will restart in less than 5 minutes!</Original>
-			<German>Server Restart in weniger als 5 Minuten!</German>
-			<Italian>Il server si riavvierà tra meno di 5 minuti!</Italian>
-			<Turkish>SERVER 5 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
-			<Chinesesimp>服务器将在5分钟内重启！</Chinesesimp>
-			<Chinese>伺服器將在 5 分鐘內重啟！</Chinese>
-			<Portuguese>O servidor irá reiniciar em menos de 5 minutos!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_RESTART_FIFTEEN">
-			<Original>The server will restart in less than 15 minutes!</Original>
-			<German>Server Restart in weniger als 15 Minuten!</German>
-			<Italian>Il server si riavvierà tra meno di 15 minuti!</Italian>
-			<Turkish>SERVER 15 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
-			<Chinesesimp>服务器将在15分钟内重启！</Chinesesimp>
-			<Chinese>伺服器將在 15 分鐘內重啟！</Chinese>
-			<Portuguese>O servidor irá reiniciar em menos de 15 minutos!</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_RESTART_THIRTY">
-			<Original>The server will restart in less than 30 minutes!</Original>
-			<German>Server Restart in weniger als 30 Minuten!</German>
-			<Italian>Il server si riavvierà tra meno di 30 minuti!</Italian>
-			<Turkish>SERVER 30 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
-			<Chinesesimp>服务器将在30分钟内重启！</Chinesesimp>
-			<Chinese>伺服器將在 30 分鐘內重啟！</Chinese>
-			<Portuguese>O servidor irá reiniciar em menos de 30 minutos!</Portuguese>
-		</Key>
-		<Key ID="STR_RESTART_PARAM">
-			<Original>Automatic Server Restart after (hours)</Original>
-			<German>Automatischer Server Restart nach (Stunden)</German>
-			<Italian>Restart Automatico del Server ogni (ore)</Italian>
-			<Turkish>Otomatik server yeniden başlat (saat)</Turkish>
-			<Chinesesimp>自动重启服务器时间（小时）</Chinesesimp>
-			<Chinese>自動重啟伺服器時間（小時）</Chinese>
-			<Portuguese>Reinício automático do servidor após (horas)</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUGOPTIONS">
-			<Original>== DEBUG MESSAGES ==</Original>
-			<German>== DEBUG NACHRICHTEN ==</German>
-			<Italian>== MESSAGGI DI DEBUG ==</Italian>
-			<Turkish>== DEBUG MESAJLARI ==</Turkish>
-			<Chinesesimp>== 除错信息 ==</Chinesesimp>
-			<Chinese>== 除錯訊息 ==</Chinese>
-			<Portuguese>== MENSAGENS DE DEBUG ==</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_CIVINFO">
-			<Original>Civil Informant</Original>
-			<German>Ziviler Informant</German>
-			<Italian>Informatore Civile</Italian>
-			<Turkish>Sivil Bilgisi</Turkish>
-			<Chinesesimp>民间线人</Chinesesimp>
-			<Chinese>民間線人</Chinese>
-			<Portuguese>Informante Civil</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_CIVREP">
-			<Original>Civil Reputation</Original>
-			<German>Ziviles Ansehen</German>
-			<Italian>Reputazione Civili</Italian>
-			<Turkish>Sivil Repütasyonu</Turkish>
-			<Chinesesimp>民间声望</Chinesesimp>
-			<Chinese>民間聲望</Chinese>
-			<Portuguese>Reputação Civil</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_INFORMANT_START">
-			<Original>A civilian from %1 says he has some information for us.</Original>
-			<German>Ein Zivilist aus %1 sagt, er hätte Informationen für uns.</German>
-			<Italian>Un civile a %1 dice di avere informazioni per noi.</Italian>
-			<Turkish>%1 adında ki bir sivil bize vereceği bir bilgisi olduğunu söylüyor.</Turkish>
-			<Chinesesimp>来自%1的一位平民说他有情报要交给我们。</Chinesesimp>
-			<Chinese>來自 %1 的一位平民說他有情報要交給我們。</Chinese>
-			<Portuguese>Um civil de %1 disse que possui algumas informações para nos apresentar.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_INFORMANT_SUCCESS">
-			<Original>The civilian gave us some important information.</Original>
-			<German>Der Zivilist gab uns wichtige Informationen.</German>
-			<Italian>Il civile ha fornito informazioni importatnti.</Italian>
-			<Turkish>Sivil bize çok önemli bilgiler verdi.</Turkish>
-			<Chinesesimp>平民给了我们一些重要情报。</Chinesesimp>
-			<Chinese>平民給了我們一些重要情報。</Chinese>
-			<Portuguese>Um civil nos concedeu algumas informações importantes.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_INFORMANT_FAIL">
-			<Original>The civilian has disappeared.</Original>
-			<German>Der Zivilist ist wieder untergetaucht.</German>
-			<Italian>Il civile è scomparso.</Italian>
-			<Turkish>Sivil ortadan kayboldu.</Turkish>
-			<Chinesesimp>平民消失了。</Chinesesimp>
-			<Chinese>平民消失了。</Chinese>
-			<Portuguese>Um civil desapareceu.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_INFORMANT_DEATH">
-			<Original>The civilian died.</Original>
-			<German>Der Zivilist wurde getötet.</German>
-			<Italian>Il civile è morto.</Italian>
-			<Turkish>Sivil öldü.</Turkish>
-			<Chinesesimp>平民死亡了。</Chinesesimp>
-			<Chinese>平民死亡了。</Chinese>
-			<Portuguese>Um civil morreu.</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_ASYMMETRIC">
-			<Original>Asymmetric Threat</Original>
-			<German>Asymmetrische Bedrohung</German>
-			<Italian>Minaccia Asimmetrica</Italian>
-			<Turkish>Asimetrik Tehdit</Turkish>
-			<Chinesesimp>非对称威胁</Chinesesimp>
-			<Chinese>非對稱威脅</Chinese>
-			<Portuguese>Ameaça Assimétrica</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_LOGISTIC">
-			<Original>Logistic</Original>
-			<German>Logistik</German>
-			<Italian>Logistica</Italian>
-			<Turkish>Lojistik</Turkish>
-			<Chinesesimp>后勤</Chinesesimp>
-			<Chinese>後勤</Chinese>
-			<Portuguese>Logística</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_TITLE">
-			<Original>Logistic Convoy Ambush</Original>
-			<German>Logistikkonvoi Überfall</German>
-			<Italian>Convoglio Sotto Attacco</Italian>
-			<Turkish>Lojistik Konvoyu Baskını</Turkish>
-			<Chinesesimp>后勤车队受袭</Chinesesimp>
-			<Chinese>後勤車隊遭到襲擊</Chinese>
-			<Portuguese>Emboscada no Comboio Logístico</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_TEXT">
-			<Original>Guerilla forces attacking our convoy near %1.</Original>
-			<German>Guerillakräfte greifen unseren Konvoi nahe %1 an.</German>
-			<Italian>Guerriglieri attaccano il nostro convoglio vicino %1</Italian>
-			<Turkish>Gerilla kuvvetleri bizim konvoyumuza saldırıyor, %1 yakınında.</Turkish>
-			<Chinesesimp>游击队正在%1附近攻击我们的车队</Chinesesimp>
-			<Chinese>游擊隊正在 %1 附近攻擊我們的車隊</Chinese>
-			<Portuguese>Forças de guerrilha estão atacando nosso comboio nas proximidades de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_SUCCESS">
-			<Original>The ambush was successfully repelled.</Original>
-			<German>Der Hinterhalt konnte erfolgreich zurückgeschlagen werden.</German>
-			<Italian>L'attacco è stato neutralizzato.</Italian>
-			<Turkish>Baskın başarıyla püskürtüldü.</Turkish>
-			<Chinesesimp>成功击退了来犯者。</Chinesesimp>
-			<Chinese>成功擊退了游擊隊。</Chinese>
-			<Portuguese>A emboscada foi frustrada com sucesso.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_FAIL">
-			<Original>The guerilla forces escaped with the convoy resources.</Original>
-			<German>Die Guerillakräfte konnten mit den Konvoiressourcen verschwinden.</German>
-			<Italian>I Guerriglieri scappano con le risorse del nostro convoglio.</Italian>
-			<Turkish>Gerilla kuvvetleri malzemelerimizle beraber kaçtılar.</Turkish>
-			<Chinesesimp>游击队抢走了车队物资。</Chinesesimp>
-			<Chinese>游擊隊搶走了車隊物資。</Chinese>
-			<Portuguese>As forças de guerrilha escaparam com os recursos do comboio.</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_SECTORSPAWN">
-			<Original>Sectorspawn</Original>
-			<German>Sektorspawn</German>
-			<Italian>Spawn Settori</Italian>
-			<Chinesesimp>战区刷新</Chinesesimp>
-			<Chinese>戰區刷新</Chinese>
-			<Portuguese>Spawn do setor</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_KILL">
-			<Original>Killed units</Original>
-			<German>Getötete Einheiten</German>
-			<Italian>Unità Uccise</Italian>
-			<Chinesesimp>击杀的单位</Chinesesimp>
-			<Chinese>擊殺單位</Chinese>
-			<Portuguese>Unidades mortas</Portuguese>
-		</Key>
-		<Key ID="STR_CR_ACE_ACTION">
-			<Original>Treat the civilian (field dressing)</Original>
-			<German>Zivilisten versorgen (einfache Bandage)</German>
-			<Italian>Soccorso Civili</Italian>
-			<Chinesesimp>治疗平民（战地绷带）</Chinesesimp>
-			<Chinese>治療平民（基礎繃帶）</Chinese>
-			<Portuguese>Preste socorro ao civil (curativo)</Portuguese>
-		</Key>
-		<Key ID="STR_CR_ACE_ACTION_FAIL">
-			<Original>You need a field dressing.</Original>
-			<German>Du brauchst eine einfache Bandage.</German>
-			<Italian>Hai bisogno di un bendaggio semplice.</Italian>
-			<Chinesesimp>你需要一个战地绷带。</Chinesesimp>
-			<Chinese>你需要一個基礎繃帶。</Chinese>
-			<Portuguese>Você precisa de curativo.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_HVT_START">
-			<Original>There is a high ranked officer near %1.</Original>
-			<German>Ein hochrangiger Offizier befindet sich in der Nähe von %1.</German>
-			<Italian>C'è un ufficiale di altro grado vicino %1.</Italian>
-			<Chinesesimp>%1附近有一名高级军官。</Chinesesimp>
-			<Chinese>%1 附近有一名高級軍官。</Chinese>
-			<Portuguese>Há um oficial de alta patente nas proximidades de %1.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_HVT_SUCCESS">
-			<Original>The officer was successfully killed.</Original>
-			<German>Der Offizier konnte erfolgreich getötet werden.</German>
-			<Italian>L'ufficiale è stato ucciso.</Italian>
-			<Chinesesimp>成功刺杀了军官。</Chinesesimp>
-			<Chinese>成功刺殺了軍官。</Chinese>
-			<Portuguese>O oficial foi morto. Missão cumprida.</Portuguese>
-		</Key>
-		<Key ID="STR_NOTIFICATION_CIV_HVT_FAIL">
-			<Original>The officer has moved on.</Original>
-			<German>Der Offizier ist weitergezogen.</German>
-			<Italian>L'ufficiale è scappato.</Italian>
-			<Chinesesimp>军官逃离了。</Chinesesimp>
-			<Chinese>軍官逃離了。</Chinese>
-			<Portuguese>O oficial escapou.</Portuguese>
-		</Key>
-		<Key ID="STR_PARAM_RESPAWN_COOLDOWN">
-			<Original>Mobile Respawn Cooldown (minutes)</Original>
-			<German>Mobiler Respawn Cooldown (Minuten)</German>
-			<Italian>Attesa Respawn Mobile (Minuti)</Italian>
-			<Chinesesimp>机动复活点冷却时间（分钟）</Chinesesimp>
-			<Chinese>機動重生點每次重生所需冷卻時間（分鐘）</Chinese>
-			<Portuguese>Tempo de espera do respawn móvel (minutos)</Portuguese>
-		</Key>
-		<Key ID="STR_RESPAWN_COOLDOWN_HINT">
-			<Original>%1 minutes mobile respawn cooldown left.</Original>
-			<German>%1 Minuten Mobiler Respawn Cooldown übrig.</German>
-			<Italian>Mancano ancora %1 minuti al respawn.</Italian>
-			<Chinesesimp>机动复活点还需要%1分钟冷却。</Chinesesimp>
-			<Chinese>機動重生點還需要 %1 分鐘冷卻。</Chinese>
-			<Portuguese>Falta(m) %1 minuto(s) de tempo de espera do respawn móvel.</Portuguese>
-		</Key>
-		<Key ID="STR_CR_RESISTANCE_KILLMSG">
-			<Original>An allied resistance fighter named %1 was killed!</Original>
-			<German>Ein verbündeter Widerstandskämpfer mit Namen %1 wurde getötet!</German>
-			<Italian>Un'alleato della resistenza di nome %1 è stato ucciso!</Italian>
-			<Chinesesimp>一位名叫%1的友军抵抗军战士阵亡了！</Chinesesimp>
-			<Chinese>一名叫做 %1 的友軍抵抗軍戰士陣亡了！</Chinese>
-			<Portuguese>Um aliado das forças de resistência de nome %1 foi morto!</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_SAVE">
-			<Original>Gamedata saving</Original>
-			<German>Savegame Speicherung</German>
-			<Italian>Salvataggio Dati di Gioco</Italian>
-			<Chinesesimp>储存游戏数据中</Chinesesimp>
-			<Chinese>儲存數據中</Chinese>
-			<Portuguese>Salvando dados do jogo</Portuguese>
-		</Key>
-		<Key ID="STR_PARAMS_DEBUG_PRODUCTION">
-			<Original>Production</Original>
-			<German>Produktion</German>
-			<Italian>Produzione</Italian>
-			<Chinesesimp>生产</Chinesesimp>
-			<Chinese>生產</Chinese>
-			<Portuguese>Produção</Portuguese>
-		</Key>
-		<!-- Added/Changed in 0.963a -->
-		<Key ID="STR_PARAMS_LOADSAVEPARAMS">
-			<Original>Load/Save Parameters</Original>
-			<German>Laden/Speichern der Parameter</German>
-		</Key>
-		<Key ID="STR_PARAMS_LOADSAVEPARAMS_SAVE">
-			<Original>SAVE selected parameters</Original>
-			<German>SPEICHERN der momentanen Parameter</German>
-		</Key>
-		<Key ID="STR_PARAMS_LOADSAVEPARAMS_LOAD">
-			<Original>LOAD parameters or use selected if no saved value found</Original>
-			<German>LADEN der gespeicherten Parameter oder momentane nutzen, wenn keine gespeicherten vorhanden sind</German>
-		</Key>
-		<Key ID="STR_PARAMS_LOADSAVEPARAMS_SELECTED">
-			<Original>Use selected parameters without saving</Original>
-			<German>Momentane Parametereinstellung ohne Speicherung</German>
-		</Key>
-		<Key ID="STR_RAISE">
-			<Original>-- Raise</Original>
-			<German>-- Höher</German>
-		</Key>
-		<Key ID="STR_LOWER">
-			<Original>-- Lower</Original>
-			<German>-- Niedriger</German>
-		</Key>
-		<Key ID="STR_NOTIFICATION_GUER_INC_TITLE">
-			<Original>Guerilla forces on the way.</Original>
-			<German>Widerstandskämpfer sind unterwegs.</German>
-		</Key>
-		<Key ID="STR_NOTIFICATION_GUER_INC">
-			<Original>Guerilla forces are incoming to %1 from the %2.</Original>
-			<German>Widerstandskämpfer nähern sich %1 aus %2.</German>
-		</Key>
-		<Key ID="STR_PARAMS_REVIVEOPTIONS">
-			<Original>== REVIVE OPTIONS (Disregarded, if you play with ACE Medical) ==</Original>
-			<German>== WIEDERBELEBUNGSEINSTELLUNGEN (Nicht berücksichtigt, wenn mit ACE Medical gespielt wird) ==</German>
-			<Spanish>== OPCIONES DE REVIVE ==</Spanish>
-			<Russian>== ВОЗВРАТИТЬ ОПЦИИ ==</Russian>
-			<Italian>== OPZIONI RIANIMAZIONE ==</Italian>
-			<Chinesesimp>== 复活选项 ==</Chinesesimp>
-			<Chinese>== 昏迷甦醒選項 ==</Chinese>
-			<Turkish>== CANLANDIRMA AYARLARI ==</Turkish>
-			<Portuguese>== OPÇÕES DE RESSUCITAÇÃO ==</Portuguese>
-		</Key>
-	</Package>
+        </Key>
+        <Key ID="STR_TUTO_TITLE8">
+            <Original>8. Deploying another FOB</Original>
+            <French>8. Déployer une autre FOB</French>
+            <German>8. Errichtung einer weiteren FOB</German>
+            <Spanish>8. Desplegar otra FOB</Spanish>
+            <Russian>8. Развёртывание новой FOB</Russian>
+            <Italian>8. Costruire un'altra FOB</Italian>
+            <Chinesesimp>8. 部署更多前哨</Chinesesimp>
+            <Chinese>8. 部署更多前線基地</Chinese>
+            <Turkish>8. Başka bir FOB kurmak</Turkish>
+            <Portuguese>8. Instalando outra FOB</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT8">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                To build a brand new FOB, go to the construction menu and then the logistics tab and build a FOB
+                container or a FOB truck (the same thing, only with wheels). Then you can position the FOB
+                container/truck where you want to deploy your shiny new FOB. However, be aware that you can't build a
+                FOB within 1km of your starting position, within 300m of any sector, or within 2km of any other FOB.&lt;br/&gt;
+                &lt;br/&gt;
+                That would simply be redundant!&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Um eine brandneue FOB zu bauen, öffnen Sie das Baumenü und unter dem Reiter Logistik bauen Sie einen FOB
+                Container oder einen FOB Lastwagen (dasselbe, bloß mit Rädern). Dann können Sie den FOB
+                Container/Lastwagen an die Position Ihrer Wahl bringen und Ihre niegelnagelneue FOB aufbauen. Beachten
+                Sie, das Sie keine FOB innerhalb von 1km von der Startposition, von 300m von einem Sektor und von 2km
+                von einer anderen FOB aufbauen können.&lt;br/&gt; &lt;br/&gt;
+                Das wäre einfach unnötig!&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                Per costruire una nuova FOB, vai nel menu di costruzione e poi alla scheda logistica e costruisci un
+                contenitore FOB o un camion FOB (la stessa cosa, solo con ruote). Quindi è possibile posizionare il
+                contenitore / camion FOB. Tuttavia, tenere presente che non è possibile costruire un FOB entro 1 km
+                dalla posizione iniziale, ed entro 300 metri da qualsiasi settore, o entro 2 km da qualsiasi altra FOB.&lt;br/&gt;
+                &lt;br/&gt;
+                Sarebbe semplicemente ridondante!&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Чтобы построить совершенно новый FOB, перейдите в меню конструирования, а затем вкладку логистики и
+                постройте контейнер FOB или грузовик FOB (то же самое, только с колесами). Затем вы можете разместить
+                контейнер / грузовик FOB, где вы хотите развернуть свой новый новый FOB. Однако имейте в виду, что вы не
+                можете построить FOB в пределах 1 км от начальной позиции, в пределах 300 м от любого сектора или в
+                пределах 2 км от любого другого FOB.&lt;br/&gt; &lt;br/&gt;
+                Это было бы просто излишним!&lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                要建立一个新前哨，打开建造菜单的后勤面板并建造一个前哨部署柜或前哨部署车（一样的东西，只是多了轮子罢了）。然后你就可以将前哨部署柜/车安置到想部署的地方了。注意，你不能在距离出发点1公里内、战区300米内和其它前哨2公里内部署前哨。&lt;br/&gt;
+                &lt;br/&gt;
+                因为搞那么多前哨实在太多余了！&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>&lt;br/&gt;&lt;br/&gt;
+                要建立一个新的前線基地，打開建造選單的後勤面板，並建立一個前線基地貨櫃或前線基地載具（一樣的東西，只是多個輪子）。然後你就能帶著前線基地貨櫃或前線基地車到任何你想佈署的位置進行佈署了。注意，你不能在起始作戰基地
+                1 公里內、戰區 300 公尺内，或是其它前線基地 2 公里内部署前線基地。&lt;br/&gt; &lt;br/&gt;
+                因為這麼多前線基地實在是太多餘了！&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Para construir uma nova FOB, acesse o menu de construção, selecione a aba de logística e então construir
+                FOB no conteiner ou uma FOB transportável (é a mesma coisa, mas com rodas). Em seguida, poderá
+                posicionar sua linda e nova FOB (transportável ou no conteiner) onde desejar. No entanto, esteja ciente
+                de que não poderá construir a FOB dentro de 1km da sua posição inicial, dentro de 300 metros de qualquer
+                setor ou dentro de 2km de outra FOB.&lt;br/&gt; &lt;br/&gt;
+                Seria simplesmente redundante!&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE9">
+            <Original>9. Secondary Objectives</Original>
+            <French>9. Missions secondaires</French>
+            <German>9. Sekundäre Ziele</German>
+            <Spanish>9. Objetivos secundarios</Spanish>
+            <Russian>9. Дополнительные задания</Russian>
+            <Italian>9. Obiettivi Secondari</Italian>
+            <Chinesesimp>9. 次要目标</Chinesesimp>
+            <Chinese>9. 次要目標</Chinese>
+            <Turkish>9. İkincil Objektifler</Turkish>
+            <Portuguese>9. Objetivos Secundários</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT9">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                When you capture sectors, sometimes the few hostiles forces remaining will surrender. You can then
+                capture those prisoners and take them back to a nearby FOB to be interrogated.&lt;br/&gt; &lt;br/&gt;
+                That interrogation, executed in the utmost respect of the Geneva Convention, will allow you to obtain
+                information which can be used to reveal the rough position of an enemy logistics base, enemy convoy or
+                friendly search and rescue.&lt;br/&gt; &lt;br/&gt;
+                After going there you will need to find the exact position of your target, then use any means at your
+                disposal to complete your objective. Succeeding at this task will be rewarded, reducing the alert level
+                consequently and with it the efficiency of all hostile forces.&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Nach Befreiung eines Sektors, werden sich manchmal ein paar der verbliebenen Feindkräfte ergeben. Sie
+                können sie gefangen nehmen und zu einer nahegelegenen FOB bringen, um sie zu verhören.&lt;br/&gt; &lt;br/&gt;
+                Dieses Verhör wird unter höchster Rücksichtnahme auf die Genfer Konventionen durchgeführt und bringt
+                Ihnen präzise Informationen, die dazu genutzt werden können, um die ungefähre Lage einer feindlichen
+                Logistik Basis zu bestimmen, feindliche Konvois aufzuspühren oder auch die ungefähre Position von
+                Kriegsgefangenen zu ermitteln.&lt;br/&gt; &lt;br/&gt;
+                Wenn sie dort angekommen sind, müssen Sie die exakte Position Ihres Ziels herausfinden, dann setzen Sie
+                alle Ihnen zur Verfügung stehenden Mittel ein, um das Einsatzziel zu erreichen. Ein erfolgreicher
+                Einsatz wird mit Verringerung des Bedrohungsniveaus und damit der Effektivität der feindlichen
+                Streitkräfte belohnt.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                Quando catturi i settori, talvolta le forze ostili che restano si arrenderanno. Quindi puoi catturare
+                quei prigionieri e riportarli in una FOB vicina per interrogarli.&lt;br/&gt; &lt;br/&gt;
+                Questa interrogazione, eseguita nel più grande rispetto della Convenzione di Ginevra, ti permetterà di
+                ottenere informazioni precise che possano essere utilizzate per rivelare la posizione rudimentale di una
+                base logistica nemica, di un convoglio nemico o di un salvataggio.&lt;br/&gt; &lt;br/&gt;
+                Dopo essere andato lì dovrai trovare la posizione esatta del tuo bersaglio, quindi utilizzare qualsiasi
+                mezzo a tua disposizione per completare il tuo obiettivo. Eseguire questo compito sarà premiato,
+                riducendo così il livello di allarme e con essa l'efficienza di tutte le forze ostili.&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Когда вы захватываете сектора, иногда несколько оставшихся сил противника будут сдаваться. Затем вы
+                можете захватить этих пленных и отвезти их в соседний ФОБ для допроса.&lt;br/&gt; &lt;br/&gt;
+                Этот допрос, выполненный в полном уважении Женевской конвенции, позволит вам получить точную информацию,
+                которая может быть использована для выявления грубой позиции базы материально-технического обеспечения
+                противника, конвоя противника или дружественного поиска и спасения.&lt;br/&gt; &lt;br/&gt;
+                Побывав там, вам нужно будет найти точное положение вашей цели, а затем использовать любые имеющиеся в
+                вашем распоряжении средства для достижения своей цели. Достижение этой цели будет вознаграждено,
+                следовательно, будет уменьшаться уровень оповещения, а вместе с ним и эффективность всех враждебных сил.&lt;br/&gt;
+                &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                有时候当你占领战区时，一些敌军残部会选择投降。你可以将他们抓到就近的前哨去审问。&lt;br/&gt; &lt;br/&gt;
+                这种在完全遵照日内瓦公约的情况下进行的审问，能为你提供用于揭示敌军后勤基地大致位置、补给车队或友军搜索与营救任务的准确情报。&lt;br/&gt; &lt;br/&gt;
+                之后你就需要找到目标的准确位置，并不惜一切代价完成目标。任务的成功带来的奖励将导致警戒等级下降，并进而削弱所有敌军部队的战斗力。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>&lt;br/&gt;&lt;br/&gt;
+                有时候當你占領戰區時，一些敵軍殘兵會選擇投降。你可以將他們抓到任何一個前線基地（不包含起始作戰基地）進行審問。&lt;br/&gt; &lt;br/&gt;
+                審問後獲得的情資將能用來定位出敵方前線基地或補給車隊的大致位置、或是換取搜索與營救友軍的準確情報。&lt;br/&gt; &lt;br/&gt;
+                之後你必須找到這些目標的精確位置並不惜代價完成任務。任務成功的獎勵將降低敵方的警界度，並進而削弱所有敵軍的戰鬥能力。&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Quando você capturar setores, em algumas situações as forças hostis remanescentes se renderão. Você
+                poderá capturar os prisioneiros e levá-los para a FOB mais próxima para serem interrogados.&lt;br/&gt;
+                &lt;br/&gt;
+                O interrogatório, executado em observância à Convenção de Genebra, o permitirá a obtenção de informações
+                que podem ser empregadas para revelar a posição aproximada da base de logística inimiga, comboio inimigo
+                ou operações de busca e resgate de forças aliadas.&lt;br/&gt; &lt;br/&gt;
+                Após chegar na área de operações, você precisará identificar a localização exata do seu alvo, e então
+                fazer uso dos meios necessários à sua disposição para concluir seu objetivo. Ao lograr êxito em sua
+                tarefa, serão recompensados, reduzindo o nível de alerta reducing the alert level inimigo e
+                consequentemente a eficiência de todas as forças hostis.&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TITLE10">
+            <Original>10. Commanding</Original>
+            <French>10. Commandement</French>
+            <German>10. Oberkommando</German>
+            <Spanish>10. Comandancia</Spanish>
+            <Russian>10. Командование</Russian>
+            <Italian>10. Comando</Italian>
+            <Chinesesimp>10. 指挥</Chinesesimp>
+            <Chinese>10. 指挥</Chinese>
+            <Turkish>10. Komuta etmek</Turkish>
+            <Portuguese>10. Comandando</Portuguese>
+        </Key>
+        <Key ID="STR_TUTO_TEXT10">
+            <Original>&lt;br/&gt;&lt;br/&gt;
+                When a player uses the Commander role, they get access to the Zeus interface by pressing the
+                corresponding key (Y by default). This interface allows the commanding of friendly forces in 3D or map
+                view.&lt;br/&gt; &lt;br/&gt;
+                Moreover the commander gets additional build options that will allow them to obtain crewed vehicles or
+                entire pre-made squads.&lt;br/&gt; &lt;br/&gt;
+                This role is now mandatory, as it provides direct access to the management of production sectors and AI
+                logistics. Given that you are positioned by a FOB, you will see the options "Production Settings" and
+                "Logistic Overview".&lt;br/&gt; &lt;br/&gt; The first enables the ability to decide which Factory
+                produces which specific resources, as well as a detailed current overview.&lt;br/&gt; &lt;br/&gt; The
+                latter allows you to command an AI logitical convoy, where you may "Add" logistical groups, purchase any
+                amount of trucks per group and command them to move specific amounts of resources across the region for
+                you.&lt;br/&gt; &lt;br/&gt;
+            </Original>
+            <German>&lt;br/&gt;&lt;br/&gt;
+                Wenn ein Spieler die Rolle des Commanders übernimmt, bekommt er spezifischen Zugang zum Zeus-Interface,
+                wenn er die entsprechende Taste dafür drückt (default Z). Dieses Interface erlaubt das Kommandieren
+                befreundeter Einheiten in der 3D- und Kartenansicht.&lt;br/&gt; &lt;br/&gt;
+                Darüber hinaus hat der Commander erweiterte Bauoptionen, die es ihm ermöglichen, Fahrzeuge mit Besatzung
+                oder auch komplette vorgefertigte Squads zu bauen.&lt;br/&gt; &lt;br/&gt;
+                Die Rolle des Commanders ist nun zwingend erforderlich, da sie direkten Zugang zum Management von
+                Produktionssektoren und KI-Logistik bietet. Dafür hat man an einer FOB die Optionen
+                "Produktionseinstellungen" und "Logistikübersicht".&lt;br/&gt; &lt;br/&gt; Ersteres gewährt sowohl die
+                Möglichkeit zu entscheiden, welcher PoI oder welche Fabrik welche Ressourcen produzieren soll, als auch
+                einen detaillierten aktuellen Überblick.&lt;br/&gt; &lt;br/&gt; Letzteres erlaubt es, einen
+                KI-Logistik-Konvoi zu befehligen, wobei man Logistik-Gruppen hinzufügen, eine beliebige Anzahl an Lkw
+                pro Gruppe kaufen und diese dann befehligen kann, eine bestimmte Anzahl an Ressourcen quer über die
+                Gesammte Region zu verfahren.&lt;br/&gt; &lt;br/&gt;
+            </German>
+            <Italian>&lt;br/&gt;&lt;br/&gt;
+                Quando un giocatore usa il ruolo del comandante, ottierrà l'accesso all'interfaccia di Zeus premendo il
+                tasto corrispondente (Y per impostazione predefinita). Questa interfaccia consente il comando di forze
+                amiche in visualizzazione 3D o mappa.&lt;br/&gt; &lt;br/&gt;
+                Inoltre il comandante ottiene ulteriori opzioni di costruzione che consentiranno loro di ottenere
+                veicoli con equipaggio o intere squadre pre-fatte.&lt;br/&gt; &lt;br/&gt;
+                Questo ruolo è ora obbligatorio in quanto fornisce accesso diretto alla gestione dei settori produttivi
+                e alla logistica AI. Dato che sei posizionato da una FOB, vedrai le opzioni "Impostazioni di produzione"
+                e "Panoramica logistica".&lt;br/&gt; &lt;br/&gt; Il primo consente di decidere quali PDI o Fabbriche
+                producono risorse specifiche, così come una panoramica corrente dettagliata.&lt;br/&gt; &lt;br/&gt;
+                Quest'ultimo ti permette di comandare un convoglio logistico di AI, dove puoi "aggiungere" gruppi
+                logistici, acquistare qualsiasi quantità di camion per gruppo e mandarli a spostare determinate risorse
+                in tutta la regione per te.&lt;br/&gt; &lt;br/&gt;
+            </Italian>
+            <Russian>&lt;br/&gt;&lt;br/&gt;
+                Когда игрок использует роль Commander, он получает специальный доступ к интерфейсу Zeus, нажав
+                соответствующую клавишу (по умолчанию Y). Этот интерфейс позволяет управлять дружественными силами в
+                трехмерном режиме или в режиме карты. &lt;br/&gt; &lt;br/&gt;
+                Кроме того, командир получает дополнительные варианты сборки, которые позволят ему создавать технику с
+                экипажем или готовые отряды. &lt;br/&gt; &lt;br/&gt;
+                Эта роль в настоящее время является обязательной, поскольку она обеспечивает прямой доступ к управлению
+                производственными секторами и логистикой ИИ. Учитывая, что вы позиционируетесь по FOB, вы увидите
+                варианты «Настройки производства» и «Обзор логистики». &lt;br/&gt; &lt;br/&gt; Первое позволяет
+                определить, какой PoI или Factory создает конкретные ресурсы, а также подробный текущий обзор.&lt;br/&gt;
+                &lt;br/&gt; Последний позволяет вам управлять логическим конвоем AI, в котором вы можете «Добавить»
+                логистические группы, приобрести любое количество грузовиков на группу и приказать им перемещать
+                определенные объемы ресурсов в регионе для вас. &lt;br/&gt; &lt;br/&gt;
+            </Russian>
+            <Chinesesimp>&lt;br/&gt;&lt;br/&gt;
+                当一名玩家扮演指挥官角色时，他将会得到按指定按键（默认为Y）打开宙斯（Zeus）界面的权限。该界面让玩家可以在3D或地图视角中指挥友军部队。&lt;br/&gt; &lt;br/&gt;
+                除此以外，指挥官还有额外的建造选项，让他可以招募有乘员的载具或一整个预设的AI班组。&lt;br/&gt; &lt;br/&gt;
+                现阶段由于该角色有着战区产出管理和AI后勤的直接权限，因此必须有玩家进行操作。当处于前哨范围内时，你将会看到“产出设置”和“后勤总览”两个选项。&lt;br/&gt; &lt;br/&gt;前者有着指定PoI和工厂资源产出类型，以及查看总览细目的功能。&lt;br/&gt;
+                &lt;br/&gt;后者则让你能够指挥AI后勤车队，其中你可以“添加”后勤组、为后勤组购买任意数量的卡车，以及指挥他们在这个地区中往来运输指定资源。&lt;br/&gt; &lt;br/&gt;
+            </Chinesesimp>
+            <Chinese>&lt;br/&gt;&lt;br/&gt;
+                當一名玩家扮演指揮官角色時，他將會得到使用宙斯功能的權限，該介面讓玩家可以在 3D 或地圖視角中指揮友軍部隊。&lt;br/&gt; &lt;br/&gt;
+                除此之外，指揮官還有額外的建築選項，讓他可以招募載有友軍單位的載具或一整個預設的 AI 班級。&lt;br/&gt; &lt;br/&gt;
+                現階段由於該角色有著戰區產出管理與AI後勤管理的直接權限，因此必須有玩家進行操作。當處於前線基地的範圍內時，你將會看到「產出設定」和「後勤總覽」兩個選項。&lt;br/&gt; &lt;br/&gt;
+                前者有著指定PoI和工廠資源產出類型，以及察看總覽細項的功能。&lt;br/&gt; &lt;br/&gt;後者則讓你能夠指揮 AI
+                車隊，其中你可以「添增」後勤單位、為後勤單位購買任意數量的卡車，並指揮他們在指定區域之間來往進行運輸物資。&lt;br/&gt; &lt;br/&gt;
+            </Chinese>
+            <Portuguese>&lt;br/&gt;&lt;br/&gt;
+                Quando um jogador assume a função de comandante, ele recebem acesso à interface Zeus ao pressionar a
+                tecla correspondente (a tecla padrão é 'Y'). Essa interface permite o comando de forças aliadas na
+                plataforma 3D ou através do mapa.&lt;br/&gt; &lt;br/&gt;
+                Ademais, o comandante recebe opções adicionais de construção que o permitirão obter veículos tripulados
+                ou grupos predeterminados.&lt;br/&gt; &lt;br/&gt;
+                Tal função é agora obrigatória, pois possibilita acesso direto à gestão dos setores de produção e
+                logísticas automatizadas. Quando estiver posicionado numa FOB, você poderá observar as opções
+                "Configuração de Produção" e "Visão Geral de Logística".&lt;br/&gt; &lt;br/&gt; A primeira habilita a
+                capacidade de decidir que fabrica/refinaria irá produzir qual recurso específico, bem como uma visão
+                geral detalhada sobre o serviço.&lt;br/&gt; &lt;br/&gt; O último permite a você comandar o sistema
+                automatizado de comboio logístico, onde você poderá "adicionar" grupos logísticos, adquirir quantos
+                transportes desejar e os comandar para transportar quantidades específicas de recursos através do
+                território.&lt;br/&gt; &lt;br/&gt;
+            </Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_ARSENALUSEPRESET">
+            <Original>Arsenal mode</Original>
+            <German>Arsenalmodus</German>
+            <Italian>Modalità Arsenale</Italian>
+            <Chinesesimp>军火库模式</Chinesesimp>
+            <Chinese>軍火庫模式</Chinese>
+            <Turkish>Ekipman(Arsenal) modu</Turkish>
+            <Portuguese>Modo do Arsenal</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_NORESTRICTIONS">
+            <Original>No restrictions</Original>
+            <German>Keine Einschränkungen</German>
+            <Italian>Senza Restrizioni</Italian>
+            <Chinesesimp>无限制</Chinesesimp>
+            <Chinese>無限制</Chinese>
+            <Turkish>Kısıtlama yok</Turkish>
+            <Portuguese>Sem restrições</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_USEPRESET">
+            <Original>Use preset from config</Original>
+            <German>Benutze Preset aus Konfiguration</German>
+            <Italian>Usa il file config.sqf</Italian>
+            <Chinesesimp>使用配置文件中的预设内容</Chinesesimp>
+            <Chinese>使用設定文件中的預設內容</Chinese>
+            <Turkish>config.sqf kullan</Turkish>
+            <Portuguese>Usar predefinição de config.sqf</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_CRATE_PUSH">
+            <Original>-- PUSH CRATE</Original>
+            <German>-- KISTE SCHIEBEN</German>
+            <Italian>-- SPINGI CASSA</Italian>
+            <Chinesesimp>-- 推货箱</Chinesesimp>
+            <Chinese>-- 推貨物</Chinese>
+            <Turkish>-- KUTUYU İTTİR</Turkish>
+            <Portuguese>-- EMPURRAR CAIXA --</Portuguese>
+        </Key>
+        <Key ID="STR_ACTION_SORT_STORAGE">
+            <Original>-- STACK AND SORT</Original>
+            <German>-- STAPELN UND SORTIEREN</German>
+            <Italian>-- IMPILA E ORDINA</Italian>
+            <Chinesesimp>-- 排列并分类</Chinesesimp>
+            <Chinese>-- 排列並分類</Chinese>
+            <Turkish>-- SIRALA VE DÜZENLE</Turkish>
+            <Portuguese>-- ORDENAR E CLASSIFICAR --</Portuguese>
+        </Key>
+        <!-- Added or changed in v0.96 -->
+        <Key ID="STR_PARAMS_SUPPMOD">
+            <Original>BI Support Module System access</Original>
+            <German>BI Support Module System Zugriff</German>
+            <Italian>Accesso Modulo Di Supporto BI</Italian>
+            <Chinesesimp>BI支援模块系统权限</Chinesesimp>
+            <Chinese>BI支援模塊系統權限</Chinese>
+            <Portuguese>Acesso ao Módulo de Suporte da Bohemia Interactive</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_COMMANDER">
+            <Original>Commander only</Original>
+            <German>Nur Kommandant</German>
+            <Italian>Solo per il Comandante</Italian>
+            <Chinesesimp>仅指挥官</Chinesesimp>
+            <Chinese>僅指揮官</Chinese>
+            <Turkish>Sadece komutan</Turkish>
+            <Portuguese>Apenas comandante</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_WHITELISTONLY">
+            <Original>Whitelisted only</Original>
+            <German>Nur Whitelist</German>
+            <Italian>Con Whitelist</Italian>
+            <Chinesesimp>仅白名单</Chinesesimp>
+            <Chinese>僅白名單</Chinese>
+            <Turkish>Sadece beyaz listedekiler</Turkish>
+            <Portuguese>Apenas quem está na lista de permissão</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_EVERYONE">
+            <Original>Everyone</Original>
+            <German>Jeder</German>
+            <Italian>Tutti</Italian>
+            <Chinesesimp>所有人</Chinesesimp>
+            <Chinese>所有人</Chinese>
+            <Turkish>Herkes</Turkish>
+            <Portuguese>Todos</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_EXTENDED_OPTIONS_ACTIONMENU">
+            <Original>-- Extended Options --</Original>
+            <German>-- Erweiterte Optionen --</German>
+            <Italian>-- Opzioni Avanzate --</Italian>
+            <Chinesesimp>-- 扩展选项 --</Chinesesimp>
+            <Chinese>-- 擴增選項 --</Chinese>
+            <Turkish>-- Gelişmiş Ayarlar --</Turkish>
+            <Portuguese>-- Opções Avançadas --</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_EXTENDED_OPTIONS">
+            <Original>Extended Options</Original>
+            <German>Erweiterte Optionen</German>
+            <Italian>Opzioni Avanzate</Italian>
+            <Chinesesimp>扩展选项</Chinesesimp>
+            <Chinese>擴增選項</Chinese>
+            <Turkish>Gelişmiş Ayarlar</Turkish>
+            <Portuguese>Opções Avançadas</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_DISABLED">
+            <Original>- disabled -</Original>
+            <German>- deaktiviert -</German>
+            <Italian>- disabilitato -</Italian>
+            <Chinesesimp>- 已禁用 -</Chinesesimp>
+            <Chinese>- 已禁用 -</Chinese>
+            <Turkish>- kapalı -</Turkish>
+            <Portuguese>- desativado -</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_SQUAD_MANAGEMENT">
+            <Original>Squad Management</Original>
+            <German>Truppmanagement</German>
+            <Italian>Gestione Squadra</Italian>
+            <Chinesesimp>班组管理</Chinesesimp>
+            <Chinese>班級管理</Chinese>
+            <Turkish>Tim Yönetimi</Turkish>
+            <Portuguese>Gestão de equipe</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_JOIN">
+            <Original>Join</Original>
+            <German>Beitreten</German>
+            <Italian>Unisciti</Italian>
+            <Chinesesimp>加入</Chinesesimp>
+            <Chinese>加入</Chinese>
+            <Turkish>Katıl</Turkish>
+            <Portuguese>Se juntar</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_CREATE">
+            <Original>Create</Original>
+            <German>Erstellen</German>
+            <Italian>Crea</Italian>
+            <Chinesesimp>创建</Chinesesimp>
+            <Chinese>建立</Chinese>
+            <Turkish>Yarat</Turkish>
+            <Portuguese>Criar</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_RENAME">
+            <Original>Rename</Original>
+            <German>Umbenennen</German>
+            <Italian>Rinomina</Italian>
+            <Chinesesimp>重命名</Chinesesimp>
+            <Chinese>重新命名</Chinese>
+            <Turkish>Yeniden Adlandır</Turkish>
+            <Portuguese>Renomear</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_LEADER">
+            <Original>Leader</Original>
+            <German>Anführer</German>
+            <Italian>Capo Squadra</Italian>
+            <Chinesesimp>班长</Chinesesimp>
+            <Chinese>班長</Chinese>
+            <Turkish>Lider</Turkish>
+            <Portuguese>Líder</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_CANCEL">
+            <Original>Cancel</Original>
+            <German>Abbrechen</German>
+            <Italian>Cancella</Italian>
+            <Chinesesimp>取消</Chinesesimp>
+            <Chinese>取消</Chinese>
+            <Turkish>İptal</Turkish>
+            <Portuguese>Cancelar</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_CHOOSE">
+            <Original>Choose</Original>
+            <German>Wählen</German>
+            <Italian>Scegli</Italian>
+            <Chinesesimp>选择</Chinesesimp>
+            <Chinese>選擇</Chinese>
+            <Turkish>Seç</Turkish>
+            <Portuguese>Selecionar</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_PLATOON_SQUAD_AWARENESS">
+            <Original>Platoon and Squad Awareness</Original>
+            <German>Sichthilfen und Kartenmarkierungen</German>
+            <Italian>Indicatori di Mappa</Italian>
+            <Chinesesimp>班排警戒</Chinesesimp>
+            <Chinese>班排警戒</Chinese>
+            <Turkish>Platon ve Tim Farkındalığı</Turkish>
+            <Portuguese>Indicador de grupo no mapa</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_SHOW_PLATOON_OVERLAY">
+            <Original>Show platoon overlay:</Original>
+            <German>Platoon Overlay:</German>
+            <Italian>Indicatore Plotone:</Italian>
+            <Chinesesimp>显示排界面：</Chinesesimp>
+            <Chinese>顯示排介面：</Chinese>
+            <Turkish>Platonu ekranda göster:</Turkish>
+            <Portuguese>Mostrar indicador de pelotão:</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_ACTIVE">
+            <Original>active</Original>
+            <German>aktiv</German>
+            <Italian>attivo</Italian>
+            <Chinesesimp>启用</Chinesesimp>
+            <Chinese>啟用</Chinese>
+            <Turkish>aktif</Turkish>
+            <Portuguese>Ativo</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_SHOW_PLAYER_NAMETAGS">
+            <Original>Show player nametags:</Original>
+            <German>Spielernamen:</German>
+            <Italian>Indicatore Nomi:</Italian>
+            <Chinesesimp>显示玩家铭牌：</Chinesesimp>
+            <Chinese>顯示玩家名牌：</Chinese>
+            <Turkish>Oyuncu isimlerini göster:</Turkish>
+            <Portuguese>Mostrar nome dos jogadores</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_YES">
+            <Original>Yes</Original>
+            <German>Ja</German>
+            <Italian>Si</Italian>
+            <Chinesesimp>是</Chinesesimp>
+            <Chinese>是</Chinese>
+            <Turkish>Evet</Turkish>
+            <Portuguese>Sim</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_NO">
+            <Original>No</Original>
+            <German>Nein</German>
+            <Italian>No</Italian>
+            <Chinesesimp>否</Chinesesimp>
+            <Chinese>否</Chinese>
+            <Turkish>Evet</Turkish>
+            <Portuguese>Não</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_ADJUST_VIEW_DISTANCE">
+            <Original>Adjust View Distance</Original>
+            <German>Sichtweite ändern</German>
+            <Italian>Aggiusta Distanza Visiva</Italian>
+            <Chinesesimp>调整视距</Chinesesimp>
+            <Chinese>調整視距</Chinese>
+            <Turkish>Görüş Mesafesi</Turkish>
+            <Portuguese>Ajustar distância de visão</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_VIEW_DISTANCE">
+            <Original>View Distance</Original>
+            <German>Sichtweite</German>
+            <Italian>Distanza Visuale</Italian>
+            <Chinesesimp>视野距离</Chinesesimp>
+            <Chinese>視野距離</Chinese>
+            <Turkish>Görüş Mesafesi</Turkish>
+            <Portuguese>Distância de visão</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_INFANTRY">
+            <Original>Infantry</Original>
+            <German>Infanterie</German>
+            <Italian>Fanteria</Italian>
+            <Chinesesimp>步兵</Chinesesimp>
+            <Chinese>步兵</Chinese>
+            <Turkish>Kara Askeri</Turkish>
+            <Portuguese>Infantaria</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_VEHICLES">
+            <Original>Vehicles</Original>
+            <German>Fahrzeuge</German>
+            <Italian>Veicoli</Italian>
+            <Chinesesimp>载具</Chinesesimp>
+            <Chinese>載具</Chinese>
+            <Turkish>Araçlar</Turkish>
+            <Portuguese>Veículos</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_OBJECTS">
+            <Original>Objects</Original>
+            <German>Objekte</German>
+            <Italian>Oggetti</Italian>
+            <Chinesesimp>物体</Chinesesimp>
+            <Chinese>物件</Chinese>
+            <Turkish>Objeler</Turkish>
+            <Portuguese>Objetos</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_ADJUST_VIEW_DISTANCE_TO_KEEP_FPS_ABOVE">
+            <Original>Adjust view distance to keep FPS above</Original>
+            <German>Automatische Sichtweite für FPS über</German>
+            <Italian>Aggiusta distanza in base agli FPS</Italian>
+            <Chinesesimp>动态调整视距令FPS高于</Chinesesimp>
+            <Chinese>自動調整視距並確保 FPS 高於</Chinese>
+            <Turkish>Görüş mesafesini ayarlarak FPS'i yüksek tutun</Turkish>
+            <Portuguese>Ajustar distância de visão para manter FPS acima de</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_ADJUST_TERRAIN_DETAILS">
+            <Original>Adjust Terrain Details</Original>
+            <German>Landschaftdetails</German>
+            <Italian>Aggiusta Dettagli Terreno</Italian>
+            <Chinesesimp>调整地形细节</Chinesesimp>
+            <Chinese>調整地形細節</Chinese>
+            <Turkish>Yer Detayı Ayarı</Turkish>
+            <Portuguese>Ajustar detalhes do terreno</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_VERY_LOW">
+            <Original>Very Low</Original>
+            <German>Sehr niedrig</German>
+            <Italian>Molto Basso</Italian>
+            <Chinesesimp>极低</Chinesesimp>
+            <Chinese>極低</Chinese>
+            <Turkish>Çok Düşük</Turkish>
+            <Portuguese>Muito baixo</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_LOW">
+            <Original>Low</Original>
+            <German>Niedrig</German>
+            <Italian>Basso</Italian>
+            <Chinesesimp>低</Chinesesimp>
+            <Chinese>低</Chinese>
+            <Turkish>Düşük</Turkish>
+            <Portuguese>Baixo</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_NORMAL">
+            <Original>Normal</Original>
+            <German>Normal</German>
+            <Italian>Normale</Italian>
+            <Chinesesimp>正常</Chinesesimp>
+            <Chinese>正常</Chinese>
+            <Turkish>Normal</Turkish>
+            <Portuguese>Normal</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_HIGH">
+            <Original>High</Original>
+            <German>Hoch</German>
+            <Italian>Alto</Italian>
+            <Chinesesimp>高</Chinesesimp>
+            <Chinese>高</Chinese>
+            <Turkish>Yüksek</Turkish>
+            <Portuguese>Alto</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_SHOW_TEAMMATES_ON_MAP">
+            <Original>Show teammates on map:</Original>
+            <German>Truppmitglieder auf Karte:</German>
+            <Italian>Mostra compagni in mappa:</Italian>
+            <Chinesesimp>在地图上显示友军：</Chinesesimp>
+            <Chinese>在地圖上顯示友軍單位：</Chinese>
+            <Turkish>Dostları haritada göster:</Turkish>
+            <Portuguese>Mostrar membros da equipe no mapa:</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_INVEHICLE_SOUND_VOLUME">
+            <Original>In-Vehicle Sound Volume</Original>
+            <German>Fahrzeug Innenlautstärke</German>
+            <Italian>Suono veicolo a bordo</Italian>
+            <Chinesesimp>载具内音量</Chinesesimp>
+            <Chinese>載具內音量</Chinese>
+            <Turkish>Araç-içi Ses</Turkish>
+            <Portuguese>Volume do som dentro do veículo</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_TEST">
+            <Original>Test</Original>
+            <German>Test</German>
+            <Italian>Test</Italian>
+            <Chinesesimp>测试</Chinesesimp>
+            <Chinese>測試</Chinese>
+            <Turkish>Test</Turkish>
+            <Portuguese>Teste</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_RESPAWN">
+            <Original>Respawn</Original>
+            <German>Respawn</German>
+            <Italian>Riapparizione</Italian>
+            <Chinesesimp>重生</Chinesesimp>
+            <Chinese>重生</Chinese>
+            <Turkish>Yeniden Doğ</Turkish>
+            <Portuguese>Respawn</Portuguese>
+        </Key>
+        <Key ID="STR_GREUH_REPLACE_NEAREST_AI">
+            <Original>Replace nearest AI</Original>
+            <German>Ersetze nächste KI</German>
+            <Italian>Rimpiazza AI</Italian>
+            <Chinesesimp>就近附身AI</Chinesesimp>
+            <Chinese>就近附身 AI</Chinese>
+            <Turkish>En yakındaki AI ile değiş</Turkish>
+            <Portuguese>Substituir IA mais próxima</Portuguese>
+        </Key>
+        <Key ID="STR_CR_KILLMSG">
+            <Original>A civilian named %1 was killed!</Original>
+            <German>Ein Zivilist mit Namen %1 wurde getötet!</German>
+            <Italian>Un civile di nome %1 è stato ucciso!</Italian>
+            <Chinesesimp>一个名叫%1的平民被击杀了！</Chinesesimp>
+            <Chinese>一個名叫 %1 的平民被擊殺了！</Chinese>
+            <Turkish>%1 ismindeki sivil öldürüldü!</Turkish>
+            <Portuguese>Um civil de nome %1 foi morto!</Portuguese>
+        </Key>
+        <Key ID="STR_CR_VEHICLEMSG">
+            <Original>A civilian's vehicle was seized!</Original>
+            <German>Ein Zivilfahrzeug wurde beschlagnahmt!</German>
+            <Italian>Un veicolo civile è stato confiscato!</Italian>
+            <Chinesesimp>一辆平民载具被强征了！</Chinesesimp>
+            <Chinese>一輛平民載具備強徵了！</Chinese>
+            <Turkish>Bir sivil aracı ele geçirildi!</Turkish>
+            <Portuguese>Um veículo de civil foi tomado!</Portuguese>
+        </Key>
+        <Key ID="STR_CR_BUILDINGMSG">
+            <Original>Civilians are complaining about %1 lost buildings.</Original>
+            <German>Die Zivilisten beklagen sich über %1 verlorene Gebäude.</German>
+            <Italian>Civili si lamentano della perdita di %1 edifici.</Italian>
+            <Chinesesimp>平民们对%1建筑的损坏有所怨言。</Chinesesimp>
+            <Chinese>平民們對 %1 的建築物戰損有所怨言。</Chinese>
+            <Turkish>Siviller %1 kadar yıkılan binaları hakkında konuşuyorlar.</Turkish>
+            <Portuguese>Civis estão reclamando sobre %1 construções destruídas</Portuguese>
+        </Key>
+        <Key ID="STR_CR_HEALMSG">
+            <Original>Civilian named %1 is thankful for your help.</Original>
+            <German>Der Zivilist %1 ist dankbar für die Hilfe.</German>
+            <Italian>Il civile di nome %1 ti ringrazia per l'aiuto.</Italian>
+            <Portuguese>Um civil chamado %1 agradeceu sua ajuda.</Portuguese>
+            <Chinese>平民 %1 感謝你的幫助。</Chinese>
+        </Key>
+        <Key ID="STR_PARAM_CR_BUILDING">
+            <Original>Civil Reputation penalty for buildings if building is</Original>
+            <German>Ziviles Ansehen sinkt, wenn Gebäude</German>
+            <Italian>Penalità nella reputazione coi civili , se l'edeficio è</Italian>
+            <Chinesesimp>当建筑_____时，民间声望会降低</Chinesesimp>
+            <Chinese>當建築物＿＿時，民間聲望會降低。</Chinese>
+            <Turkish>Şu türdeki binalara ceza verilince, ceza uygulanır</Turkish>
+            <Portuguese>Penalidade na reputação civil se a construção estiver</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_CR_DAMAGED">
+            <Original>damaged</Original>
+            <German>beschädigt</German>
+            <Italian>danneggiato</Italian>
+            <Chinesesimp>受损</Chinesesimp>
+            <Chinese>受損</Chinese>
+            <Turkish>zarar görmüş</Turkish>
+            <Portuguese>Danificada</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_CR_DESTROYED">
+            <Original>fully destroyed</Original>
+            <German>komplett zerstört</German>
+            <Italian>completamente distrutto</Italian>
+            <Chinesesimp>完全损毁</Chinesesimp>
+            <Chinese>完全損毀</Chinese>
+            <Turkish>tamamen yokedilmiş</Turkish>
+            <Portuguese>Totalmente destruída</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_RESTART_TITLE">
+            <Original>SERVER RESTART NOTIFICATION</Original>
+            <German>SERVER RESTART HINWEIS</German>
+            <Italian>NOTIFICA RESTART SERVER</Italian>
+            <Turkish>SERVER YENİDEN BAŞLATMA BİLDİRİMİ</Turkish>
+            <Chinesesimp>服务器重启提醒</Chinesesimp>
+            <Chinese>伺服器重啟提醒</Chinese>
+            <Portuguese>NOTIFICAÇÃO DE REINÍCIO DO SERVIDOR</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_RESTART_SECOND">
+            <Original>The server will restart in less than 60 seconds!</Original>
+            <German>Server Restart in weniger als 60 Sekunden!</German>
+            <Italian>Il server si riavvierà tra meno di 60 secodni!</Italian>
+            <Turkish>SERVER 60 SANİYE İÇİNDE YENİDEN BAŞLATILACAK!</Turkish>
+            <Chinesesimp>服务器将在60秒内重启！</Chinesesimp>
+            <Chinese>伺服器將在 60 秒內重啟！</Chinese>
+            <Portuguese>O servidor irá reiniciar em menos de 60 segundos!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_RESTART_FIVE">
+            <Original>The server will restart in less than 5 minutes!</Original>
+            <German>Server Restart in weniger als 5 Minuten!</German>
+            <Italian>Il server si riavvierà tra meno di 5 minuti!</Italian>
+            <Turkish>SERVER 5 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
+            <Chinesesimp>服务器将在5分钟内重启！</Chinesesimp>
+            <Chinese>伺服器將在 5 分鐘內重啟！</Chinese>
+            <Portuguese>O servidor irá reiniciar em menos de 5 minutos!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_RESTART_FIFTEEN">
+            <Original>The server will restart in less than 15 minutes!</Original>
+            <German>Server Restart in weniger als 15 Minuten!</German>
+            <Italian>Il server si riavvierà tra meno di 15 minuti!</Italian>
+            <Turkish>SERVER 15 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
+            <Chinesesimp>服务器将在15分钟内重启！</Chinesesimp>
+            <Chinese>伺服器將在 15 分鐘內重啟！</Chinese>
+            <Portuguese>O servidor irá reiniciar em menos de 15 minutos!</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_RESTART_THIRTY">
+            <Original>The server will restart in less than 30 minutes!</Original>
+            <German>Server Restart in weniger als 30 Minuten!</German>
+            <Italian>Il server si riavvierà tra meno di 30 minuti!</Italian>
+            <Turkish>SERVER 30 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
+            <Chinesesimp>服务器将在30分钟内重启！</Chinesesimp>
+            <Chinese>伺服器將在 30 分鐘內重啟！</Chinese>
+            <Portuguese>O servidor irá reiniciar em menos de 30 minutos!</Portuguese>
+        </Key>
+        <Key ID="STR_RESTART_PARAM">
+            <Original>Automatic Server Restart after (hours)</Original>
+            <German>Automatischer Server Restart nach (Stunden)</German>
+            <Italian>Restart Automatico del Server ogni (ore)</Italian>
+            <Turkish>Otomatik server yeniden başlat (saat)</Turkish>
+            <Chinesesimp>自动重启服务器时间（小时）</Chinesesimp>
+            <Chinese>自動重啟伺服器時間（小時）</Chinese>
+            <Portuguese>Reinício automático do servidor após (horas)</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUGOPTIONS">
+            <Original>== DEBUG MESSAGES ==</Original>
+            <German>== DEBUG NACHRICHTEN ==</German>
+            <Italian>== MESSAGGI DI DEBUG ==</Italian>
+            <Turkish>== DEBUG MESAJLARI ==</Turkish>
+            <Chinesesimp>== 除错信息 ==</Chinesesimp>
+            <Chinese>== 除錯訊息 ==</Chinese>
+            <Portuguese>== MENSAGENS DE DEBUG ==</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_CIVINFO">
+            <Original>Civil Informant</Original>
+            <German>Ziviler Informant</German>
+            <Italian>Informatore Civile</Italian>
+            <Turkish>Sivil Bilgisi</Turkish>
+            <Chinesesimp>民间线人</Chinesesimp>
+            <Chinese>民間線人</Chinese>
+            <Portuguese>Informante Civil</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_CIVREP">
+            <Original>Civil Reputation</Original>
+            <German>Ziviles Ansehen</German>
+            <Italian>Reputazione Civili</Italian>
+            <Turkish>Sivil Repütasyonu</Turkish>
+            <Chinesesimp>民间声望</Chinesesimp>
+            <Chinese>民間聲望</Chinese>
+            <Portuguese>Reputação Civil</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_INFORMANT_START">
+            <Original>A civilian from %1 says he has some information for us.</Original>
+            <German>Ein Zivilist aus %1 sagt, er hätte Informationen für uns.</German>
+            <Italian>Un civile a %1 dice di avere informazioni per noi.</Italian>
+            <Turkish>%1 adında ki bir sivil bize vereceği bir bilgisi olduğunu söylüyor.</Turkish>
+            <Chinesesimp>来自%1的一位平民说他有情报要交给我们。</Chinesesimp>
+            <Chinese>來自 %1 的一位平民說他有情報要交給我們。</Chinese>
+            <Portuguese>Um civil de %1 disse que possui algumas informações para nos apresentar.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_INFORMANT_SUCCESS">
+            <Original>The civilian gave us some important information.</Original>
+            <German>Der Zivilist gab uns wichtige Informationen.</German>
+            <Italian>Il civile ha fornito informazioni importatnti.</Italian>
+            <Turkish>Sivil bize çok önemli bilgiler verdi.</Turkish>
+            <Chinesesimp>平民给了我们一些重要情报。</Chinesesimp>
+            <Chinese>平民給了我們一些重要情報。</Chinese>
+            <Portuguese>Um civil nos concedeu algumas informações importantes.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_INFORMANT_FAIL">
+            <Original>The civilian has disappeared.</Original>
+            <German>Der Zivilist ist wieder untergetaucht.</German>
+            <Italian>Il civile è scomparso.</Italian>
+            <Turkish>Sivil ortadan kayboldu.</Turkish>
+            <Chinesesimp>平民消失了。</Chinesesimp>
+            <Chinese>平民消失了。</Chinese>
+            <Portuguese>Um civil desapareceu.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_INFORMANT_DEATH">
+            <Original>The civilian died.</Original>
+            <German>Der Zivilist wurde getötet.</German>
+            <Italian>Il civile è morto.</Italian>
+            <Turkish>Sivil öldü.</Turkish>
+            <Chinesesimp>平民死亡了。</Chinesesimp>
+            <Chinese>平民死亡了。</Chinese>
+            <Portuguese>Um civil morreu.</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_ASYMMETRIC">
+            <Original>Asymmetric Threat</Original>
+            <German>Asymmetrische Bedrohung</German>
+            <Italian>Minaccia Asimmetrica</Italian>
+            <Turkish>Asimetrik Tehdit</Turkish>
+            <Chinesesimp>非对称威胁</Chinesesimp>
+            <Chinese>非對稱威脅</Chinese>
+            <Portuguese>Ameaça Assimétrica</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_LOGISTIC">
+            <Original>Logistic</Original>
+            <German>Logistik</German>
+            <Italian>Logistica</Italian>
+            <Turkish>Lojistik</Turkish>
+            <Chinesesimp>后勤</Chinesesimp>
+            <Chinese>後勤</Chinese>
+            <Portuguese>Logística</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_TITLE">
+            <Original>Logistic Convoy Ambush</Original>
+            <German>Logistikkonvoi Überfall</German>
+            <Italian>Convoglio Sotto Attacco</Italian>
+            <Turkish>Lojistik Konvoyu Baskını</Turkish>
+            <Chinesesimp>后勤车队受袭</Chinesesimp>
+            <Chinese>後勤車隊遭到襲擊</Chinese>
+            <Portuguese>Emboscada no Comboio Logístico</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_TEXT">
+            <Original>Guerilla forces attacking our convoy near %1.</Original>
+            <German>Guerillakräfte greifen unseren Konvoi nahe %1 an.</German>
+            <Italian>Guerriglieri attaccano il nostro convoglio vicino %1</Italian>
+            <Turkish>Gerilla kuvvetleri bizim konvoyumuza saldırıyor, %1 yakınında.</Turkish>
+            <Chinesesimp>游击队正在%1附近攻击我们的车队</Chinesesimp>
+            <Chinese>游擊隊正在 %1 附近攻擊我們的車隊</Chinese>
+            <Portuguese>Forças de guerrilha estão atacando nosso comboio nas proximidades de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_SUCCESS">
+            <Original>The ambush was successfully repelled.</Original>
+            <German>Der Hinterhalt konnte erfolgreich zurückgeschlagen werden.</German>
+            <Italian>L'attacco è stato neutralizzato.</Italian>
+            <Turkish>Baskın başarıyla püskürtüldü.</Turkish>
+            <Chinesesimp>成功击退了来犯者。</Chinesesimp>
+            <Chinese>成功擊退了游擊隊。</Chinese>
+            <Portuguese>A emboscada foi frustrada com sucesso.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_ASYMMCONVOYAMBUSH_FAIL">
+            <Original>The guerilla forces escaped with the convoy resources.</Original>
+            <German>Die Guerillakräfte konnten mit den Konvoiressourcen verschwinden.</German>
+            <Italian>I Guerriglieri scappano con le risorse del nostro convoglio.</Italian>
+            <Turkish>Gerilla kuvvetleri malzemelerimizle beraber kaçtılar.</Turkish>
+            <Chinesesimp>游击队抢走了车队物资。</Chinesesimp>
+            <Chinese>游擊隊搶走了車隊物資。</Chinese>
+            <Portuguese>As forças de guerrilha escaparam com os recursos do comboio.</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_SECTORSPAWN">
+            <Original>Sectorspawn</Original>
+            <German>Sektorspawn</German>
+            <Italian>Spawn Settori</Italian>
+            <Chinesesimp>战区刷新</Chinesesimp>
+            <Chinese>戰區刷新</Chinese>
+            <Portuguese>Spawn do setor</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_KILL">
+            <Original>Killed units</Original>
+            <German>Getötete Einheiten</German>
+            <Italian>Unità Uccise</Italian>
+            <Chinesesimp>击杀的单位</Chinesesimp>
+            <Chinese>擊殺單位</Chinese>
+            <Portuguese>Unidades mortas</Portuguese>
+        </Key>
+        <Key ID="STR_CR_ACE_ACTION">
+            <Original>Treat the civilian (field dressing)</Original>
+            <German>Zivilisten versorgen (einfache Bandage)</German>
+            <Italian>Soccorso Civili</Italian>
+            <Chinesesimp>治疗平民（战地绷带）</Chinesesimp>
+            <Chinese>治療平民（基礎繃帶）</Chinese>
+            <Portuguese>Preste socorro ao civil (curativo)</Portuguese>
+        </Key>
+        <Key ID="STR_CR_ACE_ACTION_FAIL">
+            <Original>You need a field dressing.</Original>
+            <German>Du brauchst eine einfache Bandage.</German>
+            <Italian>Hai bisogno di un bendaggio semplice.</Italian>
+            <Chinesesimp>你需要一个战地绷带。</Chinesesimp>
+            <Chinese>你需要一個基礎繃帶。</Chinese>
+            <Portuguese>Você precisa de curativo.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_HVT_START">
+            <Original>There is a high ranked officer near %1.</Original>
+            <German>Ein hochrangiger Offizier befindet sich in der Nähe von %1.</German>
+            <Italian>C'è un ufficiale di altro grado vicino %1.</Italian>
+            <Chinesesimp>%1附近有一名高级军官。</Chinesesimp>
+            <Chinese>%1 附近有一名高級軍官。</Chinese>
+            <Portuguese>Há um oficial de alta patente nas proximidades de %1.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_HVT_SUCCESS">
+            <Original>The officer was successfully killed.</Original>
+            <German>Der Offizier konnte erfolgreich getötet werden.</German>
+            <Italian>L'ufficiale è stato ucciso.</Italian>
+            <Chinesesimp>成功刺杀了军官。</Chinesesimp>
+            <Chinese>成功刺殺了軍官。</Chinese>
+            <Portuguese>O oficial foi morto. Missão cumprida.</Portuguese>
+        </Key>
+        <Key ID="STR_NOTIFICATION_CIV_HVT_FAIL">
+            <Original>The officer has moved on.</Original>
+            <German>Der Offizier ist weitergezogen.</German>
+            <Italian>L'ufficiale è scappato.</Italian>
+            <Chinesesimp>军官逃离了。</Chinesesimp>
+            <Chinese>軍官逃離了。</Chinese>
+            <Portuguese>O oficial escapou.</Portuguese>
+        </Key>
+        <Key ID="STR_PARAM_RESPAWN_COOLDOWN">
+            <Original>Mobile Respawn Cooldown (minutes)</Original>
+            <German>Mobiler Respawn Cooldown (Minuten)</German>
+            <Italian>Attesa Respawn Mobile (Minuti)</Italian>
+            <Chinesesimp>机动复活点冷却时间（分钟）</Chinesesimp>
+            <Chinese>機動重生點每次重生所需冷卻時間（分鐘）</Chinese>
+            <Portuguese>Tempo de espera do respawn móvel (minutos)</Portuguese>
+        </Key>
+        <Key ID="STR_RESPAWN_COOLDOWN_HINT">
+            <Original>%1 minutes mobile respawn cooldown left.</Original>
+            <German>%1 Minuten Mobiler Respawn Cooldown übrig.</German>
+            <Italian>Mancano ancora %1 minuti al respawn.</Italian>
+            <Chinesesimp>机动复活点还需要%1分钟冷却。</Chinesesimp>
+            <Chinese>機動重生點還需要 %1 分鐘冷卻。</Chinese>
+            <Portuguese>Falta(m) %1 minuto(s) de tempo de espera do respawn móvel.</Portuguese>
+        </Key>
+        <Key ID="STR_CR_RESISTANCE_KILLMSG">
+            <Original>An allied resistance fighter named %1 was killed!</Original>
+            <German>Ein verbündeter Widerstandskämpfer mit Namen %1 wurde getötet!</German>
+            <Italian>Un'alleato della resistenza di nome %1 è stato ucciso!</Italian>
+            <Chinesesimp>一位名叫%1的友军抵抗军战士阵亡了！</Chinesesimp>
+            <Chinese>一名叫做 %1 的友軍抵抗軍戰士陣亡了！</Chinese>
+            <Portuguese>Um aliado das forças de resistência de nome %1 foi morto!</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_SAVE">
+            <Original>Gamedata saving</Original>
+            <German>Savegame Speicherung</German>
+            <Italian>Salvataggio Dati di Gioco</Italian>
+            <Chinesesimp>储存游戏数据中</Chinesesimp>
+            <Chinese>儲存數據中</Chinese>
+            <Portuguese>Salvando dados do jogo</Portuguese>
+        </Key>
+        <Key ID="STR_PARAMS_DEBUG_PRODUCTION">
+            <Original>Production</Original>
+            <German>Produktion</German>
+            <Italian>Produzione</Italian>
+            <Chinesesimp>生产</Chinesesimp>
+            <Chinese>生產</Chinese>
+            <Portuguese>Produção</Portuguese>
+        </Key>
+        <!-- Added/Changed in 0.963a -->
+        <Key ID="STR_PARAMS_LOADSAVEPARAMS">
+            <Original>Load/Save Parameters</Original>
+            <German>Laden/Speichern der Parameter</German>
+        </Key>
+        <Key ID="STR_PARAMS_LOADSAVEPARAMS_SAVE">
+            <Original>SAVE selected parameters</Original>
+            <German>SPEICHERN der momentanen Parameter</German>
+        </Key>
+        <Key ID="STR_PARAMS_LOADSAVEPARAMS_LOAD">
+            <Original>LOAD parameters or use selected if no saved value found</Original>
+            <German>LADEN der gespeicherten Parameter oder momentane nutzen, wenn keine gespeicherten vorhanden sind
+            </German>
+        </Key>
+        <Key ID="STR_PARAMS_LOADSAVEPARAMS_SELECTED">
+            <Original>Use selected parameters without saving</Original>
+            <German>Momentane Parametereinstellung ohne Speicherung</German>
+        </Key>
+        <Key ID="STR_RAISE">
+            <Original>-- Raise</Original>
+            <German>-- Höher</German>
+        </Key>
+        <Key ID="STR_LOWER">
+            <Original>-- Lower</Original>
+            <German>-- Niedriger</German>
+        </Key>
+        <Key ID="STR_NOTIFICATION_GUER_INC_TITLE">
+            <Original>Guerilla forces on the way.</Original>
+            <German>Widerstandskämpfer sind unterwegs.</German>
+        </Key>
+        <Key ID="STR_NOTIFICATION_GUER_INC">
+            <Original>Guerilla forces are incoming to %1 from the %2.</Original>
+            <German>Widerstandskämpfer nähern sich %1 aus %2.</German>
+        </Key>
+        <Key ID="STR_PARAMS_REVIVEOPTIONS">
+            <Original>== REVIVE OPTIONS (Disregarded, if you play with ACE Medical) ==</Original>
+            <German>== WIEDERBELEBUNGSEINSTELLUNGEN (Nicht berücksichtigt, wenn mit ACE Medical gespielt wird) ==
+            </German>
+            <Spanish>== OPCIONES DE REVIVE ==</Spanish>
+            <Russian>== ВОЗВРАТИТЬ ОПЦИИ ==</Russian>
+            <Italian>== OPZIONI RIANIMAZIONE ==</Italian>
+            <Chinesesimp>== 复活选项 ==</Chinesesimp>
+            <Chinese>== 昏迷甦醒選項 ==</Chinese>
+            <Turkish>== CANLANDIRMA AYARLARI ==</Turkish>
+            <Portuguese>== OPÇÕES DE RESSUCITAÇÃO ==</Portuguese>
+        </Key>
+    </Package>
 </Project>


### PR DESCRIPTION
Update stringtable formatting according to .editorconfig

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no <!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> |
| Fixed issues | - <!-- #-prefixed issue number(s), if any --> |

### Description:

Stringtable file uses tab indentation which is incorrect as our .editorconfig has set spaces for indentation.
This PR fixes that.
<!--
Write short description about this pull request
by replacing this comment block
-->

### Content:
- [x] Stringtable.xml with updated whitespace

<!--
Add things which are part of this pull request as checkboxes
to show if it's already finished and already part of the pull request.
-->

### Tested on:
- [x] Local MP Vanilla
- [x] ~~Local MP ACE~~
- [x] Dedicated MP Vanilla
- [x] ~~Dedicated MP ACE~~

<!--
Add strikethrough if N\A, for eg. stringtable updates

- [x] ~~Not applicable~~
-->
