### PR TITLE
fixed cf recognizing "Ground" as inventory

### DIFF
--- a/Missionframework/modules/26_cratefiller/fnc/fn_cratefiller_getNearStorages.sqf
+++ b/Missionframework/modules/26_cratefiller/fnc/fn_cratefiller_getNearStorages.sqf
@@ -5,7 +5,7 @@
     File: fn_cratefiller_getNearStorages.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-04-06
-    Last Update: 2019-05-05
+    Last Update: 2019-05-11
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -43,10 +43,9 @@ private _blacklist = [
     KPLIB_logistic_building,
     "GroundWeaponHolder",
     "WeaponHolderSimulated",
-    "#slop",
-    "#track",
     ""
 ];
+private _objects = (getMarkerPos _nearFOB) nearObjects KPLIB_param_fobRange;
 
 // Get near objects and check for storage capacity
 {
@@ -64,6 +63,7 @@ private _blacklist = [
             _ctrlStorage lbSetPicture [_index, _picture];
         };
     };
-} forEach (((getMarkerPos _nearFOB) nearObjects KPLIB_param_fobRange) select {!(typeOf _x in _blacklist)});
+} forEach (_objects select {!(typeOf _x in _blacklist) && !((typeOf _x select [0,1]) isEqualTo "#") && !(_x isKindOf "Building")});
+
 
 true

--- a/Missionframework/modules/26_cratefiller/fnc/fn_cratefiller_getNearStorages.sqf
+++ b/Missionframework/modules/26_cratefiller/fnc/fn_cratefiller_getNearStorages.sqf
@@ -5,7 +5,7 @@
     File: fn_cratefiller_getNearStorages.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-04-06
-    Last Update: 2019-05-04
+    Last Update: 2019-05-05
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -30,10 +30,9 @@ lbClear _ctrlStorage;
 private _nearFOB = [] call KPLIB_fnc_common_getPlayerFob;
 private _type = objNull;
 private _config = "";
-private _number= 0;
+private _number = 0;
 private _index = 0;
 private _picture = "";
-private _storages = [];
 private _blacklist = [
     KPLIB_preset_crateSupplyE,
     KPLIB_preset_crateSupplyF,
@@ -41,33 +40,30 @@ private _blacklist = [
     KPLIB_preset_crateAmmoF,
     KPLIB_preset_crateFuelE,
     KPLIB_preset_crateFuelF,
-    KPLIB_logistic_building
+    KPLIB_logistic_building,
+    "GroundWeaponHolder",
+    "WeaponHolderSimulated",
+    "#slop",
+    "#track",
+    ""
 ];
 
 // Get near objects and check for storage capacity
 {
     _type = typeOf _x;
-    if (_type != "GroundWeaponHolder") then {
-        _config = [_type] call KPLIB_fnc_cratefiller_getConfigPath;
-        _number = getNumber (_config >> "maximumLoad");
-        if (_number > 0) then {
-            _storages pushBack _x;
+    _config = [_type] call KPLIB_fnc_cratefiller_getConfigPath;
+    _number = getNumber (_config >> "maximumLoad");
+    // If the object has an inventory add it to the list
+    if (_number > 0) then {
+        _index = _ctrlStorage lbAdd format ["%1m - %2", round ((getMarkerPos _nearFOB) distance2D _x), getText (_config >> "displayName")];
+        _ctrlStorage lbSetData [_index, netId _x];
+        _picture = getText (_config >> "picture");
+        if (_picture isEqualTo "pictureThing") then {
+            _ctrlStorage lbSetPicture [_index, "KPGUI\res\icon_help.paa"];
+        } else {
+            _ctrlStorage lbSetPicture [_index, _picture];
         };
     };
 } forEach (((getMarkerPos _nearFOB) nearObjects KPLIB_param_fobRange) select {!(typeOf _x in _blacklist)});
-
-// Fill the list
-{
-    _type = typeOf _x;
-    _config = [_type] call KPLIB_fnc_cratefiller_getConfigPath;
-    _index = _ctrlStorage lbAdd format ["%1m - %2", round ((getMarkerPos _nearFOB) distance2D _x), getText (_config >> "displayName")];
-    _ctrlStorage lbSetData [_index, netId _x];
-    _picture = getText (_config >> "picture");
-    if (_picture isEqualTo "pictureThing") then {
-        _ctrlStorage lbSetPicture [_index, "KPGUI\res\icon_help.paa"];
-    } else {
-        _ctrlStorage lbSetPicture [_index, _picture];
-    };
-} forEach _storages;
 
 true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |
| Fixed issues | #603-2|

### Description:

This PR fixes `The cratefiller shows groundWeaponHolder as valid storage spaces`.

### Content:
- [x] Bug fix for 603-2

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP

### Compatibility checked with:
* ACE