### PR TITLE
fixed "Different objects than vehicles aren't recycleable"

### DIFF
--- a/Missionframework/modules/23_logistic/fnc/fn_logistic_refreshTargets.sqf
+++ b/Missionframework/modules/23_logistic/fnc/fn_logistic_refreshTargets.sqf
@@ -5,7 +5,7 @@
     File: fn_logistic_refreshTargets.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-01-25
-    Last Update: 2019-05-13
+    Last Update: 2019-05-14
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -84,8 +84,7 @@ if (_dialogId isEqualTo KPLIB_IDC_LOGISTIC_RECYCLE_DIALOG) then {
 // Fill the controls
 {
     _type = typeOf _x;
-    _name = getText (_cfgVeh >> _type >> "displayName");
-    _index = _ctrlVehicleList lbAdd format ["%1", _name];
+    _index = _ctrlVehicleList lbAdd (getText (_cfgVeh >> _type >> "displayName"));
     _ctrlVehicleList lbSetData [_index, netId _x];
     _picture = getText (_cfgVeh >> _type >> "picture");
     if (_picture isEqualTo "pictureThing") then {

--- a/Missionframework/modules/23_logistic/fnc/fn_logistic_refreshTargets.sqf
+++ b/Missionframework/modules/23_logistic/fnc/fn_logistic_refreshTargets.sqf
@@ -1,10 +1,11 @@
+#include "..\ui\defines.hpp"
 /*
     KPLIB_fnc_logistic_refreshTargets
 
     File: fn_logistic_refreshTargets.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-01-25
-    Last Update: 2019-04-11
+    Last Update: 2019-05-13
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -30,33 +31,69 @@ private _ctrlVehicleList = _dialog displayCtrl _ctrlId;
 
 lbClear _ctrlVehicleList;
 
-// Get all FOB vehicles
-private _nearFOB = [] call KPLIB_fnc_common_getPlayerFob;
-private _vehicles = (getMarkerPos _nearFOB) nearEntities [["LandVehicle", "Air", "Ship"], KPLIB_param_fobRange];
-
 // Variables
-private _cfg = configFile >> "CfgVehicles";
+private _nearFOB = [] call KPLIB_fnc_common_getPlayerFob;
+private _cfgVeh = configFile >> "CfgVehicles";
 private _type = "";
 private _name = "";
 private _index = 0;
+private _objects = [];
+private _blacklist = [
+    KPLIB_preset_crateSupplyE,
+    KPLIB_preset_crateSupplyF,
+    KPLIB_preset_crateAmmoE,
+    KPLIB_preset_crateAmmoF,
+    KPLIB_preset_crateFuelE,
+    KPLIB_preset_crateFuelF,
+    KPLIB_logistic_building,
+    "GroundWeaponHolder",
+    "WeaponHolderSimulated",
+    "Camera",
+    ""
+];
 
 // Add a blank entry
 _index = _ctrlVehicleList lbAdd "----------";
 _ctrlVehicleList lbSetData [_index, "placeholder"];
 
-// Fill the list
+// Detect the dialog type and select all objects dependent on the settings
+if (_dialogId isEqualTo KPLIB_IDC_LOGISTIC_RECYCLE_DIALOG) then {
+    // If recycle dialog is open
+    _objects = ((getMarkerPos _nearFOB) nearObjects KPLIB_param_fobRange) select {
+        !(typeOf _x in _blacklist) &&
+        !((typeOf _x select [0,1]) isEqualTo "#") &&
+        !(_x isKindOf "Building") &&
+        !(_x isKindOf "Man")
+    };
+} else {
+    // If resupply dialog is open
+    if (KPLIB_param_aceResupply) then {
+        {
+            _type = typeOf _x;
+            _ammoMax = getNumber (_cfgVeh >> _type >> "ace_rearm_defaultSupply");
+            _fuelMax = getNumber (_cfgVeh >> _type >> "ace_refuel_fuelCargo");
+            if (_ammoMax != 0 || _fuelMax != 0) then {
+                _objects pushBack _x;
+            };
+        } forEach ((getMarkerPos _nearFOB) nearEntities [["LandVehicle", "Air", "Ship"], KPLIB_param_fobRange]);
+    } else {
+        _objects = (getMarkerPos _nearFOB) nearEntities [["LandVehicle", "Air", "Ship"], KPLIB_param_fobRange];
+    };
+};
+
+// Fill the controls
 {
     _type = typeOf _x;
-    _name = getText (_cfg >> _type >> "displayName");
+    _name = getText (_cfgVeh >> _type >> "displayName");
     _index = _ctrlVehicleList lbAdd format ["%1", _name];
     _ctrlVehicleList lbSetData [_index, netId _x];
-    _picture = getText (_cfg >> _type >> "picture");
+    _picture = getText (_cfgVeh >> _type >> "picture");
     if (_picture isEqualTo "pictureThing") then {
         _ctrlVehicleList lbSetPicture [_index, "KPGUI\res\kp512_CA.paa"];
     } else {
         _ctrlVehicleList lbSetPicture [_index, _picture];
     };
-} forEach _vehicles;
+} forEach _objects;
 
 _ctrlVehicleList lbSetCurSel 0;
 

--- a/Missionframework/modules/26_cratefiller/fnc/fn_cratefiller_getNearStorages.sqf
+++ b/Missionframework/modules/26_cratefiller/fnc/fn_cratefiller_getNearStorages.sqf
@@ -5,7 +5,7 @@
     File: fn_cratefiller_getNearStorages.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-04-06
-    Last Update: 2019-05-11
+    Last Update: 2019-05-14
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -54,7 +54,7 @@ private _objects = (getMarkerPos _nearFOB) nearObjects KPLIB_param_fobRange;
     _number = getNumber (_config >> "maximumLoad");
     // If the object has an inventory add it to the list
     if (_number > 0) then {
-        _index = _ctrlStorage lbAdd format ["%1m - %2", round ((getMarkerPos _nearFOB) distance2D _x), getText (_config >> "displayName")];
+        _index = _ctrlStorage lbAdd format ["%1m - %2", round ((getPos player) distance2D _x), getText (_config >> "displayName")];
         _ctrlStorage lbSetData [_index, netId _x];
         _picture = getText (_config >> "picture");
         if (_picture isEqualTo "pictureThing") then {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |
| Fixed issues | #603-5 |

### Description:
This PR fixes `Different objects than vehicles aren't recycleable` .
Also the resupply menu now filters the vehicles when ACE resupply is enabled, so that only ACE fuel/rearm vehicles will be displayed.

### Content:
- [x] Bug fix for 603-5
- [x] Additional resupply filter for ace fuel/rearm vehicles

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP

### Compatibility checked with:
* ACE