### PR TITLE
V0.97 post Sprint 5 addActions tweaks

### DIFF
--- a/Missionframework/modules/01_core/fnc/fn_core_handleVehicleSpawn.sqf
+++ b/Missionframework/modules/01_core/fnc/fn_core_handleVehicleSpawn.sqf
@@ -32,7 +32,7 @@ switch(typeOf _vehicle) do {
         // Add redeploy action globaly and for JIP
         [
             _vehicle,
-            [localize "STR_ACTION_REDEPLOY", {[] spawn KPLIB_fnc_core_redeploy}, nil, -801, false, true, "", "_target == _originalTarget", 10]
+            [localize "STR_ACTION_REDEPLOY", {[] spawn KPLIB_fnc_core_redeploy}, nil, -801, false, true, "", "_this == vehicle _this", 10]
         ] remoteExecCall ["addAction", 0, true];
     };
 };

--- a/Missionframework/modules/01_core/fnc/fn_core_handleVehicleSpawn.sqf
+++ b/Missionframework/modules/01_core/fnc/fn_core_handleVehicleSpawn.sqf
@@ -1,0 +1,38 @@
+/*
+    KPLIB_fnc_core_handleVehicleSpawn
+
+    File: fn_core_handleVehicleSpawn.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-09-10
+    Last Update: 2018-09-10
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    Handle vehicle spawn event
+
+    Parameter(s):
+        0: OBJECT - Vehicle which was spawned
+
+    Returns:
+    NOTHING
+*/
+params ["_vehicle"];
+
+switch(typeOf _vehicle) do {
+    case KPLIB_preset_fobBox;
+    case KPLIB_preset_fobTruck: {
+        // Add FOB build action globaly and for JIP
+        [
+            _vehicle,
+            [localize "STR_ACTION_FOB_DEPLOY", {[param [0], param [1], param[3]] call KPLIB_fnc_core_buildFob}, true, -800, false, true, "", "[_target, _this] call KPLIB_fnc_core_canBuildFob", 10]
+        ] remoteExecCall ["addAction", 0, true];
+    };
+
+    case KPLIB_preset_potato: {
+        // Add redeploy action globaly and for JIP
+        [
+            _vehicle,
+            [localize "STR_ACTION_REDEPLOY", {[] spawn KPLIB_fnc_core_redeploy}, nil, -801, false, true, "", "_target == _originalTarget", 10]
+        ] remoteExecCall ["addAction", 0, true];
+    };
+};

--- a/Missionframework/modules/01_core/fnc/fn_core_setupPlayerActions.sqf
+++ b/Missionframework/modules/01_core/fnc/fn_core_setupPlayerActions.sqf
@@ -4,7 +4,7 @@
     File: fn_common_setupPlayerActions.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-28
-    Last Update: 2018-08-26
+    Last Update: 2018-09-10
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -19,54 +19,16 @@
 
 // Actions avalible GLOBALLY on objects
 if (isServer) then {
-    // Actions on Vehicles
-    ["KPLIB_vehicle_spawned", {
-        params ["_vehicle"];
-
-        switch(typeOf _vehicle) do {
-            case KPLIB_preset_fobBox;
-            case KPLIB_preset_fobTruck: {
-                // Add FOB build action globaly and for JIP
-                [
-                    _vehicle,
-                    [localize "STR_ACTION_FOB_DEPLOY", {[param [0], param [1], param[3]] call KPLIB_fnc_core_buildFob}, true, -800, false, true, "", "[_target, _this] call KPLIB_fnc_core_canBuildFob", 10]
-                ] remoteExecCall ["addAction", 0, true];
-            };
-
-            case KPLIB_preset_potato: {
-                // Add redeploy action globaly and for JIP
-                [
-                    _vehicle,
-                    [localize "STR_ACTION_REDEPLOY", {[] spawn KPLIB_fnc_core_redeploy}, nil, -801, false, true, "", "vehicle player == player", 10]
-                ] remoteExecCall ["addAction", 0, true];
-            };
-        };
-    }] call CBA_fnc_addEventHandler;
+    // Add actions to supported vehicles
+    ["KPLIB_vehicle_spawned", KPLIB_fnc_core_handleVehicleSpawn] call CBA_fnc_addEventHandler;
 };
 
 // Actions avalible LOCALLY to player
 if(hasInterface) then {
-    ["KPLIB_player_fob", {
-        params ["_player", "_fob"];
-
-        private _redeployActionId = _player getVariable ["KPLIB_actionId_redeploy", nil];
-
-        // Remove redeploy action if player had one avalible
-        if (_fob isEqualTo "") then {
-            if (!isNil "_redeployActionId") then {
-                _player removeAction _redeployActionId;
-                _player setVariable ["KPLIB_actionId_redeploy", nil];
-            };
-        } else {
-            // If entered fob and had no action
-            if (isNil "_redeployActionId") then {
-                // Add action to player
-                _redeployActionId = _player addAction [localize "STR_ACTION_REDEPLOY", {[] spawn KPLIB_fnc_core_redeploy}, nil, -801, false, true, "", "vehicle player == player", 10];
-                // Save action id so it can we removed when out of FOB
-                _player setVariable ["KPLIB_actionId_redeploy", _redeployActionId];
-            };
-        };
-    }] call CBA_fnc_addEventHandler
+    // FOB redeploy action
+    private _fobRedeployCondition = '_target isEqualTo _originalTarget && !(_originalTarget getVariable ["KPLIB_fob", ""] isEqualTo "")';
+    private _actionArray = [localize "STR_ACTION_REDEPLOY", {[] spawn KPLIB_fnc_core_redeploy}, nil, -801, false, true, "", _fobRedeployCondition, 10];
+    [_actionArray] call CBA_fnc_addPlayerAction;
 };
 
 true

