### PR TITLE
V0.97 post sprint 4 fixes/updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,6 +92,10 @@
         "KPLIB_param_wipeSave1",
         "KPLIB_param_wipeSave2",
         "KPLIB_plm_groups",
+        "KPR_fnc_getPlaytime",
+        "KPR_fnc_getRankName",
+        "KPR_fnc_getScore",
+        "KPR_levelSystem",
         "KPR_playerNation",
         "KPR_players",
         "KPR_uniforms"

--- a/Missionframework/modules/02_build/fnc/fn_build_displayScript.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_displayScript.sqf
@@ -37,7 +37,7 @@ switch _mode do {
         // ESC closes whole camera
         _display displayAddEventHandler ["keyDown", {
             if (_this select 1 == 1) then {
-                call KPLIB_fnc_build_camera_close;
+                call KPLIB_fnc_build_camClose;
             };
         }];
 

--- a/Missionframework/modules/99_playerMenu/fnc/fn_plm_showRankData.sqf
+++ b/Missionframework/modules/99_playerMenu/fnc/fn_plm_showRankData.sqf
@@ -4,7 +4,7 @@
     File: fn_plm_showRankData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-08-05
-    Last Update: 2018-08-05
+    Last Update: 2018-08-25
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -27,46 +27,13 @@ private _ctrlNoRanks = _dialog displayCtrl 758037;
 // Disable no ranks hint
 _ctrlNoRanks ctrlShow false;
 
-// Get data of current player
-private _playerData = +(KPR_players select (KPR_players findIf {_x select 1 == getPlayerUID player}));
-private _playtime = _playerData select 6;
-
-// Get index of the current player uniform
-private _indexU = KPR_uniforms findIf {_x select 0 == uniform player};
-
-// Configclass of the insignia
-private _insigniaClass = configNull;
-
-// Get configClass of the insignia, if player wears a supported uniform
-if (_indexU != -1) then {
-    _validUniform = true;
-
-    private _nation = KPR_uniforms select _indexU select 1;
-    if (KPR_playerNation) then {_nation = _playerData select 3;};
-
-    switch (_nation) do {
-        case 0: {_nation = "BWF";};
-        case 1: {_nation = "BWT";};
-        case 2: {_nation = "CRO";};
-        case 3: {_nation = "USA";};
-        default {_nation = "USA";};
-    };
-
-    _insigniaClass = [["CfgUnitInsignia", format ["KPR_%1_%2", _nation, str (_playerData select 2)]], configNull] call BIS_fnc_loadClass;
-};
-
-// Get readable name of the current player rank
-private _rankname = getText (_insigniaClass >> "displayname");
-
-// Generate readable time values
-private _playtimeD = floor (_playtime / 1440);
-_playtime = _playtime % 1440;
-private _playtimeH = floor (_playtime / 60);
-private _playtimeM = _playtime % 60;
-
 // Show data in dialog
-_ctrlRank ctrlSetText (_rankname select [6]);
-_ctrlScore ctrlSetText str (_playerData select 5);
-_ctrlPlaytime ctrlSetText format ["%1d %2h %3m", _playtimeD, _playtimeH, _playtimeM];
+_ctrlRank ctrlSetText ([] call KPR_fnc_getRankName);
+if (KPR_levelSystem) then {
+    _ctrlScore ctrlSetText str ([] call KPR_fnc_getScore);
+} else {
+    _ctrlScore ctrlSetText (localize "STR_PLAYERDIALOG_NOLVLSYSTEM");
+};
+_ctrlPlaytime ctrlSetText ([] call KPR_fnc_getPlaytime);
 
 true

--- a/Missionframework/modules/99_playerMenu/ui/KP_playerMenu.hpp
+++ b/Missionframework/modules/99_playerMenu/ui/KP_playerMenu.hpp
@@ -123,8 +123,6 @@ class KP_playerMenu {
 
     class controls {
 
-        class KP_DialogCross: KP_DialogCrossC {};
-
         class KP_PlayerRank: KP_Text {
             idc = 758032;
             style = 2;
@@ -242,5 +240,7 @@ class KP_playerMenu {
             text = "$STR_APPLY";
             onButtonClick = "[] call KPLIB_fnc_plm_save";
         };
+
+        class KP_DialogCross: KP_DialogCrossC {};
     };
 };

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1425,6 +1425,10 @@
             <Original>You're not the leader of this group.</Original>
             <German>Du bist nicht der Anführer dieser Gruppe.</German>
         </Key>
+        <Key ID="STR_PLAYERDIALOG_NOLVLSYSTEM">
+            <Original>Leveling system disabled</Original>
+            <German>Levelsystem deaktiviert</German>
+        </Key>
     </Package>
     <Package name="Debriefings">
         <Key ID="STR_DEBRIEF_WINTITLE">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |
| Fixed issues | #471 |

### Description:
Small fixes and updates for the sprint 4 result.
Note: Currently we can't fix the "directly close bug" for the admin menu as it only contains buttons. Later I guess we'll add a small "statistics/info area" at the top of the dialog and make sure one of the dynamic text controls will be the first focus.

### Content:
- [x] Fixed a typo for the cam close function in the build module
- [x] Updated the player menu to the state of the standalone version
- [x] Fixed direct close in player menu

### Tested on:
- [x] Local MP Vanilla
- [x] ~~Local MP ACE~~
- [x] Dedicated MP Vanilla
- [x] ~~Dedicated MP ACE~~