### PR TITLE
Enemy module pt1

### DIFF
--- a/Missionframework/KPLIB_functions.hpp
+++ b/Missionframework/KPLIB_functions.hpp
@@ -4,7 +4,7 @@
     File: KPLIB_functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-16
-    Last Update: 2018-12-13
+    Last Update: 2019-02-02
 
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -26,4 +26,5 @@ class KPLIB {
     #include "modules\14_virtual\functions.hpp"
     #include "modules\15_build\functions.hpp"
     #include "modules\16_garrison\functions.hpp"
+    #include "modules\24_enemy\functions.hpp"
 };

--- a/Missionframework/modules/01_common/fnc/fn_common_createCrew.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_createCrew.sqf
@@ -4,7 +4,7 @@
     File: fn_common_createCrew.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-25
-    Last Update: 2018-12-17
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -53,7 +53,7 @@ private _crewClasses = _turrets apply {
 };
 
 // Spawn group and move into to vehicle
-private _grp = [_side, _driverClass + _crewClasses, getPos _vehicle] call KPLIB_fnc_common_createGroup;
+private _grp = [_driverClass + _crewClasses, getPos _vehicle, _side] call KPLIB_fnc_common_createGroup;
 // Move the units into the vehicle, -1 indicates driver
 {
     if (_forEachIndex isEqualTo 0) then {

--- a/Missionframework/modules/01_common/fnc/fn_common_createGroup.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_createGroup.sqf
@@ -4,16 +4,16 @@
     File: fn_common_createGroup.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-24
-    Last Update: 2018-12-08
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
         Creates a group at given side with units according to given array of classnames and fires the Liberation group created event.
 
     Parameter(s):
-        _side       - Side of the group                             [SIDE, defaults to KPLIB_preset_sideE]
         _units      - Array of classnames to spawn as group members [ARRAY, defaults to []]
         _spawnPos   - Position to spawn the group and units         [POSITION, defaults to KPLIB_zeroPos]
+        _side       - Side of the group                             [SIDE, defaults to KPLIB_preset_sideE]
         _addition   - Additional argument for unit creation         [STRING, defaults to "NONE"]
 
     Returns:
@@ -21,9 +21,9 @@
 */
 
 params [
-    ["_side", KPLIB_preset_sideE, [sideEmpty]],
     ["_units", [], [[]]],
     ["_spawnPos", [KPLIB_zeroPos], [[]], [3]],
+    ["_side", KPLIB_preset_sideE, [sideEmpty]],
     ["_addition", "NONE", [""]]
 ];
 

--- a/Missionframework/modules/01_common/fnc/fn_common_getFobAlphabetName.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_getFobAlphabetName.sqf
@@ -4,7 +4,7 @@
     File: fn_common_getFobAlphabetName.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-27
-    Last Update: 2018-12-08
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -20,7 +20,7 @@ params [
     ["_fob", "", [""]]
 ];
 
-private _index = KPLIB_sectors_fobs findIf {_x == _fob};
+private _index = KPLIB_sectors_fobs find _fob;
 
 if (_index isEqualTo -1) then {
     ""

--- a/Missionframework/modules/02_core/fnc/fn_core_areUnitsNear.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_areUnitsNear.sqf
@@ -4,7 +4,7 @@
     File: fn_core_areUnitsNear.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-07
-    Last Update: 2018-12-08
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -19,7 +19,7 @@
         Result [BOOL]
 */
 
-// TODO
+// !TODO!
 // Guess we can move this to common
 
 params [

--- a/Missionframework/modules/02_core/fnc/fn_core_changeSectorOwner.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_changeSectorOwner.sqf
@@ -4,7 +4,7 @@
     File: fn_core_changeSectorOwner.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-07
-    Last Update: 2018-11-27
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -27,7 +27,7 @@ if (_toPlayerSide) then {
     KPLIB_sectors_blufor pushBack _sectorToChange;
     [] call KPLIB_fnc_core_checkWinCond;
 } else {
-    KPLIB_sectors_blufor deleteAt (KPLIB_sectors_blufor findIf {_x isEqualTo _sectorToChange});
+    KPLIB_sectors_blufor deleteAt (KPLIB_sectors_blufor find _sectorToChange);
 };
 
 publicVariable "KPLIB_sectors_blufor";

--- a/Missionframework/modules/02_core/fnc/fn_core_handleVehicleSpawn.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_handleVehicleSpawn.sqf
@@ -4,7 +4,7 @@
     File: fn_core_handleVehicleSpawn.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-09-10
-    Last Update: 2018-12-11
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -29,7 +29,7 @@ switch (typeOf _vehicle) do {
             _vehicle,
             "STR_KPLIB_ACTION_DEPLOY",
             [{["KPLIB_fob_build_requested", _this select 0] call CBA_fnc_localEvent}, true, -800, false, true, "", "[_target, _this] call KPLIB_fnc_core_canBuildFob", 10]
-        ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+        ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _vehicle];
     };
 
     case KPLIB_preset_respawnTruckF;
@@ -41,7 +41,7 @@ switch (typeOf _vehicle) do {
             _vehicle,
             "STR_KPLIB_ACTION_REDEPLOY",
             [{["KPLIB_respawn_requested", _this] call CBA_fnc_localEvent}, nil, -801, false, true, "", "_this == vehicle _this", 10]
-        ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+        ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _vehicle];
     };
 
     case KPLIB_preset_addHeliF: {
@@ -52,7 +52,7 @@ switch (typeOf _vehicle) do {
                 "STR_KPLIB_ACTION_HELIMOVE",
                 [{[_this select 0] call KPLIB_fnc_core_heliToDeck;}, nil, 10, true, true, "", "(_target distance KPLIB_eden_startbase) < 20", 4],
                 "#FF8000"
-            ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+            ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _vehicle];
         };
     };
 };

--- a/Missionframework/modules/02_core/fnc/fn_core_spawnPotato.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_spawnPotato.sqf
@@ -4,7 +4,7 @@
     File: fn_core_spawnPotato.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-05-01
-    Last Update: 2018-12-08
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -18,7 +18,7 @@
 */
 
 // Check if there wasn't a Potato 01 already spawned or if the spawned one is destroyed.
-// NOTE: As the loading will happen before this function is called, it won't interfere with a loaded Potato 01.
+// !NOTE! As the loading will happen before this function is called, it won't interfere with a loaded Potato 01.
 if(!isServer || alive KPLIB_core_potato01) exitWith {};
 
 // If Potato 01 wreck is too close to respawn we should delete it.

--- a/Missionframework/modules/02_core/fnc/fn_core_spawnStartFobBox.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_spawnStartFobBox.sqf
@@ -4,7 +4,7 @@
     File: fn_core_spawnStartFobBox.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-09
-    Last Update: 2018-12-11
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -41,7 +41,7 @@ private _fobBox = [KPLIB_preset_fobBoxF, [_spawnPos select 0, _spawnPos select 1
     "STR_KPLIB_ACTION_DEPLOYRANDOM",
     [{[_this select 0] call KPLIB_fnc_core_buildFobRandom;}, true, -800, false, true, "", "(_target distance KPLIB_eden_boxspawn) < 3 && KPLIB_sectors_fobs isEqualTo []", 4],
     "#FF0000"
-] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _fobBox];
 
 // Add event handler to call this script again if box was destroyed.
 _fobBox addMPEventHandler ["MPKilled", {[_this select 0] call KPLIB_fnc_core_spawnStartFobBox}];

--- a/Missionframework/modules/02_core/scripts/server/sectorMonitor.sqf
+++ b/Missionframework/modules/02_core/scripts/server/sectorMonitor.sqf
@@ -4,7 +4,7 @@
     File: sectorMonitor.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-05
