### PR TITLE
Move Base marker on Altis

### DIFF
--- a/Missionbasefiles/kp_liberation.Altis/mission.sqm
+++ b/Missionbasefiles/kp_liberation.Altis/mission.sqm
@@ -10855,7 +10855,7 @@ class Mission
 		class Item501
 		{
 			dataType="Marker";
-			position[]={27435.021,0,5463.521};
+			position[]={27350.303,0,5634.2764};
 			name="KPLIB_eden_startbase_marker";
 			text="Operation Base";
 			type="mil_start";


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no  |
| Fixed issues | - |

### Description:

Fix redeploy action available only on part of ship

### Content:
- [x] Moved base marker closer to the starting ship

### Tested on:
- [x] Local MP Vanilla
