### PR TITLE
Update A3_defines array syntax for SQF Lint

### DIFF
--- a/Missionframework/KP_GUI/A3_defines.hpp
+++ b/Missionframework/KP_GUI/A3_defines.hpp
@@ -1164,8 +1164,8 @@ class RscMapControl
     colorMainRoadsFill[] = {1,0.6,0.4,1};
     colorGrid[] = {0.1,0.1,0.1,0.6};
     colorGridMap[] = {0.1,0.1,0.1,0.6};
-    stickX[] = {0.2,["Gamma",1,1.5]};
-    stickY[] = {0.2,["Gamma",1,1.5]};
+    stickX[] = {0.2,{"Gamma",1,1.5}};
+    stickY[] = {0.2,{"Gamma",1,1.5}};
     class Legend
     {
         colorBackground[] = {1,1,1,0.5};


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no|
| New feature? | no <!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> |
| Fixed issues | - <!-- #-prefixed issue number(s), if any --> |

### Description:
 
Updated vanilla UI classes defines syntax. Current syntax is incompatible with SQF Lint and is breaking the parser.

(this was in older files but I guess it got lost in some refactoring)