-    Last Update: 2018-11-09
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -15,7 +15,7 @@ scriptName "KPLIB_sectorMonitor";
 if(isServer) then {
 
     // Update sector markers every time sector state was changed
-    {[_x, {call KPLIB_fnc_core_updateSectorMarkers}] call CBA_fnc_addEventHandler;} forEach ["KPLIB_sector_activated", "KPLIB_sector_deactivated"];
+    {[_x, {[] call KPLIB_fnc_core_updateSectorMarkers}] call CBA_fnc_addEventHandler;} forEach ["KPLIB_sector_activated", "KPLIB_sector_deactivated"];
 
     // Init function, executed every time whole list of sectors was iterated
     private _initFunction = {

--- a/Missionframework/modules/02_core/ui/KPLIB_titles.hpp
+++ b/Missionframework/modules/02_core/ui/KPLIB_titles.hpp
@@ -4,7 +4,7 @@
     File: KPLIB_defines.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-28
-    Last Update: 2018-11-27
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -71,7 +71,7 @@ class RscTitles
         };
     };
 
-// TODO: Rework and implementation of the Status Overlay
+// !TODO! Rework and implementation of the Status Overlay
 /*
     class statusoverlay
     {

--- a/Missionframework/modules/10_resources/README.md
+++ b/Missionframework/modules/10_resources/README.md
@@ -1,7 +1,7 @@
 # KP Liberation Module Description
 
 ## Resources Module
-TODO Description
+!TODO! Description
 
 ### Dependencies
 * Init

--- a/Missionframework/modules/10_resources/fnc/fn_res_addActions.sqf
+++ b/Missionframework/modules/10_resources/fnc/fn_res_addActions.sqf
@@ -4,7 +4,7 @@
     File: fn_res_addActions.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-15
-    Last Update: 2018-12-16
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -32,7 +32,7 @@ if ((typeOf _object) in KPLIB_res_crateClasses) then {
         "STR_KPLIB_ACTION_CHECKCRATE",
         [{[_this select 0] call KPLIB_fnc_res_checkCrate;}, nil, -500, false, true, "", "isNull attachedTo _target", 4],
         "#FFFF00"
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _object];
 
     // Add push action to crate
     [
@@ -40,7 +40,7 @@ if ((typeOf _object) in KPLIB_res_crateClasses) then {
         "STR_KPLIB_ACTION_PUSHCRATE",
         [{[_this select 0] call KPLIB_fnc_res_pushCrate;}, nil, -501, false, false, "", "isNull attachedTo _target", 4],
         "#FFFF00"
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _object];
 
     // Add store action to crate
     [
@@ -48,7 +48,7 @@ if ((typeOf _object) in KPLIB_res_crateClasses) then {
         "STR_KPLIB_ACTION_STORECRATE",
         [{[_this select 0] call KPLIB_fnc_res_storeCrate;}, nil, -502, false, true, "", "isNull attachedTo _target", 4],
         "#FFFF00"
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _object];
 
     // Add load to transport action to crate
     [
@@ -56,7 +56,7 @@ if ((typeOf _object) in KPLIB_res_crateClasses) then {
         "STR_KPLIB_ACTION_LOADCRATE",
         [{[_this select 0] call KPLIB_fnc_res_loadCrate;}, nil, -503, false, true, "", "isNull attachedTo _target", 4],
         "#FFFF00"
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _object];
 };
 
 // Storage actions
@@ -71,7 +71,7 @@ if ((typeOf _object) in KPLIB_res_storageClasses) then {
             "STR_KPLIB_ACTION_UNSTORE" + (toUpper _x),
             [{[_this select 0, _this select 3] call KPLIB_fnc_res_unstoreCrate;}, _x, -500 - _forEachIndex, false, true, "", "", 10],
             "#FFFF00"
-        ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+        ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _object];
     } forEach ["Supply", "Ammo", "Fuel"];
 
     // Stack and Sort action for storage
@@ -80,7 +80,7 @@ if ((typeOf _object) in KPLIB_res_storageClasses) then {
         "STR_KPLIB_ACTION_STACKNSORT",
         [{[_this select 0] call KPLIB_fnc_res_stackNsort;}, nil, -503, false, false, "", "", 10],
         "#FFFF00"
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _object];
 };
 
 true

--- a/Missionframework/modules/10_resources/fnc/fn_res_getStorageSpace.sqf
+++ b/Missionframework/modules/10_resources/fnc/fn_res_getStorageSpace.sqf
@@ -1,0 +1,31 @@
+/*
+    KPLIB_fnc_res_getStorageSpace
+
+    File: fnc_res_getStorageSpace.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-16
+    Last Update: 2019-02-16
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Returns the amount of free storage space of a given storage.
+
+    Parameter(s):
+        _storage - Storage to check for free space [OBJECT, defaults to objNull]
+
+    Returns:
+        Amount of free storage spaces [NUMBER]
+*/
+
+params [
+    ["_storage", objNull, [objNull]]
+];
+
+// Get the storage positions amount
+private _allSpaces = count ([typeOf _storage] call KPLIB_fnc_res_getAttachArray);
+
+// Get amount of already stored crates
+private _attachedCrates = count (attachedObjects _storage);
+
+// Return free space amount
+_allSpaces - _attachedCrates

--- a/Missionframework/modules/10_resources/fnc/fn_res_getStorages.sqf
+++ b/Missionframework/modules/10_resources/fnc/fn_res_getStorages.sqf
@@ -1,0 +1,26 @@
+/*
+    KPLIB_fnc_res_getStorages
+
+    File: fn_res_getStorages.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-16
+    Last Update: 2019-02-16
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Returns all storages inside given radius of a given position.
+
+    Parameter(s):
+        _center - Position AGL from where to look for storages  [POSITION AGL, defaults to KPLIB_zeroPos]
+        _radius - Radius from the center                        [NUMBER, defaults to 100]
+
+    Returns:
+        All found storage objects [ARRAY]
+*/
+
+params [
+    ["_center", KPLIB_zeroPos, [[]], 3],
+    ["_radius", 100, [0]]
+];
+
+_center nearEntities [KPLIB_res_storageClasses, _radius]

--- a/Missionframework/modules/10_resources/fnc/fn_res_getStorages.sqf
+++ b/Missionframework/modules/10_resources/fnc/fn_res_getStorages.sqf
@@ -4,7 +4,7 @@
     File: fn_res_getStorages.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-16
-    Last Update: 2019-02-16
+    Last Update: 2019-02-18
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -23,4 +23,4 @@ params [
     ["_radius", 100, [0]]
 ];
 
-_center nearEntities [KPLIB_res_storageClasses, _radius]
+nearestObjects [_center, KPLIB_res_storageClasses, _radius]

--- a/Missionframework/modules/10_resources/fnc/fn_res_loadCrate.sqf
+++ b/Missionframework/modules/10_resources/fnc/fn_res_loadCrate.sqf
@@ -4,7 +4,7 @@
     File: fn_res_loadCrate.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-16
-    Last Update: 2018-12-16
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -61,7 +61,7 @@ if !(_nearTransport getVariable ["KPLIB_res_unloadAction", false]) then {
         "STR_KPLIB_ACTION_UNLOADCRATE",
         [{[_this select 0] call KPLIB_fnc_res_unloadCrate;}, nil, -500, false, true, "", "!((_target getVariable ['KPLIB_res_usedSlots', 0]) isEqualTo 0)", 10],
         "#FFFF00"
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, true];
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _nearTransport];
 
     _nearTransport setVariable ["KPLIB_res_unloadAction", true, true];
 };

--- a/Missionframework/modules/10_resources/fnc/fn_res_storeCrate.sqf
+++ b/Missionframework/modules/10_resources/fnc/fn_res_storeCrate.sqf
@@ -4,7 +4,7 @@
     File: fn_res_storeCrate.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-15
-    Last Update: 2018-12-16
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -60,7 +60,7 @@ _crate attachTo [_nearStorage, [
     [typeOf _crate] call KPLIB_fnc_res_getCrateZ
 ]];
 