--- a/Missionframework/modules/01_core/functions.hpp
+++ b/Missionframework/modules/01_core/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-28
-    Last Update: 2018-08-31
+    Last Update: 2018-09-10
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -46,6 +46,9 @@ class core {
 
     // Handle an activated sector
     class core_handleSector {};
+
+    // Handle vehicle spawn event
+    class core_handleVehicleSpawn {};
 
     // Module initialization
     class core_initModule {

--- a/Missionframework/modules/01_core/scripts/server/eventLoop.sqf
+++ b/Missionframework/modules/01_core/scripts/server/eventLoop.sqf
@@ -40,7 +40,7 @@ private _initFunction = {
 
         // Set fob variable on player if it has changed
          if !(_currentPlayer getVariable ["KPLIB_fob", ""] isEqualTo _playerFob) then {
-            _currentPlayer setVariable ["KPLIB_fob", _playerFob];
+            _currentPlayer setVariable ["KPLIB_fob", _playerFob, true];
             // Emit event
             ["KPLIB_player_fob", [_currentPlayer, _playerFob]] call CBA_fnc_globalEvent;
         };

--- a/Missionframework/modules/02_build/fnc/fn_build_setupPlayerActions.sqf
+++ b/Missionframework/modules/02_build/fnc/fn_build_setupPlayerActions.sqf
@@ -4,7 +4,7 @@
     File: fn_build_setupPlayerActions.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-07-01
-    Last Update: 2018-08-26
+    Last Update: 2018-09-10
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -20,13 +20,14 @@
 // Actions avalible LOCALLY to player
 if(hasInterface) then {
     // Build action
-    private _buildCondition = 'vehicle player == player && !(player getVariable ["KPLIB_fob", ""] in ["", "KPLIB_eden_startbase_marker"])';
+    private _buildCondition = '_target == _originalTarget && !(_originalTarget getVariable ["KPLIB_fob", ""] in ["", "KPLIB_eden_startbase_marker"])';
     private _buildAction = {
         private _pos = getMarkerPos (player getVariable "KPLIB_fob");
         [_pos, KPLIB_range_fob] call KPLIB_fnc_build_start;
     };
-    _buildActionId = player addAction [localize "STR_ACTION_FOB_BUILD", _buildAction, nil, -802, false, true, "", _buildCondition, 10];
-    player setVariable ["KPLIB_actionId_build", _buildActionId];
+
+    private _actionArray = [localize "STR_ACTION_FOB_BUILD", _buildAction, nil, -802, false, true, "", _buildCondition, 10];
+    [_actionArray] call CBA_fnc_addPlayerAction;
 };
 
 true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes|
| New feature? | no |
| Needs wipe? | no|
| Fixed issues | -|

### Description:

Post Sprint 5 `addAction` tweaks, small vehicle respawn action handling refactor

### Content:
- [x] Fixed build action persistence
- [x] Simplified "Redeploy" and "FOB Build" actions code
- [x] Vehicle actions handling moved to external method

### Tested on:
- [x] Local MP Vanilla
- [x] ~~Local MP ACE~~
- [x] Dedicated MP Vanilla
- [x] ~~Dedicated MP ACE~~