-// TODO: We need to test, if this on/off is really necessary.
+// !TODO! We need to test, if this on/off is really necessary.
 // [_crate, false] remoteExecCall ["enableRopeAttach", true];
 
 true

--- a/Missionframework/modules/10_resources/functions.hpp
+++ b/Missionframework/modules/10_resources/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-13
-    Last Update: 2018-12-16
+    Last Update: 2019-02-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -34,6 +34,12 @@ class res {
 
     // Gets array with amounts of all resources at given location
     class res_getResTotal {};
+
+    // Gets array with all storage objects in given radius of given position
+    class res_getStorages {};
+
+    // Gets amount of free storage space of given storage
+    class res_getStorageSpace {};
 
     // Gets array with resource values of given storage
     class res_getStorageValue {};

--- a/Missionframework/modules/14_virtual/fnc/fn_virtual_addCurator.sqf
+++ b/Missionframework/modules/14_virtual/fnc/fn_virtual_addCurator.sqf
@@ -4,7 +4,7 @@
     File: fn_virtual_addCurator.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-18
-    Last Update: 2018-12-11
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -32,7 +32,7 @@ unassignCurator _oldCurator;
 [{isNull getAssignedCuratorLogic (_this select 0)}, {
     params ["_unit", "_mode", "_oldCurator"];
 
-    // TODO
+    // !TODO!
     // This causes rpt spam about not existing objects
     // Disable for now
     //deleteVehicle _oldCurator;

--- a/Missionframework/modules/15_build/fnc/fn_build_changeQueueMode.sqf
+++ b/Missionframework/modules/15_build/fnc/fn_build_changeQueueMode.sqf
@@ -6,7 +6,7 @@
     File: fn_build_changeQueueMode.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-29
-    Last Update: 2018-12-17
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -25,7 +25,7 @@ params [
 private _display = ctrlParent _control;
 private _confirmBtnControl = _display displayCtrl KPLIB_IDC_BUILD_CONFIRM;
 
-// TODO preserve and restore current build queue
+// !TODO! preserve and restore current build queue
 switch (LGVAR_D(buildMode, 0)) do {
     case 0: {
         _control ctrlSetText "Move mode";

--- a/Missionframework/modules/15_build/fnc/fn_build_confirmAll.sqf
+++ b/Missionframework/modules/15_build/fnc/fn_build_confirmAll.sqf
@@ -5,7 +5,7 @@
     File: fn_build_confirmAll.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-28
-    Last Update: 2018-11-29
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -21,7 +21,7 @@
 private _validItems = LGVAR(buildQueue) select {_x getVariable ["KPLIB_validPos", true]};
 LSVAR("buildQueue", LGVAR(buildQueue) - _validItems);
 
-// TODO implement build queue handling (resource check etc.)
+// !TODO! implement build queue handling (resource check etc.)
 systemChat "buildConfirm: Resource check not implemented yet!";
 {
     private _dirAndUp = [vectorDir _x, vectorUp _x];

--- a/Missionframework/modules/15_build/fnc/fn_build_confirmSingle.sqf
+++ b/Missionframework/modules/15_build/fnc/fn_build_confirmSingle.sqf
@@ -4,7 +4,7 @@
     File: fn_build_confirmSingle.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-29
-    Last Update: 2018-12-17
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -27,7 +27,7 @@ _createParams params ["_className", "_pos", "_dir", "_justBuild"];
 
 private ["_obj"];
 
-// TODO save only builings via Build module, units and vehicles should be moved to persistence module
+// !TODO! save only builings via Build module, units and vehicles should be moved to persistence module
 switch true do {
     case (_className isKindOf "Man"): {
         _obj = [createGroup KPLIB_preset_sideF, _className] call KPLIB_fnc_common_createUnit;

--- a/Missionframework/modules/15_build/fnc/fn_build_handleMouse.sqf
+++ b/Missionframework/modules/15_build/fnc/fn_build_handleMouse.sqf
@@ -6,7 +6,7 @@
     File: fn_build_handleMouse.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-09-09
-    Last Update: 2018-12-11
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -115,7 +115,7 @@ switch toLower _mode do {
     case "onmousezchanged_buildcategorylist";
     case "onmousezchanged_buildlist": {
         // Disable camera movement when scrolling over build dialog
-        // TODO is there any better solution?
+        // !TODO! is there any better solution?
         LGVAR(camera) camCommand "manual off";
 
         [{

--- a/Missionframework/modules/15_build/fnc/fn_build_loadData.sqf
+++ b/Missionframework/modules/15_build/fnc/fn_build_loadData.sqf
@@ -4,7 +4,7 @@
     File: fn_build_loadData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-04
-    Last Update: 2018-12-08
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -49,7 +49,7 @@ if (_moduleData isEqualTo []) then {
 
             private ["_object"];
 
-            // TODO proper deserialization/serialization with groups and vehicle crews handling
+            // !TODO! proper deserialization/serialization with groups and vehicle crews handling
             switch true do {
                 case (_className isKindOf "Man"): {
                     _object = [createGroup KPLIB_preset_sideF, _className] call KPLIB_fnc_common_createUnit;

--- a/Missionframework/modules/15_build/ui/KPLIB_buildDisplay.hpp
+++ b/Missionframework/modules/15_build/ui/KPLIB_buildDisplay.hpp
@@ -4,7 +4,7 @@
     File: KPLIB_defines.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-07-01
-    Last Update: 2018-12-12
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -110,7 +110,7 @@ class KPLIB_build {
 
             // Toolbox Controls
             class Controls {
-                // TODO move toolbox items creation to script
+                // !TODO! move toolbox items creation to script
                 class KPLIB_Toolbox_MoveItems: KPGUI_PRE_ActiveText {
                     text = "Build mode";
                     idc = KPLIB_IDC_BUILD_TOOLBOX_MOVEITEMS;

--- a/Missionframework/modules/16_garrison/README.md
+++ b/Missionframework/modules/16_garrison/README.md
@@ -9,6 +9,7 @@ It'll also provide functions to change garrison data and a garrison management d
 * Init
 * Common
 * Core
+* Garrison
 
 ### Functions
 * KPLIB_fnc_garrison_changeOwner

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -49,7 +49,7 @@ private _heavyVeh = [];
 
 // Despawn garrison light vehicles
 {
-    if ((alive _x) && !((crew _x) isEqualTo []) && !(_x getVariable ["KPLIB_captured", false])) then {
+    if ((alive _x) && !((crew _x) isEqualTo []) && !(_x getVariable ["KPLIB_captured", false]) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
         _vehicle = _x;
         _lightVeh pushBack (typeOf _x);
         {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach (crew _x);

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -49,11 +49,18 @@ private _heavyVeh = [];
 
 // Despawn garrison light vehicles
 {
-    if ((alive _x) && !((crew _x) isEqualTo []) && !(_x getVariable ["KPLIB_captured", false]) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
-        _vehicle = _x;
-        _lightVeh pushBack (typeOf _x);
-        {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach (crew _x);
-        deleteVehicle _vehicle;
+    if ((alive _x) && !(_x getVariable ["KPLIB_captured", false])) then {
+        // A combat-capable vehicle
+        if (!((crew _x) isEqualTo []) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
+            _vehicle = _x;
+            _lightVeh pushBack (typeOf _x);
+            {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach (crew _x);
+            deleteVehicle _vehicle;
+        };
+        // An unarmed and empty transport vehicle
+        if (((crew _x) isEqualTo []) && (_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
+            deleteVehicle _x;
+        };
     };
 } forEach (_activeGarrisonRef select 3);
 

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -50,17 +50,12 @@ private _heavyVeh = [];
 // Despawn garrison light vehicles
 {
     if ((alive _x) && !(_x getVariable ["KPLIB_captured", false])) then {
-        // A combat-capable vehicle
         if (!((crew _x) isEqualTo []) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
             _vehicle = _x;
             _lightVeh pushBack (typeOf _x);
             {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach (crew _x);
-            deleteVehicle _vehicle;
         };
-        // An unarmed and empty transport vehicle
-        if (((crew _x) isEqualTo []) && (_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
-            deleteVehicle _x;
-        };
+        deleteVehicle _x;
     };
 } forEach (_activeGarrisonRef select 3);
 

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_despawn.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-20
-    Last Update: 2018-11-27
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -41,7 +41,7 @@ private _heavyVeh = [];
     };
 } forEach (_activeGarrisonRef select 2);
 
-/* NOTE:
+/* !NOTE!
     With the current despawn checks for the vehicles, the vehicle won't be deleted if it's a wreck or the crew bailed out due to damage.
     This leads to the behaviour that it would be deleted if there is a blufor unit or a player in the vehicle (if the enemy is opfor).
     We'll address the "capture enemy vehicle" with a variable which will be set to the vehicle like "KPLIB_captured" in a later iteration.

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_getGarrison.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_getGarrison.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_getGarrison.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-24
-    Last Update: 2018-11-18
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -27,7 +27,7 @@ private _array = [KPLIB_garrison_array, KPLIB_garrison_active] select _active;
 private _index = (_array findIf {_x select 0 == _sector});
 
 if(_index isEqualTo -1) then {
-    [[], [], [], [], []]
+    []
 } else {
     _array select _index
 }

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_getVehSpawnPos.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_getVehSpawnPos.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_getVehSpawnPos.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-23
-    Last Update: 2018-12-19
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -22,9 +22,13 @@ params [
 ];
 
 private _spawnPos = (_center getPos [50 + (random 200), random 360]) findEmptyPosition [0, 100, "B_T_VTOL_01_armed_F"];
+private _nearRoad = selectRandom (_center nearRoads 150);
+if !(isNil "_nearRoad") then {
+    _spawnPos = getPos _nearRoad;
+};
 
 // Avoid spawn position on water or empty position by findEmptyPosition
-if (_spawnPos isEqualTo [] || {surfaceIsWater _spawnPos}) exitWith {_this call KPLIB_fnc_garrison_getVehSpawnPos};
+if (_spawnPos isEqualTo [] || surfaceIsWater _spawnPos || !((_spawnPos nearEntities 20) isEqualTo [])) exitWith {_this call KPLIB_fnc_garrison_getVehSpawnPos};
 
 // Return position with a slight z Offset
 [_spawnPos select 0, _spawnPos select 1, 0.25]

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_initSector.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_initSector.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_initSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-24
-    Last Update: 2018-12-09
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -25,7 +25,7 @@ if (_sector isEqualTo "") exitWith {[]};
 
 // Initialize general sector garrisons
 private _tempMarker = toArray _sector;
-private _side = 0;          // 0 - Enemy Military Troops; 1 - Local Militia Troops; 2 - Players (NOTE: It's very possible that this will change, so consider it as placeholder)
+private _side = 0;          // 0 - Enemy Military Troops; 1 - Local Militia Troops; 2 - Players (!NOTE! It's very possible that this will change, so consider it as placeholder)
 private _soldiers = 0;      // Amount of soldiers
 private _lVehicles = [];    // Array of light vehicle classnames
 private _hVehicles = [];    // Array of heavy vehicle classnames

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorInfantry.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorInfantry.sqf
@@ -72,7 +72,7 @@ _grp = [_classnames, _spawnPos, _side] call KPLIB_fnc_common_createGroup;
     _activeGarrisonRef pushBack _x;
 } forEach (units _grp);
 
-// FOR DEBUG: Add group to Zeus
+// !DEBUG! Add group to Zeus
 {
     _x addCuratorEditableObjects [units _grp, true]
 } forEach allCurators;

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorInfantry.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorInfantry.sqf
@@ -78,7 +78,7 @@ _grp = [_classnames, _spawnPos, _side] call KPLIB_fnc_common_createGroup;
 } forEach allCurators;
 
 // Remove possible initialization waypoints
-while {(count (waypoints _grp)) != 0} do {deleteWaypoint ((waypoints _grp) select 0);};
+{deleteWaypoint [_grp, 0];} forEach (waypoints _grp);
 // Make sure every soldier is following the leader
 {_x doFollow (leader _grp)} forEach (units _grp);
 

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorInfantry.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorInfantry.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_spawnSectorInfantry.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-20
-    Last Update: 2018-12-21
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -65,7 +65,7 @@ for "_i" from 1 to _amount do {
 };
 
 // Create group
-_grp = [_side, _classnames, _spawnPos] call KPLIB_fnc_common_createGroup;
+_grp = [_classnames, _spawnPos, _side] call KPLIB_fnc_common_createGroup;
 
 // Add units of created group to active garrison array
 {

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorVehicle.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_spawnSectorVehicle.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_spawnSectorVehicle.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-21
-    Last Update: 2018-12-19
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -35,7 +35,7 @@ private _sectorPos = getMarkerPos _sector;
 private _spawnPos = [_sectorPos] call KPLIB_fnc_garrison_getVehSpawnPos;
 private _activeGarrisonRef = [_sector, true] call KPLIB_fnc_garrison_getGarrison;
 
-/* NOTE
+/* !NOTE!
     This works totally fine and also adds e.g. a CSAT vehicle classname as Blufor side, if ordered.
     The "problem" is, that it has the normal config crew, so it's manned by CSAT soldiers which belong to Blufor side.
     Maybe we have to replace it with an own function, especially as some AAF vehicles (resistance side) are also in the blufor preset.
@@ -45,12 +45,12 @@ private _vehicle = [_classname, _spawnPos, random 360, true, true] call KPLIB_fn
 _vehicle setDamage 0;
 private _crew = crew _vehicle;
 
-// FOR DEBUG: Add group to Zeus
+// !DEBUG! Add group to Zeus
 {
     _x addCuratorEditableObjects [[_vehicle], true]
 } forEach allCurators;
 
-/* NOTE
+/* !NOTE!
     Adding a patrol waypoint pattern to the vehicle let it move like the infantry squads, which is the same like in the old framework.
     Unfortunately this leads to the behaviour that they can get stuck and drive over their homies with no regrets.
     So we could let them spawn standing still and just "scan the area" or we keep it like in the old framework and let them drive around.

--- a/Missionframework/modules/24_enemy/README.md
+++ b/Missionframework/modules/24_enemy/README.md
@@ -1,0 +1,15 @@
+# KP Liberation Module Description
+
+## Enemy Module
+
+
+### Dependencies
+* Init
+* Common
+* Core
+
+### Functions
+
+
+### Scripts
+No scripts will be started by this module

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_addAwareness.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_addAwareness.sqf
@@ -1,0 +1,29 @@
+/*
+    KPLIB_fnc_enemy_addAwareness
+
+    File: fn_enemy_addAwareness.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-24
+    Last Update: 2019-02-24
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Adds given amount to enemy awareness value.
+
+    Parameter(s):
+        _amount - Positive or negative amount to add [NUMBER, defaults to 0]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_amount", 0, [0]]
+];
+
+KPLIB_enemy_awareness = KPLIB_enemy_awareness + _amount;
+if (KPLIB_enemy_awareness < 0) then {KPLIB_enemy_awareness = 0;};
+if (KPLIB_enemy_awareness > 100) then {KPLIB_enemy_awareness = 100;};
+publicVariable "KPLIB_enemy_awareness";
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_addStrength.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_addStrength.sqf
@@ -1,0 +1,30 @@
+/*
+    KPLIB_fnc_enemy_addStrength
+
+    File: fn_enemy_addStrength.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-24
+    Last Update: 2019-02-24
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Adds given amount to enemy strength value.
+
+    Parameter(s):
+        _amount - Positive or negative amount to add [NUMBER, defaults to 0]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_amount", 0, [0]]
+];
+
+// Exit, if not enough strength available
+if (_amount < 0 && _amount > KPLIB_enemy_strength) exitWith {false};
+
+KPLIB_enemy_strength = KPLIB_enemy_strength + _amount;
+publicVariable "KPLIB_enemy_strength";
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_getTransportClasses.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_getTransportClasses.sqf
@@ -4,7 +4,7 @@
     File: fn_enemy_getTransportClasses.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-18
-    Last Update: 2019-02-18
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -24,7 +24,7 @@ params [
 ];
 
 // Select ground or air transport array
-private _toCheck = [KPLIB_preset_vehTransPlE, KPLIB_preset_heliTransPlE] select _air;
+private _toCheck = [(KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE), KPLIB_preset_heliTransPlE] select _air;
 
 // Check via config for enough transport seats and return resulting array
 private _validVeh = [];

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_getTransportClasses.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_getTransportClasses.sqf
@@ -1,0 +1,37 @@
+/*
+    KPLIB_fnc_enemy_getTransportClasses
+
+    File: fn_enemy_getTransportClasses.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-18
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Gets all transport classnames of preset vehicles which are capable to transport given amount of soldiers.
+
+    Parameter(s):
+        _amount - Amount of soldiers which should be transported [NUMBER, defaults to 0]
+        _air    - Should it be an air vehicle [BOOL, defaults to false]
+
+    Returns:
+        Array of valid vehicle classnames [ARRAY]
+*/
+
+params [
+    ["_amount", 0, [0]],
+    ["_air", false, [false]]
+];
+
+// Select ground or air transport array
+private _toCheck = [KPLIB_preset_vehTransPlE, KPLIB_preset_heliTransPlE] select _air;
+
+// Check via config for enough transport seats and return resulting array
+private _validVeh = [];
+{
+    if ((getNumber (configfile >> "CfgVehicles" >> _x >> "transportSoldier")) >= _amount) then {
+        _validVeh pushBack _x;
+    };
+} forEach _toCheck;
+
+_validVeh

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_handleConvoyEnd.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_handleConvoyEnd.sqf
@@ -1,0 +1,39 @@
+/*
+    KPLIB_fnc_enemy_handleConvoyEnd
+
+    File: fn_enemy_handleConvoyEnd.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-23
+    Last Update: 2019-02-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Handles convoy processing, after it reached the destination.
+
+    Parameter(s):
+        _units          - Arrived units of convoy   [ARRAY, defaults to []]
+        _destination    - Destination of the convoy [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_units", [], [[]]],
+    ["_destination", "", [""]]
+];
+
+// Get group
+private _grp = group (_units select 0);
+
+// !DEBUG!
+hint format ["Arrived: %1\nUnits: %2\nDestination: %3 (%4)", units _grp, _units, markerText _destination, _destination];
+
+[_destination, count _units] call KPLIB_fnc_garrison_addInfantry;
+
+{
+    deleteVehicle (vehicle _x);
+    deleteVehicle _x;
+} forEach (units _grp);
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_loadData.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_loadData.sqf
@@ -1,0 +1,36 @@
+/*
+    KPLIB_fnc_enemy_loadData
+
+    File: fn_enemy_loadData.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Loads data which is bound to this module from the given save data or initializes needed data for a new campaign.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Enemy module loading...";};
+
+private _moduleData = ["enemy"] call KPLIB_fnc_init_getSaveData;
+
+// Check if there is a new campaign
+if (_moduleData isEqualTo []) then {
+    if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Enemy module data empty, creating new data...";};
+    // Nothing to do here
+} else {
+    // Otherwise start applying the saved data
+    if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Enemy module data found, applying data...";};
+
+    KPLIB_enemy_strength = _moduleData select 0;
+    KPLIB_enemy_awareness = _moduleData select 1;
+};
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_postInit.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_postInit.sqf
@@ -1,0 +1,43 @@
+/*
+    KPLIB_fnc_enemy_postInit
+
+    File: fn_enemy_postInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        The postInit function of a module takes care of starting/executing the modules functions or scripts.
+        Basically it starts/initializes the module functionality to make all provided features usable.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module postInit finished [BOOL]
+*/
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [POST] [ENEMY] Module initializing...", diag_tickTime];};
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+
+    // Start strength increase events
+    [] call KPLIB_fnc_enemy_strengthInc;
+
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [POST] [ENEMY] Module initialized", diag_tickTime];};
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_preInit.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_preInit.sqf
@@ -54,7 +54,7 @@ if (isServer) then {
     ["KPLIB_sector_deactivated", {[_this select 0] call KPLIB_fnc_enemy_sectorDeact;}] call CBA_fnc_addEventHandler;
 
     // Register convoy arrival event handler
-    ["KPLIB_transferConvoy_end", {[_this select 0] call KPLIB_fnc_enemy_handleConvoyEnd;}] call CBA_fnc_addEventHandler;
+    ["KPLIB_transferConvoy_end", {_this call KPLIB_fnc_enemy_handleConvoyEnd;}] call CBA_fnc_addEventHandler;
 };
 
 // HC section

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_preInit.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_enemy_preInit.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-02
-    Last Update: 2019-02-18
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -43,6 +43,18 @@ if (isServer) then {
 
     // Register save event handler
     ["KPLIB_doSave", {[] call KPLIB_fnc_enemy_saveData;}] call CBA_fnc_addEventHandler;
+
+    // Register sector activation event handler
+    ["KPLIB_sector_activated", {[_this select 0] call KPLIB_fnc_enemy_sectorAct;}] call CBA_fnc_addEventHandler;
+
+    // Register sector captured event handler
+    ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_enemy_sectorCapture;}] call CBA_fnc_addEventHandler;
+
+    // Register sector deactivation event handler
+    ["KPLIB_sector_deactivated", {[_this select 0] call KPLIB_fnc_enemy_sectorDeact;}] call CBA_fnc_addEventHandler;
+
+    // Register convoy arrival event handler
+    ["KPLIB_transferConvoy_end", {[_this select 0] call KPLIB_fnc_enemy_handleConvoyEnd;}] call CBA_fnc_addEventHandler;
 };
 
 // HC section

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_preInit.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_preInit.sqf
@@ -1,0 +1,60 @@
+/*
+    KPLIB_fnc_enemy_preInit
+
+    File: fn_enemy_preInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        The preInit function defines global variables, adds event handlers and set some vital settings which are used in this module.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module preInit finished [BOOL]
+*/
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [PRE] [ENEMY] Module initializing...", diag_tickTime];};
+
+/*
+    ----- Module Globals -----
+*/
+
+// Strength of the enemy (0-1000)
+KPLIB_enemy_strength = 500;
+
+// Awareness of the enemy (0-100)
+KPLIB_enemy_awareness = 0;
+
+/*
+    ----- Module Initialization -----
+*/
+
+// Process CBA Settings
+[] call KPLIB_fnc_enemy_settings;
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+    // Register load event handler
+    ["KPLIB_doLoad", {[] call KPLIB_fnc_enemy_loadData;}] call CBA_fnc_addEventHandler;
+
+    // Register save event handler
+    ["KPLIB_doSave", {[] call KPLIB_fnc_enemy_saveData;}] call CBA_fnc_addEventHandler;
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [PRE] [ENEMY] Module initialized", diag_tickTime];};
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_reinforceGarrison.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_reinforceGarrison.sqf
@@ -4,17 +4,50 @@
     File: fn_enemy_reinforceGarrison.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-18
-    Last Update: 2019-02-18
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
-        No description added yet.
+        Generates units/vehicles via the KPLIB_enemy_strength resource and send it to given sector from given military base.
 
     Parameter(s):
-        _localVariable - Description [DATATYPE, defaults to DEFAULTVALUE]
+        _base           - Military base sector to send reinforcements from  [STRING, defaults to ""]
+        _destination    - Sector which should receive the reinforcements    [STRING, defaults to ""]
+        _infantry       - Amount of infantry which should be send           [NUMBER, defaults to 0]
+        _vehicleClasses - Array of vehicle classnames which should be send  [ARRAY, defaults to []]
 
     Returns:
-        Function reached the end [BOOL]
+        Array of created groups [ARRAY]
 */
 
-true
+params [
+    ["_base", "", [""]],
+    ["_destination", "", [""]],
+    ["_troops", 0, [0]],
+    ["_vehicleClasses", [], [[]]]
+];
+
+// Exit, if no military base or destination is given
+if (_base isEqualTo "" || !(_base in KPLIB_sectors_military) || _destination isEqualTo "") exitWith {[]};
+
+// Calculate costs and exit, if not enough strength
+// !NOTE! Values are placeholder
+private _costs = _troops * 2 + (count _vehicleClasses) * 10;
+if (_costs > KPLIB_enemy_strength) exitWith {[]};
+
+if (KPLIB_param_debug) then {diag_log format ["[KP LIBERATION] [ENEMY] Reinfore garrison of %1 (%2) for %3 strength with [%4, %5]", markerText _destination, _destination, _costs, _troops, _vehicleClasses];};
+
+[-_costs] call KPLIB_fnc_enemy_addStrength;
+
+// Add infantry and vehicles to base garrison
+[_base, _troops] call KPLIB_fnc_garrison_addInfantry;
+{
+    if (_x in (KPLIB_preset_vehHeavyApcPlE + KPLIB_preset_vehHeavyPlE)) then {
+        [_base, _x, true] call KPLIB_fnc_garrison_addVeh;
+    } else {
+        [_base, _x] call KPLIB_fnc_garrison_addVeh;
+    };
+} forEach _vehicleClasses;
+
+// Start garrison transfer convoy
+[_base, _destination, _troops, _vehicleClasses] call KPLIB_fnc_enemy_transferGarrison

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_reinforceGarrison.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_reinforceGarrison.sqf
@@ -1,0 +1,20 @@
+/*
+    KPLIB_fnc_enemy_reinforceGarrison
+
+    File: fn_enemy_reinforceGarrison.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-18
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        No description added yet.
+
+    Parameter(s):
+        _localVariable - Description [DATATYPE, defaults to DEFAULTVALUE]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_saveData.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_saveData.sqf
@@ -1,0 +1,30 @@
+/*
+    KPLIB_fnc_enemy_saveData
+
+    File: fn_enemy_saveData.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Fetches data which is bound to this module and send it to the global save data array.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Enemy module saving...";};
+
+// Set module data to save and send it to the global save data array
+["enemy",
+    [
+        KPLIB_enemy_strength,
+        KPLIB_enemy_awareness
+    ]
+] call KPLIB_fnc_init_setSaveData;
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_sectorAct.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_sectorAct.sqf
@@ -1,0 +1,24 @@
+/*
+    KPLIB_fnc_enemy_sectorAct
+
+    File: fn_enemy_sectorAct.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-20
+    Last Update: 2019-02-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Handles sector activation event.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_sector", "", [""]]
+];
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_sectorCapture.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_sectorCapture.sqf
@@ -1,0 +1,24 @@
+/*
+    KPLIB_fnc_enemy_sectorCapture
+
+    File: fn_enemy_sectorCapture.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-20
+    Last Update: 2019-02-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Handles sector capture event.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_sector", "", [""]]
+];
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_sectorDeact.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_sectorDeact.sqf
@@ -1,0 +1,24 @@
+/*
+    KPLIB_fnc_enemy_sectorDeact
+
+    File: fn_enemy_sectorDeact.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-20
+    Last Update: 2019-02-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Handles sector deactivation event.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_sector", "", [""]]
+];
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_settings.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_settings.sqf
@@ -1,0 +1,20 @@
+/*
+    KPLIB_fnc_enemy_settings
+
+    File: fn_enemy_settings.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-17
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        CBA Settings initialization for this module
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_strengthInc.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_strengthInc.sqf
@@ -4,7 +4,7 @@
     File: fn_enemy_strengthInc.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-18
-    Last Update: 2019-02-18
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -19,7 +19,7 @@
 
 // Increase strength by remaining enemy military bases
 private _increase = (count (KPLIB_sectors_military select {!(_x in KPLIB_sectors_blufor)})) * 10;
-KPLIB_enemy_strength = KPLIB_enemy_strength + _increase;
+[_increase] call KPLIB_fnc_enemy_addStrength;
 
 // Enforce cap for strength
 if (KPLIB_enemy_strength > 1000) then {

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_strengthInc.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_strengthInc.sqf
@@ -1,0 +1,37 @@
+/*
+    KPLIB_fnc_enemy_strengthInc
+
+    File: fn_enemy_strengthInc.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-18
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        CBA loop to increase the enemy strength in given interval depending on the remaining military bases.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+// Increase strength by remaining enemy military bases
+private _increase = (count (KPLIB_sectors_military select {!(_x in KPLIB_sectors_blufor)})) * 10;
+KPLIB_enemy_strength = KPLIB_enemy_strength + _increase;
+
+// Enforce cap for strength
+if (KPLIB_enemy_strength > 1000) then {
+    KPLIB_enemy_strength = 1000;
+    if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [ENEMY] Strength reached cap of 1000";};
+} else {
+    if (KPLIB_param_debug) then {diag_log format ["[KP LIBERATION] [ENEMY] Strength increased from %1 to %2", KPLIB_enemy_strength - _increase, KPLIB_enemy_strength];};
+};
+
+// Schedule the next call
+if (KPLIB_campaignRunning) then {
+    [{[] call KPLIB_fnc_enemy_strengthInc;}, [], 1800] call CBA_fnc_waitAndExecute;
+};
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
@@ -78,6 +78,10 @@ if !(_troops > (_garrison select 2)) then {
         private _spawnDir = random 360;
         if !(isNil "_nearRoad") then {
             _spawnPos = getPosATL _nearRoad;
+            while {!((_spawnPos nearEntities 5) isEqualTo [])} do {
+                _nearRoad = selectRandom ((markerPos _origin) nearRoads 100);
+                _spawnPos = getPosATL _nearRoad;
+            };
             _spawnDir = _nearRoad getDir ((roadsConnectedTo _nearRoad) select 0);
         };
 

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
@@ -11,7 +11,8 @@
         Transfer given amount of infantry or vehicle classes from one sector to another.
         Given the condition, that the amount of infantry or the specific classname is available at the origin sector.
         The origin sector also has to be inactive.
-        NOTE: Maybe this could be moved to the garrison module.
+
+        !NOTE! Maybe this could be moved to the garrison module.
 
     Parameter(s):
         _origin         - Sector from which the troops should be transfered                     [STRING, defaults to ""]
@@ -108,7 +109,7 @@ if !(_troops > (_garrison select 2)) then {
 
 // Handle requested vehicles
 if !(_vehicleClasses isEqualTo []) then {
-
+    // !TODO!
 };
 
 // Send created units to destination

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
@@ -1,0 +1,20 @@
+/*
+    KPLIB_fnc_enemy_transferGarrison
+
+    File: fn_enemy_transferGarrison.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-18
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        No description added yet.
+
+    Parameter(s):
+        _localVariable - Description [DATATYPE, defaults to DEFAULTVALUE]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+true

--- a/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
+++ b/Missionframework/modules/24_enemy/fnc/fn_enemy_transferGarrison.sqf
@@ -4,17 +4,112 @@
     File: fn_enemy_transferGarrison.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-18
-    Last Update: 2019-02-18
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
-        No description added yet.
+        Transfer given amount of infantry or vehicle classes from one sector to another.
+        Given the condition, that the amount of infantry or the specific classname is available at the origin sector.
+        The origin sector also has to be inactive.
+        NOTE: Maybe this could be moved to the garrison module.
 
     Parameter(s):
-        _localVariable - Description [DATATYPE, defaults to DEFAULTVALUE]
+        _origin         - Sector from which the troops should be transfered                     [STRING, defaults to ""]
+        _destination    - Sector to which the troops should be transfered                       [STRING, defaults to ""]
+        _infantry       - Amount of infantry which should be transfered                         [NUMBER, defaults to 0]
+        _vehicleClasses - Array of vehicle classnames which should be transfered                [ARRAY, defaults to []]
+        _onFoot         - True if soldiers should walk instead of being transported by a truck  [BOOL, defaults to false]
 
     Returns:
-        Function reached the end [BOOL]
+        Array of created groups [ARRAY]
 */
+
+params [
+    ["_origin", "", [""]],
+    ["_destination", "", [""]],
+    ["_troops", 0, [0]],
+    ["_vehicleClasses", [], [[]]],
+    ["_onFoot", false, [false]]
+];
+
+// Exit, if no origin or destination is given
+if (_origin == "" || _destination == "") exitWith {[]};
+
+// Exit, if origin sector is currently active
+if (_origin in KPLIB_garrison_active) exitWith {[]};
+
+if (KPLIB_param_debug) then {diag_log format ["[KP LIBERATION] [ENEMY] Transferring garrison from %1 (%2) to %3 (%4) with [%5, %6]", markerText _origin, _origin, markerText _destination, _destination, _troops, _vehicleClasses];};
+
+["KPLIB_transferConvoy_start", [_origin, _destination]] call CBA_fnc_localEvent;
+
+// Arrays for created units
+private _infantry = [];
+private _vehicles = [];
+
+// Handle requested infantry
+if !(_troops > (([_origin] call KPLIB_fnc_garrison_getGarrison) select 2)) then {
+    // Define one infantry squad for transport
+    private _squadComp = [
+        KPLIB_preset_rsSquadLeaderE,
+        KPLIB_preset_rsRiflemanE,
+        KPLIB_preset_rsRiflemanE,
+        KPLIB_preset_rsRiflemanE,
+        KPLIB_preset_rsRiflemanE,
+        KPLIB_preset_rsRiflemanE,
+        KPLIB_preset_rsRiflemanE,
+        KPLIB_preset_rsRiflemanE
+    ];
+
+    // Remove infantry from origin garrison
+    [_origin, -_troops] call KPLIB_fnc_garrison_addInfantry;
+
+    // Other local variables for infantry transport handling
+    private _nearRoad = objNull;
+    private _transport = objNull;
+    private _grp = grpNull;
+
+    while {_troops > 0} do {
+        // Create infantry group
+        _nearRoad = selectRandom ((markerPos _origin) nearRoads 100);
+        _grp = [_squadComp select [0, 8 min _troops], getPosATL _nearRoad] call KPLIB_fnc_common_createGroup;
+        _infantry pushBack _grp;
+        _troops = _troops - (count (units _grp));
+
+        // Add vehicle, if needed
+        if (!_onFoot) then {
+            private _transportClasses = [count (units _grp)] call KPLIB_fnc_enemy_getTransportClasses;
+            _transport = [selectRandom _transportClasses, getPosATL _nearRoad, _nearRoad getDir ((roadsConnectedTo _nearRoad) select 0)] call KPLIB_fnc_common_createVehicle;
+            _grp addVehicle _transport;
+        };
+
+        // !DEBUG!
+        {
+            _x addCuratorEditableObjects [units _grp + [_transport]];
+        } forEach allCurators;
+    };
+} else {
+    if (KPLIB_param_debug) then {diag_log format ["[KP LIBERATION] [ENEMY] %1 exceeds garrison strength of %2 for transfer", _troops, _origin];};
+};
+
+// Send created units to destination
+{
+    // Get group
+    private _grp = _x;
+    if !(_x isEqualType grpNull) then {
+        _grp = group ((crew _x) select 0);
+    };
+
+    // Remove possible initialization waypoints
+    while {(count (waypoints _grp)) != 0} do {deleteWaypoint ((waypoints _grp) select 0);};
+
+    // Add waypoint for destination
+    private _waypoint = _grp addWaypoint [getPosATL (selectRandom ((markerPos _destination) nearRoads 50)), 1];
+    _waypoint setWaypointType "MOVE";
+    _waypoint setWaypointBehaviour "SAFE";
+    _waypoint setWaypointCombatMode "GREEN";
+    _waypoint setWaypointSpeed "LIMITED";
+    _waypoint setWaypointCompletionRadius 50;
+    _waypoint setWaypointStatements ["true", format ["['KPLIB_transferConvoy_end', [thislist, ""%1""]] call CBA_fnc_localEvent;", _destination]];
+} forEach (_infantry + _vehicles);
 
 true

--- a/Missionframework/modules/24_enemy/functions.hpp
+++ b/Missionframework/modules/24_enemy/functions.hpp
@@ -1,0 +1,47 @@
+/*
+    KP LIBERATION MODULE FUNCTIONS
+
+    File: functions.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Defines for all functions, which are brought by this module.
+*/
+
+class enemy {
+    file = "modules\24_enemy\fnc";
+
+    // Get valid transport vehicle for given amount of soldiers
+    class enemy_getTransportClasses {};
+
+    // Loads module specific data from the save
+    class enemy_loadData {};
+
+    // Module post initialization
+    class enemy_postInit {
+        postInit = 1;
+    };
+
+    // Module pre initialization
+    class enemy_preInit {
+        preInit = 1;
+    };
+
+    // Send given troops from nearest military base to sector
+    class enemy_reinforceGarrison {};
+
+    // Saves module specific data for the save
+    class enemy_saveData {};
+
+    // CBA Settings for this module
+    class enemy_settings {};
+
+    // Strength increase event function
+    class enemy_strengthInc {};
+
+    // Transfer given troops from one sector to another
+    class enemy_transferGarrison {};
+};

--- a/Missionframework/modules/24_enemy/functions.hpp
+++ b/Missionframework/modules/24_enemy/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-02
-    Last Update: 2019-02-18
+    Last Update: 2019-02-23
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -16,6 +16,9 @@ class enemy {
 
     // Get valid transport vehicle for given amount of soldiers
     class enemy_getTransportClasses {};
+
+    // Handles transfer convoy arrival
+    class enemy_handleConvoyEnd {};
 
     // Loads module specific data from the save
     class enemy_loadData {};
@@ -35,6 +38,15 @@ class enemy {
 
     // Saves module specific data for the save
     class enemy_saveData {};
+
+    // Handle sector activation
+    class enemy_sectorAct {};
+
+    // Handle sector capture
+    class enemy_sectorCapture {};
+
+    // Handle sector deactivation
+    class enemy_sectorDeact {};
 
     // CBA Settings for this module
     class enemy_settings {};

--- a/Missionframework/modules/24_enemy/functions.hpp
+++ b/Missionframework/modules/24_enemy/functions.hpp
@@ -14,6 +14,9 @@
 class enemy {
     file = "modules\24_enemy\fnc";
 
+    // Add/Remove awareness amount
+    class enemy_addAwareness {};
+
     // Add/Remove strength amount
     class enemy_addStrength {};
 

--- a/Missionframework/modules/24_enemy/functions.hpp
+++ b/Missionframework/modules/24_enemy/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-02
-    Last Update: 2019-02-23
+    Last Update: 2019-02-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -13,6 +13,9 @@
 
 class enemy {
     file = "modules\24_enemy\fnc";
+
+    // Add/Remove strength amount
+    class enemy_addStrength {};
 
     // Get valid transport vehicle for given amount of soldiers
     class enemy_getTransportClasses {};

--- a/Missionframework/modules/99_example/README.md
+++ b/Missionframework/modules/99_example/README.md
@@ -1,0 +1,14 @@
+# KP Liberation Module Description
+
+## Example Module
+This is an example module description.
+Used as template for new modules. Make sure to replace the `example` everywhere accordingly.
+
+### Dependencies
+* None
+
+### Functions
+
+
+### Scripts
+No scripts will be started by this module

--- a/Missionframework/modules/99_example/fnc/fn_example_loadData.sqf
+++ b/Missionframework/modules/99_example/fnc/fn_example_loadData.sqf
@@ -1,0 +1,33 @@
+/*
+    KPLIB_fnc_example_loadData
+
+    File: fn_example_loadData.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Loads data which is bound to this module from the given save data or initializes needed data for a new campaign.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Example module loading...";};
+
+private _moduleData = ["example"] call KPLIB_fnc_init_getSaveData;
+
+// Check if there is a new campaign
+if (_moduleData isEqualTo []) then {
+    if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Example module data empty, creating new data...";};
+    // Nothing to do here
+} else {
+    // Otherwise start applying the saved data
+    if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Example module data found, applying data...";};
+};
+
+true

--- a/Missionframework/modules/99_example/fnc/fn_example_postInit.sqf
+++ b/Missionframework/modules/99_example/fnc/fn_example_postInit.sqf
@@ -1,0 +1,40 @@
+/*
+    KPLIB_fnc_example_postInit
+
+    File: fn_example_postInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        The postInit function of a module takes care of starting/executing the modules functions or scripts.
+        Basically it starts/initializes the module functionality to make all provided features usable.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module postInit finished [BOOL]
+*/
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [POST] [EXAMPLE] Module initializing...", diag_tickTime];};
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [POST] [EXAMPLE] Module initialized", diag_tickTime];};
+
+true

--- a/Missionframework/modules/99_example/fnc/fn_example_preInit.sqf
+++ b/Missionframework/modules/99_example/fnc/fn_example_preInit.sqf
@@ -1,0 +1,55 @@
+/*
+    KPLIB_fnc_example_preInit
+
+    File: fn_example_preInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        The preInit function defines global variables, adds event handlers and set some vital settings which are used in this module.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module preInit finished [BOOL]
+*/
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [PRE] [EXAMPLE] Module initializing...", diag_tickTime];};
+
+/*
+    ----- Module Globals -----
+*/
+
+
+/*
+    ----- Module Initialization -----
+*/
+
+// Process CBA Settings
+[] call KPLIB_fnc_example_settings;
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+    // Register load event handler
+    ["KPLIB_doLoad", {[] call KPLIB_fnc_example_loadData;}] call CBA_fnc_addEventHandler;
+
+    // Register save event handler
+    ["KPLIB_doSave", {[] call KPLIB_fnc_example_saveData;}] call CBA_fnc_addEventHandler;
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {diag_log format ["[KP LIBERATION] [%1] [PRE] [EXAMPLE] Module initialized", diag_tickTime];};
+
+true

--- a/Missionframework/modules/99_example/fnc/fn_example_saveData.sqf
+++ b/Missionframework/modules/99_example/fnc/fn_example_saveData.sqf
@@ -1,0 +1,29 @@
+/*
+    KPLIB_fnc_example_saveData
+
+    File: fn_example_saveData.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Fetches data which is bound to this module and send it to the global save data array.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+if (KPLIB_param_debug) then {diag_log "[KP LIBERATION] [SAVE] Example module saving...";};
+
+// Set module data to save and send it to the global save data array
+["example",
+    [
+
+    ]
+] call KPLIB_fnc_init_setSaveData;
+
+true

--- a/Missionframework/modules/99_example/fnc/fn_example_settings.sqf
+++ b/Missionframework/modules/99_example/fnc/fn_example_settings.sqf
@@ -1,0 +1,37 @@
+/*
+    KPLIB_fnc_example_settings
+
+    File: fn_example_settings.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        CBA Settings initialization for this module
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+/*
+    ----- EXAMPLE SETTINGS -----
+*/
+
+// KPLIB_param_example
+// This is an example setting.
+// Default: true
+[
+    "KPLIB_param_example",
+    "CHECKBOX",
+    ["Example Setting Name", "Example Setting Tooltip"],
+    "Example Setting Category",
+    true,
+    1,
+    {}
+] call CBA_Settings_fnc_init;
+
+true

--- a/Missionframework/modules/99_example/functions.hpp
+++ b/Missionframework/modules/99_example/functions.hpp
@@ -1,0 +1,35 @@
+/*
+    KP LIBERATION MODULE FUNCTIONS
+
+    File: functions.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Defines for all functions, which are brought by this module.
+*/
+
+class example {
+    file = "modules\99_example\fnc";
+
+    // Loads module specific data from the save
+    class example_loadData {};
+
+    // Module post initialization
+    class example_postInit {
+        postInit = 1;
+    };
+
+    // Module pre initialization
+    class example_preInit {
+        preInit = 1;
+    };
+
+    // Saves module specific data for the save
+    class example_saveData {};
+
+    // CBA Settings for this module
+    class example_settings {};
+};

--- a/Missionframework/modules/99_example/ui.hpp
+++ b/Missionframework/modules/99_example/ui.hpp
@@ -3,7 +3,7 @@
 
     File: ui.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
-    Date: 2018-08-02
+    Date: 2019-02-18
     Last Update: 2019-02-18
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -11,4 +11,4 @@
         Initializes the ui defines, dialogs and elements which are brought by this module.
 */
 
-#include "ui\KPLIB_admin.hpp"
+#include "ui\KPLIB_example.hpp"

--- a/Missionframework/modules/99_example/ui/KPLIB_example.hpp
+++ b/Missionframework/modules/99_example/ui/KPLIB_example.hpp
@@ -1,14 +1,17 @@
 /*
-    KP LIBERATION MODULE UI FILE
+    KP Liberation example dialog
 
-    File: ui.hpp
+    File: KPLIB_example.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
-    Date: 2018-08-02
+    Date: 2019-02-18
     Last Update: 2019-02-18
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
-        Initializes the ui defines, dialogs and elements which are brought by this module.
+        Just a placeholder file for the example module.
 */
 
-#include "ui\KPLIB_admin.hpp"
+
+class KPLIB_example {
+    idd = 758099;
+};


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | #529 |

### Description:
As stated in the issue itself, this provides the first part of the enemy module to provide a basic foundation for the future iterations. The currently implemented functions to transfer garrisons can be tested via the debug console.
Example for transfering units from the Feres Outpost military base to Feres:

```
["KPLIB_eden_base", "KPLIB_eden_city_1", 20, ["O_MRAP_02_gmg_F","O_LSV_02_AT_F"]] call KPLIB_fnc_enemy_reinforceGarrison;
```

There is still some rare occurances of "vehicle spawn explosion", even if there is always a "is something already there" check. My assumption is, that it's caused by the fact that we keep calling the spawning, so it maybe can't recognize it sometimes, that there is a vehicle spawned directly before the current one. Would be interesting to test this in the next sprint and maybe find a way to have it running in a capsuled scheduled environment. Reason for this assumption is, that the spawning in general is handled like in the old framework. The only real difference is the (un-)scheduled environment where the spawning happen.

Furthermore this PR contains smaller tweaks outside of the module and a example module structure as template for creating new modules.

### Content:
- [x] Values for the enemy capabilities concerning strength and awareness
- [x] Functions to alter these values
- [x] Placeholder event handler functions for sector activation/capturing/deactivaten
- [x] Transfer garrison units from one sector to another
- [x] Create new enemy units at military bases and use them as reinforcements
- [x] Small tweaks in several places
- [x] One example module structure

### Successfully tested on:
- [x] Local MP Vanilla
- [x] Dedicated MP Vanilla

### Compatibility checked with:
* None