### PR TITLE
Fix typos and add missing russian translations

### DIFF
--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -70,7 +70,7 @@
             <French>-- CONSTRUIRE --</French>
             <German>-- BAUEN --</German>
             <Spanish>-- CONSTRUIR --</Spanish>
-            <Russian>-- ОБЕСПЕЧЕНИЕ --</Russian>
+            <Russian>-- ПОСТРОИТЬ --</Russian>
             <Italian>-- COSTRUISCI --</Italian>
             <Chinesesimp>-- 建造 --</Chinesesimp>
             <Chinese>-- 建造 --</Chinese>
@@ -106,7 +106,7 @@
             <French>Effectifs</French>
             <German>Nachschub</German>
             <Spanish>Efectivos</Spanish>
-            <Russian>Персонал</Russian>
+            <Russian>Припасы</Russian>
             <Italian>Personale</Italian>
             <Chinesesimp>补给</Chinesesimp>
             <Chinese>補給</Chinese>
@@ -214,7 +214,7 @@
             <French>Construction annulée.</French>
             <German>Bauen abgebrochen.</German>
             <Spanish>Construcción cancelada</Spanish>
-            <Russian>Постройка отменена</Russian>
+            <Russian>Постройка отменена.</Russian>
             <Italian>Costruzione cancellata.</Italian>
             <Chinesesimp>建造取消。</Chinesesimp>
             <Chinese>建造取消。</Chinese>
@@ -226,7 +226,7 @@
             <French>Construction confirmée.</French>
             <German>Bauen bestätigt.</German>
             <Spanish>Construcción confirmada.</Spanish>
-            <Russian>Постройка подтверждена</Russian>
+            <Russian>Постройка подтверждена.</Russian>
             <Italian>Costruzione confermata.</Italian>
             <Chinesesimp>建造完成。</Chinesesimp>
             <Chinese>建造成功。</Chinese>
@@ -238,7 +238,7 @@
             <French>Impossible de placer ici : il y a %1 objet(s) dans les %2 mètres de la position voulue.</French>
             <German>Kann hier nicht platziert werden: %1 Objekt(e) innerhalb von %2 Meter der Position</German>
             <Spanish>Imposible de colocar aqui: hay 1% objeto(s) a %2 metros de la posición del objeto</Spanish>
-            <Russian>Нельзя разместить здесь:  в %2 метрах есть 1% объект(а).</Russian>
+            <Russian>Нельзя разместить здесь: в %2 метрах есть 1% объект(а).</Russian>
             <Italian>impossibile piazzare qui: ci sono %1 oggetti vicini %2 metri dalla posizione dell'oggetto in costruzione</Italian>
             <Chinesesimp>无法安置在这里：当前位置%2米内有%1个物体阻挡。</Chinesesimp>
             <Chinese>無法在此建造：目前 %2 公尺內有 %1 個物件存在。</Chinese>
@@ -274,7 +274,7 @@
             <French>-- CHARGER MUNITIONS</French>
             <German>-- KISTE AUFLADEN</German>
             <Spanish>-- CARGAR CAJA DE MUNICIÓN</Spanish>
-            <Russian>-- ЗАГРУЗИТЬ ЯЩИК С БОЕПРИПАСАМИ</Russian>
+            <Russian>-- ЗАГРУЗИТЬ В ТРАНСПОРТ</Russian>
             <Italian>-- CARICA CASSA</Italian>
             <Chinesesimp>-- 装载货箱</Chinesesimp>
             <Chinese>-- 裝載貨物</Chinese>
@@ -296,21 +296,24 @@
         <Key ID="STR_ACTION_LOAD_VIV">
             <Original>-- LOAD TO VEHICLE</Original>
             <German>-- AUF FAHRZEUG LADEN</German>
+            <Russian>-- ЗАГРУЗИТЬ В ТРАНСПОРТ</Russian>
         </Key>
         <Key ID="STR_ACTION_UNLOAD_VIV">
             <Original>-- UNLOAD FROM VEHICLE</Original>
             <German>-- VON FAHRZEUG ABLADEN</German>
+            <Russian>-- ВЫГРУЗИТЬ ИЗ ТРАНСПОРТА</Russian>
         </Key>
         <Key ID="STR_ACTION_NOTRANSPORT_VIV">
             <Original>-- NO TRANSPORT VEHICLES NEARBY</Original>
             <German>-- KEIN TRANSPORTFAHRZEUG IN DER NÄHE</German>
+            <Russian>-- НЕТ ТРАНСПОРТА ПОБЛИЗОСТИ</Russian>
         </Key>
         <Key ID="STR_BOX_LOADED">
             <Original>Ammo box successfully loaded on the transport vehicle.</Original>
             <French>La caisse de munitions a été chargée sur le véhicule de transport.</French>
             <German>Munitionskiste erfolgreich auf das Transportfahrzeug geladen.</German>
             <Spanish>Caja de munición cargada correctamente en el vehículo de transporte</Spanish>
-            <Russian>Ящик с боеприпасами загружен в транспортное средство</Russian>
+            <Russian>Ящик с боеприпасами загружен в транспортное средство.</Russian>
             <Italian>Cassa munizioni correttamente caricata sul camion da trasporto</Italian>
             <Chinesesimp>货箱已装载到运输载具中。</Chinesesimp>
             <Chinese>貨物已上至運輸載具中。</Chinese>
@@ -322,7 +325,7 @@
             <French>La caisse de munitions a été déchargée du véhicule de transport.</French>
             <German>Munitionskiste erfolgreich vom Transportfahrzeug abgeladen.</German>
             <Spanish>Caja de munición descargada correctamente del vehículo de transporte</Spanish>
-            <Russian>Ящик с боеприпасами выгружен из транспортного средства</Russian>
+            <Russian>Ящик с боеприпасами выгружен из транспортного средства.</Russian>
             <Italian>Cassa munizioni correttamente scaricata dal camion da trasporto</Italian>
             <Chinesesimp>货箱已从运输载具中卸载。</Chinesesimp>
             <Chinese>貨物已從運輸載具中卸下。</Chinese>
@@ -370,7 +373,7 @@
             <French>Impossible de déployer une nouvelle FOB ici, vous devez être à au moins %1 mètres de toutes les zones capturables. La zone la plus proche est à %2 mètres d'ici.</French>
             <German>Kann hier keine FOB platzieren, du musst min. %1 Meter von allen Sektoren entfernt sein. Der nächste Sektor ist %2 Meter entfernt.</German>
             <Spanish>Imposible desplegar una nueva FOB aquí, debes estar al menos a %1 metros de cualquier zona capturable. La zona más cercana está a %2 metros</Spanish>
-            <Russian>Нельзя развернуть FOB здесь, вы должны находится в %1 метрах от захваченной зоны. Ближайшиая зона в %2 метрах.</Russian>
+            <Russian>Нельзя развернуть FOB здесь, вы должны находится в %1 метрах от захваченной зоны. Ближайшая зона в %2 метрах.</Russian>
             <Italian>Impossibile creare la nuova FOB qui, devi essere almeno %1 metri distante dalla Zona catturabile più vicina. La Zona Catturabile più vicina si trova a %2 metri.</Italian>
             <Chinesesimp>无法在此部署前哨，前哨与战区之间的距离不得低于%1米。最近的战区在%2米开外。</Chinesesimp>
             <Chinese>無法在此佈署前線基地，前線基地與戰區之間的距離不得低於 %1 公尺，最近的戰區離此 %2 公尺。</Chinese>
@@ -717,7 +720,7 @@
             <French>Le recyclage de %1 rapportera :</French>
             <German>Die Wiederverwertung von %1 erbringt:</German>
             <Spanish>Reciclando este %1 obtienes:</Spanish>
-            <Russian>Утилизируя %1 получим</Russian>
+            <Russian>Утилизируя %1 вы получите</Russian>
             <Italian>Riciclando questo %1 otterrai:</Italian>
             <Chinesesimp>回收%1将会获得：</Chinesesimp>
             <Chinese>回收%1將會獲得：</Chinese>
@@ -753,7 +756,7 @@
             <French>SECTEUR CAPTURE</French>
             <German>SEKTOR EINGENOMMEN</German>
             <Spanish>SECTOR CAPTURADO</Spanish>
-            <Russian>ЗОНА ЗАХВАЧЕНА</Russian>
+            <Russian>СЕКТОР ЗАХВАЧЕН</Russian>
             <Italian>SETTORE CATTURATO</Italian>
             <Chinesesimp>战区已占领</Chinesesimp>
             <Chinese>戰區已占領</Chinese>
@@ -777,7 +780,7 @@
             <French>SECTEUR ATTAQUE</French>
             <German>SEKTOR ANGEGRIFFEN</German>
             <Spanish>SECTOR ATACADO</Spanish>
-            <Russian>ЗОНА АТАКОВАНА</Russian>
+            <Russian>СЕКТОР АТАКОВАН</Russian>
             <Italian>SETTORE SOTTO ATTACCO</Italian>
             <Chinesesimp>战区遭到攻击</Chinesesimp>
             <Chinese>戰區遭到襲擊</Chinese>
@@ -801,7 +804,7 @@
             <French>SECTEUR LOST</French>
             <German>SEKTOR VERLOREN</German>
             <Spanish>SECTOR PERDIDO</Spanish>
-            <Russian>ЗОНА ПОТЕРЯНА</Russian>
+            <Russian>СЕКТОР ПОТЕРЯН</Russian>
             <Italian>SETTORE PERSO</Italian>
             <Chinesesimp>战区已丢失</Chinesesimp>
             <Chinese>已失去戰區</Chinese>
@@ -825,7 +828,7 @@
             <French>SECTEUR SECURISE</French>
             <German>SEKTOR SICHER</German>
             <Spanish>SECTOR SEGURO</Spanish>
-            <Russian>ЗОНА В БЕЗОПАСНОСТИ</Russian>
+            <Russian>СЕКТОР В БЕЗОПАСНОСТИ</Russian>
             <Italian>SETTORE AL SICURO</Italian>
             <Chinesesimp>战区已安全</Chinesesimp>
             <Chinese>戰區已安全</Chinese>
@@ -1074,6 +1077,7 @@
             <Original>== GAMEPLAY OPTIONS ==</Original>
             <German>== SPIELEINSTELLUNGEN ==</German>
             <Spanish>== OPCIONES DE JUEGO</Spanish>
+            <Russian>== ИГРОВЫЕ ОПЦИИ ==</Russian>
             <Italian>==OPZIONI DI GIOCO ==</Italian>
             <Chinesesimp>== 游戏选项 ==</Chinesesimp>
             <Chinese>== 遊戲選項 ==</Chinese>
@@ -1657,7 +1661,7 @@
             <French>GESTION D'ESCOUADE</French>
             <German>GRUPPENVERWALTUNG</German>
             <Spanish>GESTIÓN DE ESCUADRA</Spanish>
-            <Russian>УПРАВЛЕНИЕ СОСТАВОМ ГРУПП</Russian>
+            <Russian>УПРАВЛЕНИЕ ОТРЯДОМ</Russian>
             <Italian>GESTIONE SQUADRA</Italian>
             <Chinesesimp>班组管理</Chinesesimp>
             <Chinese>班級管理</Chinese>
@@ -1669,7 +1673,7 @@
             <French>-- GESTION D'ESCOUADE</French>
             <German>-- GRUPPENVERWALTUNG</German>
             <Spanish>-- GESTIÓN DE ESCUADRA</Spanish>
-            <Russian>-- УПРАВЛЕНИЕ СОСТАВОМ ГРУПП</Russian>
+            <Russian>-- УПРАВЛЕНИЕ ОТРЯДОМ</Russian>
             <Italian>-- GESTIONE SQUADRA</Italian>
             <Chinesesimp>-- 班组管理</Chinesesimp>
             <Chinese>-- 班級管理</Chinese>
@@ -1789,7 +1793,7 @@
             <French>Principale</French>
             <German>Primär</German>
             <Spanish>Principal</Spanish>
-            <Russian>Главный</Russian>
+            <Russian>Основное</Russian>
             <Italian>Primaria</Italian>
             <Chinesesimp>主要</Chinesesimp>
             <Chinese>主要</Chinese>
@@ -1801,7 +1805,7 @@
             <French>Secondaire</French>
             <German>Sekundär</German>
             <Spanish>Secundaria</Spanish>
-            <Russian>Подчинённый</Russian>
+            <Russian>Дополнительное</Russian>
             <Italian>Secondaria</Italian>
             <Chinesesimp>次要</Chinesesimp>
             <Chinese>次要</Chinese>
@@ -1813,7 +1817,7 @@
             <French>Aucune</French>
             <German>Keine</German>
             <Spanish>Ninguno</Spanish>
-            <Russian>Никто</Russian>
+            <Russian>Нету</Russian>
             <Italian>Nessuno</Italian>
             <Chinesesimp>无</Chinesesimp>
             <Chinese>無</Chinese>
@@ -2245,7 +2249,7 @@
             <French>Par défaut</French>
             <German>Standard</German>
             <Spanish>Por defecto</Spanish>
-            <Russian>Стандартно</Russian>
+            <Russian>По умолчанию</Russian>
             <Italian>Default</Italian>
             <Chinesesimp>默认</Chinesesimp>
             <Chinese>預設</Chinese>
@@ -2281,7 +2285,7 @@
             <French>Etes-vous sur de vouloir replier cette fob?</French>
             <German>Bist du dir sicher, dass du deine FOB einpacken willst?</German>
             <Spanish>¿Estas seguro de querer reempaquetar esta FOB?</Spanish>
-            <Russian>Ты уверен что хочешь свернуть эту FOB?</Russian>
+            <Russian>Вы уверены что вы хотите свернуть эту FOB?</Russian>
             <Italian>Sei sicuro di voler smontare la FOB?</Italian>
             <Chinesesimp>你确定要收起这个前哨？</Chinesesimp>
             <Chinese>你確定要收起這個前線基地？</Chinese>
@@ -2411,6 +2415,7 @@
         <Key ID="STR_PARAM_CLEAR_CARGO">
             <Original>Clear spawned vehicle cargo</Original>
             <German>Inventar gespawnter Fahrzeuge leeren</German>
+            <Russian>Очистить созданный инвентарь транспорта</Russian>
             <Italian>Cancella il carico del veicolo creato</Italian>
             <Portuguese>Remover carga do veículo requisitado</Portuguese>
             <Chinese>移除載具上的物品</Chinese>
@@ -2552,7 +2557,7 @@
             <French>Votre equipement actuel sera restauré à chaque respawn.</French>
             <German>Deine Ausrüstung wird bei jedem Respwan wiederhergestellt.</German>
             <Spanish>Tu actual equipamiento seá mantenido en cada respawn.</Spanish>
-            <Russian>Ваше текущее снаряжение будет загружаться после каждого возраждения</Russian>
+            <Russian>Ваше текущее снаряжение будет загружаться после каждого возрождения</Russian>
             <Italian>Il tuo equipaggiamneto sarà ricaricato ad ogni respawn</Italian>
             <Chinesesimp>你的装备将在重生时恢复到现有状态。</Chinesesimp>
             <Chinese>重生後，你的裝備將恢復到現有狀態。</Chinese>
@@ -2576,7 +2581,7 @@
             <French>Transfer d'équipement réussi depuis %1.</French>
             <German>Erfolgreich Ausrüstung von %1 übertragen.</German>
             <Spanish>Transferencia de equipamiento de %1 terminada.</Spanish>
-            <Russian>Успешная загрузка снаряжения игрока %1</Russian>
+            <Russian>Успешная загрузка снаряжения игрока %1.</Russian>
             <Italian>Equipaggiamento traferito correttamente da %1</Italian>
             <Chinesesimp>成功从%1读取了装备</Chinesesimp>
             <Chinese>成功複製了 %1 的裝備</Chinese>
@@ -2600,7 +2605,7 @@
             <French>Lieu de déploiement :</French>
             <German>Einsatzposition:</German>
             <Spanish>Lugar para el despliegue:</Spanish>
-            <Russian>Позиция размешения:</Russian>
+            <Russian>Позиция размещения:</Russian>
             <Italian>Luogo di Schieramento:</Italian>
             <Chinesesimp>部署地点：</Chinesesimp>
             <Chinese>佈署地點：</Chinese>
@@ -2756,7 +2761,7 @@
             <French>Réarmement dans %1s</French>
             <German>Aufmunitioniert in %1s</German>
             <Spanish>Rearmando en %1s</Spanish>
-            <Russian>Перезарядка за %1с</Russian>
+            <Russian>Перезарядка через %1с</Russian>
             <Italian>Riarmando 1%</Italian>
             <Chinesesimp>%1后开始补充弹药</Chinesesimp>
             <Chinese>%1 秒後開始補充彈藥</Chinese>
@@ -2852,7 +2857,7 @@
             <French>Mission secondaire déjà en cours</French>
             <German>Sekundäre Mission läuft bereits</German>
             <Spanish>Misión secundaria ya en curso</Spanish>
-            <Russian>Дополнительная задача уже есть</Russian>
+            <Russian>Дополнительная задача уже запущена</Russian>
             <Italian>Missione secondaria attualmente in progresso</Italian>
             <Chinesesimp>次要任务正在进行中</Chinesesimp>
             <Chinese>次要目標正在進行中</Chinese>
@@ -2864,7 +2869,7 @@
             <French>Les forces hostiles se dirigent vers %1.</French>
             <German>Feindliche Streitkräfte bewegen sich auf %1 zu.</German>
             <Spanish>Fuerzas hostiles acercándose a %1.</Spanish>
-            <Russian>Замечена вражеская группа рядом с %1</Russian>
+            <Russian>Замечена вражеская группа рядом с %1.</Russian>
             <Italian>Forze ostili sono in avvicinamento su %1.</Italian>
             <Chinesesimp>敌军部队正在前往%1</Chinesesimp>
             <Chinese>敵軍正在前往 %1</Chinese>
@@ -3305,7 +3310,7 @@
             <French>Défenseurs BLUFOR dans les secteurs capturés</French>
             <German>BLUFOR Verteidiger in besetzten Sektoren</German>
             <Spanish>Defensores BLUFOR en los sectores controlados</Spanish>
-            <Russian>BLUFOR защитники в захваченных зонах</Russian>
+            <Russian>BLUFOR защитники в захваченных секторах</Russian>
             <Italian>Trupppe BLUFOR nei settori controllati</Italian>
             <Chinesesimp>我军部队防御己方战区</Chinesesimp>
             <Chinese>我軍部隊協防我方戰區</Chinese>
@@ -3613,7 +3618,7 @@
             <Original>Killah Potatoes flag</Original>
             <German>Killah Potatoes Flagge</German>
             <Spanish>Bandera de Killah Potatoes</Spanish>
-            <Russian>КР флаг</Russian>
+            <Russian>Флаг Killah Potatoes</Russian>
             <Italian>Bandiera dei Killah Potatoes</Italian>
             <Chinesesimp>Killah Potatoes旗</Chinesesimp>
             <Chinese>Killah Potatoes旗</Chinese>
@@ -3645,7 +3650,7 @@
         <Key ID="STR_RECYCLE_BUILDING">
             <Original>Salvage Depot</Original>
             <German>Demontageeinrichtung</German>
-            <Russian>Собрать склад</Russian>
+            <Russian>Утилизационный склад</Russian>
             <Italian>Edificio smaltimento rifiuti</Italian>
             <Chinesesimp>回收站</Chinesesimp>
             <Chinese>回收站</Chinese>
@@ -3667,7 +3672,7 @@
             <Original>Helipad</Original>
             <German>Helikopterlandeplatz</German>
             <Spanish>Helipuerto</Spanish>
-            <Russian>Верт.площадка</Russian>
+            <Russian>Верт. площадка</Russian>
             <Italian>Eliporto</Italian>
             <Chinesesimp>停机坪</Chinesesimp>
             <Chinese>停機坪</Chinese>
@@ -3700,7 +3705,7 @@
             <Original>-- STORE CRATE</Original>
             <German>-- KISTE EINLAGERN</German>
             <Spanish>-- CAJA DE ALMACENAJE</Spanish>
-            <Russian>-- ХРАНЕНИЕ МАГАЗИНА</Russian>
+            <Russian>-- ЗАГРУЗИТЬ НА СКЛАД</Russian>
             <Italian>-- DEPOSITA CASSA</Italian>
             <Chinesesimp>-- 仓储货箱</Chinesesimp>
             <Chinese>-- 倉儲貨物</Chinese>
@@ -3711,7 +3716,7 @@
             <Original>-- UNLOAD SUPPLY CRATE</Original>
             <German>-- NACHSCHUB ABLADEN</German>
             <Spanish>-- DESCARGA CAJA DE SUMINISTRO</Spanish>
-            <Russian>-- ЗАГРУЗИТЬ СРОК ПОСТАВКИ</Russian>
+            <Russian>-- ВЫГРУЗИТЬ ЯЩИК ПРИПАСОВ</Russian>
             <Italian>-- SCARICA CASSA RIFORNIMENTI</Italian>
             <Chinesesimp>-- 卸载补给箱</Chinesesimp>
             <Chinese>-- 卸載補給箱</Chinese>
@@ -3722,7 +3727,7 @@
             <Original>-- UNLOAD AMMO CRATE</Original>
             <German>-- MUNITION ABLADEN</German>
             <Spanish>-- DESCARGA CAJA DE MUNICIÓN</Spanish>
-            <Russian>-- РАЗГРУЗКА БОЕПРИПАСОВ</Russian>
+            <Russian>-- ВЫГРУЗИТЬ ЯЩИК БОЕПРИПАСОВ</Russian>
             <Italian>-- SCARICA CASSA MUNIZIONI</Italian>
             <Chinesesimp>-- 卸载弹药箱</Chinesesimp>
             <Chinese>-- 卸載彈藥箱</Chinese>
@@ -3733,7 +3738,7 @@
             <Original>-- UNLOAD FUEL CRATE</Original>
             <German>-- KRAFTSTOFF ABLADEN</German>
             <Spanish>-- DESCARGA CAJA DE COMBUSTIBLE</Spanish>
-            <Russian>-- РАЗГРУЗКА ТОПЛИВА</Russian>
+            <Russian>-- ВЫГРУЗИТЬ ЯЩИК ТОПЛИВА</Russian>
             <Italian>-- SCARICA CASSA CARBURANTE</Italian>
             <Chinesesimp>-- 卸载燃料箱</Chinesesimp>
             <Chinese>-- 卸載油料箱</Chinese>
@@ -3797,7 +3802,7 @@
         <Key ID="STR_NORECBUILDING_ERROR">
             <Original>Can't recycle:\nNo Salvage Depot in FOB area</Original>
             <German>Wiederverwerten nicht möglich:\nKeine Demontageeinrichtung im Bereich der FOB</German>
-            <Russian>Невозможно выполнить переработку:\nNo месте аварийного склада в области FOB</Russian>
+            <Russian>Невозможно выполнить переработку:\nНет утилизационного склада в области FOB</Russian>
             <Italian>Nessun edificio per il riciclaggio presente nell'area</Italian>
             <Chinesesimp>无法回收：\n前哨区域内没有回收站</Chinesesimp>
             <Chinese>無法回收：\n前線基地區域內沒有回收站</Chinese>
@@ -3807,7 +3812,7 @@
         <Key ID="STR_REASSIGN_ZEUS">
             <Original>-- REASSIGN ZEUS</Original>
             <German>-- ZEUS NEU ZUWEISEN</German>
-            <Russian>-- РЕАГИРОВАТЬ ZEUS</Russian>
+            <Russian>-- ПЕРЕНАЗНАЧИТЬ ZEUS</Russian>
             <Italian>-- RIASSEGNA ZEUS</Italian>
             <Chinesesimp>-- 重新分配ZEUS</Chinesesimp>
             <Chinese>-- 重新分配宙斯</Chinese>
@@ -3837,7 +3842,7 @@
         <Key ID="STR_BLACKLISTED_ITEM_FOUND">
             <Original>Following items are not allowed:\n%1</Original>
             <German>Folgende Gegenstände sind nicht erlaubt:\n%1</German>
-            <Russian>Следующие элементы не разрешены:\n%1</Russian>
+            <Russian>Следующие предметы не разрешены:\n%1</Russian>
             <Italian>Questi elementi non sono ammessi:\n%1</Italian>
             <Chinesesimp>以下物品已被禁用：\n%1</Chinesesimp>
             <Chinese>以下品已被禁用：\n%1</Chinese>
@@ -3897,7 +3902,7 @@
         <Key ID="STR_PRODUCTION_PRODUCING">
             <Original>Producing:</Original>
             <German>Produziert:</German>
-            <Russian>Производства:</Russian>
+            <Russian>Производит:</Russian>
             <Italian>Prodotto:</Italian>
             <Chinesesimp>正在生产：</Chinesesimp>
             <Chinese>正在生產：</Chinese>
@@ -3917,7 +3922,7 @@
         <Key ID="STR_PRODUCTION_STORAGE">
             <Original>Storage:</Original>
             <German>Lagerbereich:</German>
-            <Russian>Место хранения:</Russian>
+            <Russian>Склад:</Russian>
             <Italian>Area Stoccaggio:</Italian>
             <Chinesesimp>仓储：</Chinesesimp>
             <Chinese>倉儲：</Chinese>
@@ -3927,7 +3932,7 @@
         <Key ID="STR_PRODUCTION_NOSTORAGE">
             <Original>Not present</Original>
             <German>Nicht vorhanden</German>
-            <Russian>нет</Russian>
+            <Russian>Отсутствует</Russian>
             <Italian>Inesistente</Italian>
             <Chinesesimp>仓储：</Chinesesimp>
             <Chinese>沒有倉儲物品</Chinese>
@@ -3937,7 +3942,7 @@
         <Key ID="STR_PRODUCTION_TIMER">
             <Original>Time left:</Original>
             <German>Verbl. Zeit:</German>
-            <Russian>Время вышло:</Russian>
+            <Russian>Осталось:</Russian>
             <Italian>Tempo rimasto:</Italian>
             <Chinesesimp>剩余时间：</Chinesesimp>
             <Chinese>剩餘時間：</Chinese>
@@ -3957,7 +3962,7 @@
         <Key ID="STR_PRODUCTION_MINUTES">
             <Original>%1 minutes</Original>
             <German>%1 Minuten</German>
-            <Russian>%1 Минут</Russian>
+            <Russian>%1 Минут(-ы)</Russian>
             <Italian>%1 Minuti</Italian>
             <Chinesesimp>%1分钟</Chinesesimp>
             <Chinese>%1 分鐘</Chinese>
@@ -3967,7 +3972,7 @@
         <Key ID="STR_PRODUCTION_FACILITIES">
             <Original>Facilities available</Original>
             <German>Verfügbare Einrichtungen</German>
-            <Russian>Услуги доступны</Russian>
+            <Russian>Доступные заводы</Russian>
             <Italian>Strutture Disponibili</Italian>
             <Chinesesimp>可用工厂</Chinesesimp>
             <Chinese>可用工廠</Chinese>
@@ -3977,7 +3982,7 @@
         <Key ID="STR_PRODUCTION_STORAGEDETAIL">
             <Original>Stock Overview</Original>
             <German>Übersicht Lagerbestände</German>
-            <Russian>Обзор запасов</Russian>
+            <Russian>Обзор склада</Russian>
             <Italian>Scorte</Italian>
             <Chinesesimp>仓储总览</Chinesesimp>
             <Chinese>倉儲總覽</Chinese>
@@ -4037,7 +4042,7 @@
         <Key ID="STR_SECSUPPLYBUILD_ACTION">
             <Original>-- Build supply facility --</Original>
             <German>-- Nachschubeinrichtung bauen --</German>
-            <Russian>-- Построить систему снабжения --</Russian>
+            <Russian>-- Построить завод припасов --</Russian>
             <Italian>-- Crea impianto approvvigionamento --</Italian>
             <Chinesesimp>-- 建造补给工厂 --</Chinesesimp>
             <Chinese>-- 建造補給工廠 --</Chinese>
@@ -4047,7 +4052,7 @@
         <Key ID="STR_SECAMMOBUILD_ACTION">
             <Original>-- Build ammo facility --</Original>
             <German>-- Munitionseinrichtung bauen --</German>
-            <Russian>-- Создать боеприпасы --</Russian>
+            <Russian>-- Построить завод боеприпасов --</Russian>
             <Italian>-- Crea impianto munizioni --</Italian>
             <Chinesesimp>-- 建造弹药工厂 --</Chinesesimp>
             <Chinese>-- 建造彈藥工廠 --</Chinese>
@@ -4057,7 +4062,7 @@
         <Key ID="STR_SECFUELBUILD_ACTION">
             <Original>-- Build fuel facility --</Original>
             <German>-- Kraftstoffeinrichtung bauen --</German>
-            <Russian>-- Построить топливный объект --</Russian>
+            <Russian>-- Построить завод топлива --</Russian>
             <Italian>-- Crea impianto carburante --</Italian>
             <Chinesesimp>-- 建造燃料工厂 --</Chinesesimp>
             <Chinese>-- 建造油料工廠 --</Chinese>
@@ -4067,7 +4072,7 @@
         <Key ID="STR_PRODUCTION_FACFALSE">
             <Original>Needed facility not built in sector.</Original>
             <German>Benötigte Einrichtung nicht vorhanden.</German>
-            <Russian>Необходимый объект не построен в секторе.</Russian>
+            <Russian>Необходимый завод не построен в секторе.</Russian>
             <Italian>Impianto necessario non costruito nel settore.</Italian>
             <Chinesesimp>该战区内没有所需的工厂。</Chinesesimp>
             <Chinese>該戰區內沒有所需的工廠。</Chinese>
@@ -4077,7 +4082,7 @@
         <Key ID="STR_PRODUCTION_FACBUILD_ERROR">
             <Original>Not enough resources.\n\nYou need:\n%1 Supplies\n%2 Ammo\n%3 Fuel</Original>
             <German>Nicht genug Ressourcen.\n\nDu benötigst:\n%1 Nachschub\n%2 Munition\n%3 Kraftstoff</German>
-            <Russian>Недостаточно ресурсов.\n\nВам нужно: \n%1 Расходные материалы \n%2 Боеприпасы \n%3 Топливо</Russian>
+            <Russian>Недостаточно ресурсов.\n\nВам нужно:\n%1 Припасы\n%2 Боеприпасы\n%3 Топливо</Russian>
             <Italian>Risorse insufficenti.\n\nHai bisogno di:\n%1 approvvigionamenti\n%2 Munizioni\n%3 Carburante </Italian>
             <Chinesesimp>资源不足。\n\n你需要\n%1补给\n%2弹药\n%3燃料</Chinesesimp>
             <Chinese>資源不足。\n\n你需要\n%1補給\n%2彈藥\n%3油料</Chinese>
@@ -4087,7 +4092,7 @@
         <Key ID="STR_PRODUCTION_FACBUILD_SUCCESS">
             <Original>Facility established.</Original>
             <German>Einrichtung etabliert.</German>
-            <Russian>Учреждение создано.</Russian>
+            <Russian>Завод построен.</Russian>
             <Italian>Struttura creata.</Italian>
             <Chinesesimp>工厂已建立。</Chinesesimp>
             <Chinese>工廠已建立。</Chinese>
@@ -4147,7 +4152,7 @@
         <Key ID="STR_LOGISTIC_STATUS">
             <Original>Status:</Original>
             <German>Status:</German>
-            <Russian>Статус</Russian>
+            <Russian>Статус:</Russian>
             <Italian>Stato:</Italian>
             <Chinesesimp>状态：</Chinesesimp>
             <Chinese>狀態：</Chinese>
@@ -4167,7 +4172,7 @@
         <Key ID="STR_LOGISTIC_LOADING">
             <Original>Loading</Original>
             <German>Verladen</German>
-            <Russian>Загрузка</Russian>
+            <Russian>Погрузка</Russian>
             <Italian>Caricamento</Italian>
             <Chinesesimp>装载中</Chinesesimp>
             <Chinese>裝載中</Chinese>
@@ -4207,7 +4212,7 @@
         <Key ID="STR_LOGISTIC_NOSPACE">
             <Original>No storagespace</Original>
             <German>Kein Lagerplatz</German>
-            <Russian>Нет места для хранения</Russian>
+            <Russian>Нет места на складе</Russian>
             <Italian>Spazio non avviabile</Italian>
             <Chinesesimp>仓储空间不足</Chinesesimp>
             <Chinese>倉儲空間不足</Chinese>
@@ -4217,7 +4222,7 @@
         <Key ID="STR_LOGISTIC_DESTINATION">
             <Original>Next destination:</Original>
             <German>Nächster Zielort:</German>
-            <Russian>Следующая цель:</Russian>
+            <Russian>Следующий пункт:</Russian>
             <Italian>Prossima destinazione:</Italian>
             <Chinesesimp>下个目的地：</Chinesesimp>
             <Chinese>下個目的地：</Chinese>
@@ -4257,7 +4262,7 @@
         <Key ID="STR_LOGSTIC_SELLTRUCK">
             <Original>Unassign Truck</Original>
             <German>LKW abziehen</German>
-            <Russian>Отменить передачу</Russian>
+            <Russian>Убрать грузовик</Russian>
             <Italian>Rimuovi camion</Italian>
             <Chinesesimp>取消指派卡车</Chinesesimp>
             <Chinese>取消指派卡車</Chinese>
@@ -4267,7 +4272,7 @@
         <Key ID="STR_LOGISTIC_TT_BUYTRUCK">
             <Original>Costs: 100 supplies and 100 fuel.</Original>
             <German>Kosten: 100 Nachschub und 100 Kraftstoff.</German>
-            <Russian>Затраты: 100 поставок и 100 единиц топлива.</Russian>
+            <Russian>Затраты: 100 припасов и 100 единиц топлива.</Russian>
             <Italian>Costo: 100 approvvigionamenti e 100 carburante.</Italian>
             <Chinesesimp>花费：100补给和100燃料。</Chinesesimp>
             <Chinese>花費：100 補給和 100 油料。</Chinese>
@@ -4277,7 +4282,7 @@
         <Key ID="STR_LOGISTIC_TT_SELLTRUCK">
             <Original>Gives: 50 supplies and 50 fuel.</Original>
             <German>Erstattet: 50 Nachschub und 50 Kraftstoff.</German>
-            <Russian>Дает: 50 предметов снабжения и 50 единиц топлива.</Russian>
+            <Russian>Дает: 50 припасов и 50 единиц топлива.</Russian>
             <Italian>Rimborso: 50 approvvigionamenti e 50 carburante.</Italian>
             <Chinesesimp>回收：50补给和50燃料。</Chinesesimp>
             <Chinese>回收：50 補給和 50 燃料。</Chinese>
@@ -4307,7 +4312,7 @@
         <Key ID="STR_LOGISTIC_CANTAFFORD">
             <Original>Not enough resources</Original>
             <German>Nicht genug Ressourcen</German>
-            <Russian>недостаточно ресурсов</Russian>
+            <Russian>Недостаточно ресурсов</Russian>
             <Italian>Risorse insufficenti</Italian>
             <Chinesesimp>资源不足</Chinesesimp>
             <Chinese>資源不足</Chinese>
@@ -4347,7 +4352,7 @@
         <Key ID="STR_LOGISTIC_TT_SUPPLY">
             <Original>Supplies value from here to the other destination. (only whole numbers)</Original>
             <German>Nachschubmenge von hier zum anderen Ziel. (nur ganzzahlig)</German>
-            <Russian>Расставляет стоимость отсюда до другого пункта назначения. (Целые числа)</Russian>
+            <Russian>Припасы отсюда до другого места назначения. (Целые числа)</Russian>
             <Italian>Valore approvvigionamenti da qui all'altra destinazione. (solo numeri interi)</Italian>
             <Chinesesimp>从这里运往另一地点的补给数量。（请用整数）</Chinesesimp>
             <Chinese>從這裡運往另一地點的補給數量。（請用整數）</Chinese>
@@ -4588,7 +4593,7 @@
             <French>4. Secteurs</French>
             <German>4. Sektoren</German>
             <Spanish>4. Sectores</Spanish>
-            <Russian>4. Зоны</Russian>
+            <Russian>4. Секторы</Russian>
             <Italian>4. Settori</Italian>
             <Chinesesimp>4. 战区</Chinesesimp>
             <Chinese>4. 戰區</Chinese>
@@ -4690,7 +4695,7 @@
             </Italian>
             <Russian>&lt;br/&gt;&lt;br/&gt;
             В этой кампании вы должны управлять, хранить и защищать три типа ресурсов:&lt;br/&gt; &lt;br/&gt;
-            &lt;t color='#00ff00'&gt;ОБЕСПЕЧЕНИЕ:&lt;/t&gt; Это самое важное. Без расходных материалов вы не сможете развернуть дополнительных солдат или реквизировать любую военную технику. Таким образом, HQ рекомендует расставить приоритеты первым!&lt;br/&gt; &lt;br/&gt;
+            &lt;t color='#00ff00'&gt;ПРИПАСЫ:&lt;/t&gt; Это самое важное. Без расходных материалов вы не сможете развернуть дополнительных солдат или реквизировать любую военную технику. Таким образом, HQ рекомендует расставить приоритеты первым!&lt;br/&gt; &lt;br/&gt;
             &lt;t color='#ff0000'&gt;БОЕПРИПАСЫ:&lt;/t&gt; Используется для оснащения вооруженных автомобилей, а также элитных (и хорошо вооруженных) солдат.&lt;br/&gt; &lt;br/&gt;
             &lt;t color='#ffff00'&gt;ТОПЛИВО:&lt;/t&gt; Каждому транспортному средству нужно топливо,некоторым требуется больше, чем другим.&lt;br/&gt; &lt;br/&gt;
             Вы можете встретить все три ресурса в любом секторе, но для значительного и постоянного снабжения вы должны захватывать сектора PoI и Заводы! После захвата оба требуют области хранения (действие меню прокрутки), а затем PoI также потребует создания объекта (опять же, действие в меню прокрутки). Все три объекта могут быть построены в любом одном PoI, но вы должны заплатить первоначальную стоимость, чтобы настроить эти объекты! Это 50 конкретных ресурсов и 100 других двух.&lt;br/&gt; &lt;br/&gt;
@@ -4954,6 +4959,7 @@
         <Key ID="STR_PARAMS_ARSENALUSEPRESET">
             <Original>Arsenal mode</Original>
             <German>Arsenalmodus</German>
+            <Russian>Режим арсенала</Russian>
             <Italian>Modalità Arsenale</Italian>
             <Chinesesimp>军火库模式</Chinesesimp>
             <Chinese>軍火庫模式</Chinese>
@@ -4963,6 +4969,7 @@
         <Key ID="STR_PARAMS_NORESTRICTIONS">
             <Original>No restrictions</Original>
             <German>Keine Einschränkungen</German>
+            <Russian>Без ограничений</Russian>
             <Italian>Senza Restrizioni</Italian>
             <Chinesesimp>无限制</Chinesesimp>
             <Chinese>無限制</Chinese>
@@ -4972,6 +4979,7 @@
         <Key ID="STR_PARAMS_USEPRESET">
             <Original>Use preset from config</Original>
             <German>Benutze Preset aus Konfiguration</German>
+            <Russian>Использовать предустановки из конфига</Russian>
             <Italian>Usa il file config.sqf</Italian>
             <Chinesesimp>使用配置文件中的预设内容</Chinesesimp>
             <Chinese>使用設定文件中的預設內容</Chinese>
@@ -4981,6 +4989,7 @@
         <Key ID="STR_ACTION_CRATE_PUSH">
             <Original>-- PUSH CRATE</Original>
             <German>-- KISTE SCHIEBEN</German>
+            <Russian>-- ТОЛКНУТЬ ЯЩИК</Russian>
             <Italian>-- SPINGI CASSA</Italian>
             <Chinesesimp>-- 推货箱</Chinesesimp>
             <Chinese>-- 推貨物</Chinese>
@@ -4990,6 +4999,7 @@
         <Key ID="STR_ACTION_SORT_STORAGE">
             <Original>-- STACK AND SORT</Original>
             <German>-- STAPELN UND SORTIEREN</German>
+            <Russian>-- СОБРАТЬ И ОТСОРТИРОВАТЬ</Russian>
             <Italian>-- IMPILA E ORDINA</Italian>
             <Chinesesimp>-- 排列并分类</Chinesesimp>
             <Chinese>-- 排列並分類</Chinese>
@@ -5008,6 +5018,7 @@
         <Key ID="STR_PARAMS_COMMANDER">
             <Original>Commander only</Original>
             <German>Nur Kommandant</German>
+            <Russian>Только командир</Russian>
             <Italian>Solo per il Comandante</Italian>
             <Chinesesimp>仅指挥官</Chinesesimp>
             <Chinese>僅指揮官</Chinese>
@@ -5017,6 +5028,7 @@
         <Key ID="STR_PARAMS_WHITELISTONLY">
             <Original>Whitelisted only</Original>
             <German>Nur Whitelist</German>
+            <Russian>Только из Whitelist</Russian>
             <Italian>Con Whitelist</Italian>
             <Chinesesimp>仅白名单</Chinesesimp>
             <Chinese>僅白名單</Chinese>
@@ -5026,6 +5038,7 @@
         <Key ID="STR_PARAMS_EVERYONE">
             <Original>Everyone</Original>
             <German>Jeder</German>
+            <Russian>Все</Russian>
             <Italian>Tutti</Italian>
             <Chinesesimp>所有人</Chinesesimp>
             <Chinese>所有人</Chinese>
@@ -5053,6 +5066,7 @@
         <Key ID="STR_GREUH_DISABLED">
             <Original>- disabled -</Original>
             <German>- deaktiviert -</German>
+            <Russian>- выключен -</Russian>
             <Italian>- disabilitato -</Italian>
             <Chinesesimp>- 已禁用 -</Chinesesimp>
             <Chinese>- 已禁用 -</Chinese>
@@ -5323,6 +5337,7 @@
         <Key ID="STR_CR_KILLMSG">
             <Original>A civilian named %1 was killed!</Original>
             <German>Ein Zivilist mit Namen %1 wurde getötet!</German>
+            <Russian>Гражданский %1 был убит!</Russian>
             <Italian>Un civile di nome %1 è stato ucciso!</Italian>
             <Chinesesimp>一个名叫%1的平民被击杀了！</Chinesesimp>
             <Chinese>一個名叫 %1 的平民被擊殺了！</Chinese>
@@ -5332,6 +5347,7 @@
         <Key ID="STR_CR_VEHICLEMSG">
             <Original>A civilian's vehicle was seized!</Original>
             <German>Ein Zivilfahrzeug wurde beschlagnahmt!</German>
+            <Russian>Транспорт гражданского был захвачен!</Russian>
             <Italian>Un veicolo civile è stato confiscato!</Italian>
             <Chinesesimp>一辆平民载具被强征了！</Chinesesimp>
             <Chinese>一輛平民載具備強徵了！</Chinese>
@@ -5341,6 +5357,7 @@
         <Key ID="STR_CR_BUILDINGMSG">
             <Original>Civilians are complaining about %1 lost buildings.</Original>
             <German>Die Zivilisten beklagen sich über %1 verlorene Gebäude.</German>
+            <Russian>Гражданские жалуются из-за %1 разрушенных зданий.</Russian>
             <Italian>Civili si lamentano della perdita di %1 edifici.</Italian>
             <Chinesesimp>平民们对%1建筑的损坏有所怨言。</Chinesesimp>
             <Chinese>平民們對 %1 的建築物戰損有所怨言。</Chinese>
@@ -5350,6 +5367,7 @@
         <Key ID="STR_CR_HEALMSG">
             <Original>Civilian named %1 is thankful for your help.</Original>
             <German>Der Zivilist %1 ist dankbar für die Hilfe.</German>
+            <Russian>Гражданский %1 благодарен за вашу помощь.</Russian>
             <Italian>Il civile di nome %1 ti ringrazia per l'aiuto.</Italian>
             <Portuguese>Um civil chamado %1 agradeceu sua ajuda.</Portuguese>
             <Chinese>平民 %1 感謝你的幫助。</Chinese>
@@ -5357,6 +5375,7 @@
         <Key ID="STR_PARAM_CR_BUILDING">
             <Original>Civil Reputation penalty for buildings if building is</Original>
             <German>Ziviles Ansehen sinkt, wenn Gebäude</German>
+            <Russian>Штраф к Репутации Гражданских для построек, если постройка</Russian>
             <Italian>Penalità nella reputazione coi civili , se l'edeficio è</Italian>
             <Chinesesimp>当建筑_____时，民间声望会降低</Chinesesimp>
             <Chinese>當建築物＿＿時，民間聲望會降低。</Chinese>
@@ -5366,6 +5385,7 @@
         <Key ID="STR_PARAM_CR_DAMAGED">
             <Original>damaged</Original>
             <German>beschädigt</German>
+            <Russian>повреждена</Russian>
             <Italian>danneggiato</Italian>
             <Chinesesimp>受损</Chinesesimp>
             <Chinese>受損</Chinese>
@@ -5375,6 +5395,7 @@
         <Key ID="STR_PARAM_CR_DESTROYED">
             <Original>fully destroyed</Original>
             <German>komplett zerstört</German>
+            <Russian>полностью уничтожена</Russian>
             <Italian>completamente distrutto</Italian>
             <Chinesesimp>完全损毁</Chinesesimp>
             <Chinese>完全損毀</Chinese>
@@ -5384,6 +5405,7 @@
         <Key ID="STR_NOTIFICATION_RESTART_TITLE">
             <Original>SERVER RESTART NOTIFICATION</Original>
             <German>SERVER RESTART HINWEIS</German>
+            <Russian>НАПОМИНАНИЕ О ПЕРЕЗАПУСКЕ СЕРВЕРА</Russian>
             <Italian>NOTIFICA RESTART SERVER</Italian>
             <Turkish>SERVER YENİDEN BAŞLATMA BİLDİRİMİ</Turkish>
             <Chinesesimp>服务器重启提醒</Chinesesimp>
@@ -5393,6 +5415,7 @@
         <Key ID="STR_NOTIFICATION_RESTART_SECOND">
             <Original>The server will restart in less than 60 seconds!</Original>
             <German>Server Restart in weniger als 60 Sekunden!</German>
+            <Russian>Сервер перезапустится меньше чем через 60 секунд!</Russian>
             <Italian>Il server si riavvierà tra meno di 60 secodni!</Italian>
             <Turkish>SERVER 60 SANİYE İÇİNDE YENİDEN BAŞLATILACAK!</Turkish>
             <Chinesesimp>服务器将在60秒内重启！</Chinesesimp>
@@ -5402,6 +5425,7 @@
         <Key ID="STR_NOTIFICATION_RESTART_FIVE">
             <Original>The server will restart in less than 5 minutes!</Original>
             <German>Server Restart in weniger als 5 Minuten!</German>
+            <Russian>Сервер перезапустится через 5 минут!</Russian>
             <Italian>Il server si riavvierà tra meno di 5 minuti!</Italian>
             <Turkish>SERVER 5 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
             <Chinesesimp>服务器将在5分钟内重启！</Chinesesimp>
@@ -5411,6 +5435,7 @@
         <Key ID="STR_NOTIFICATION_RESTART_FIFTEEN">
             <Original>The server will restart in less than 15 minutes!</Original>
             <German>Server Restart in weniger als 15 Minuten!</German>
+            <Russian>Сервер перезапустится меньше чем через 15 минут!</Russian>
             <Italian>Il server si riavvierà tra meno di 15 minuti!</Italian>
             <Turkish>SERVER 15 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
             <Chinesesimp>服务器将在15分钟内重启！</Chinesesimp>
@@ -5420,6 +5445,7 @@
         <Key ID="STR_NOTIFICATION_RESTART_THIRTY">
             <Original>The server will restart in less than 30 minutes!</Original>
             <German>Server Restart in weniger als 30 Minuten!</German>
+            <Russian>Сервер перезапустится меньше чем через 30 минут!</Russian>
             <Italian>Il server si riavvierà tra meno di 30 minuti!</Italian>
             <Turkish>SERVER 30 DAKIKA İÇİNDE TEKRAR BAŞLATILACAK!</Turkish>
             <Chinesesimp>服务器将在30分钟内重启！</Chinesesimp>
@@ -5429,6 +5455,7 @@
         <Key ID="STR_RESTART_PARAM">
             <Original>Automatic Server Restart after (hours)</Original>
             <German>Automatischer Server Restart nach (Stunden)</German>
+            <Russian>Автоматический перезапуск сервера после (часов)</Russian>
             <Italian>Restart Automatico del Server ogni (ore)</Italian>
             <Turkish>Otomatik server yeniden başlat (saat)</Turkish>
             <Chinesesimp>自动重启服务器时间（小时）</Chinesesimp>
@@ -5438,6 +5465,7 @@
         <Key ID="STR_PARAMS_DEBUGOPTIONS">
             <Original>== DEBUG MESSAGES ==</Original>
             <German>== DEBUG NACHRICHTEN ==</German>
+            <Russian>== ОТЛАДОЧНЫЕ СООБЩЕНИЯ ==</Russian>
             <Italian>== MESSAGGI DI DEBUG ==</Italian>
             <Turkish>== DEBUG MESAJLARI ==</Turkish>
             <Chinesesimp>== 除错信息 ==</Chinesesimp>
@@ -5465,6 +5493,7 @@
         <Key ID="STR_NOTIFICATION_CIV_INFORMANT_START">
             <Original>A civilian from %1 says he has some information for us.</Original>
             <German>Ein Zivilist aus %1 sagt, er hätte Informationen für uns.</German>
+            <Russian>Гражданский из %1 говорит, что у него есть информация для нас.</Russian>
             <Italian>Un civile a %1 dice di avere informazioni per noi.</Italian>
             <Turkish>%1 adında ki bir sivil bize vereceği bir bilgisi olduğunu söylüyor.</Turkish>
             <Chinesesimp>来自%1的一位平民说他有情报要交给我们。</Chinesesimp>
@@ -5474,6 +5503,7 @@
         <Key ID="STR_NOTIFICATION_CIV_INFORMANT_SUCCESS">
             <Original>The civilian gave us some important information.</Original>
             <German>Der Zivilist gab uns wichtige Informationen.</German>
+            <Russian>Гражданский передал нам важную информацию.</Russian>
             <Italian>Il civile ha fornito informazioni importatnti.</Italian>
             <Turkish>Sivil bize çok önemli bilgiler verdi.</Turkish>
             <Chinesesimp>平民给了我们一些重要情报。</Chinesesimp>
@@ -5483,6 +5513,7 @@
         <Key ID="STR_NOTIFICATION_CIV_INFORMANT_FAIL">
             <Original>The civilian has disappeared.</Original>
             <German>Der Zivilist ist wieder untergetaucht.</German>
+            <Russian>Гражданский пропал.</Russian>
             <Italian>Il civile è scomparso.</Italian>
             <Turkish>Sivil ortadan kayboldu.</Turkish>
             <Chinesesimp>平民消失了。</Chinesesimp>
@@ -5492,6 +5523,7 @@
         <Key ID="STR_NOTIFICATION_CIV_INFORMANT_DEATH">
             <Original>The civilian died.</Original>
             <German>Der Zivilist wurde getötet.</German>
+            <Russian>Гражданский умер.</Russian>
             <Italian>Il civile è morto.</Italian>
             <Turkish>Sivil öldü.</Turkish>
             <Chinesesimp>平民死亡了。</Chinesesimp>
@@ -5611,6 +5643,7 @@
         <Key ID="STR_PARAM_RESPAWN_COOLDOWN">
             <Original>Mobile Respawn Cooldown (minutes)</Original>
             <German>Mobiler Respawn Cooldown (Minuten)</German>
+            <Russian>Задержка дислокации на КШМ (минуты)</Russian>
             <Italian>Attesa Respawn Mobile (Minuti)</Italian>
             <Chinesesimp>机动复活点冷却时间（分钟）</Chinesesimp>
             <Chinese>機動重生點每次重生所需冷卻時間（分鐘）</Chinese>
@@ -5619,6 +5652,7 @@
         <Key ID="STR_RESPAWN_COOLDOWN_HINT">
             <Original>%1 minutes mobile respawn cooldown left.</Original>
             <German>%1 Minuten Mobiler Respawn Cooldown übrig.</German>
+            <Russian>%1 минут(-ы) задержки дислокации на КШМ осталось.</Russian>
             <Italian>Mancano ancora %1 minuti al respawn.</Italian>
             <Chinesesimp>机动复活点还需要%1分钟冷却。</Chinesesimp>
             <Chinese>機動重生點還需要 %1 分鐘冷卻。</Chinese>
@@ -5627,6 +5661,7 @@
         <Key ID="STR_CR_RESISTANCE_KILLMSG">
             <Original>An allied resistance fighter named %1 was killed!</Original>
             <German>Ein verbündeter Widerstandskämpfer mit Namen %1 wurde getötet!</German>
+            <Russian>Союзный боец сопротивления %1 был убит!</Russian>
             <Italian>Un'alleato della resistenza di nome %1 è stato ucciso!</Italian>
             <Chinesesimp>一位名叫%1的友军抵抗军战士阵亡了！</Chinesesimp>
             <Chinese>一名叫做 %1 的友軍抵抗軍戰士陣亡了！</Chinese>
@@ -5652,48 +5687,56 @@
         <Key ID="STR_PARAMS_LOADSAVEPARAMS">
             <Original>Load/Save Parameters</Original>
             <German>Laden/Speichern der Parameter</German>
+            <Russian>Сохранить/Загрузить параметры</Russian>
             <Italian>Carica/Salva Parametri</Italian>
         </Key>
         <Key ID="STR_PARAMS_LOADSAVEPARAMS_SAVE">
             <Original>SAVE selected parameters</Original>
             <German>SPEICHERN der momentanen Parameter</German>
+            <Russian>Сохранить выбранные параметры</Russian>
             <Italian>SALVA i parametri</Italian>
         </Key>
         <Key ID="STR_PARAMS_LOADSAVEPARAMS_LOAD">
             <Original>LOAD parameters or use selected if no saved value found</Original>
             <German>LADEN der gespeicherten Parameter oder momentane nutzen, wenn keine gespeicherten vorhanden sind</German>
+            <Russian>Загрузить параметры или использовать выбранные, если не найдено сохранненого значения</Russian>
             <Italian>CARICA parametri o utilizza selezionati se non è stato trovato alcun valore salvato</Italian>
         </Key>
         <Key ID="STR_PARAMS_LOADSAVEPARAMS_SELECTED">
             <Original>Use selected parameters without saving</Original>
             <German>Momentane Parametereinstellung ohne Speicherung</German>
+            <Russian>Использовать выбранные параметры без сохранения</Russian>
             <Italian>Usa i parametri selezionati senza salvare</Italian>
         </Key>
         <Key ID="STR_RAISE">
             <Original>-- Raise</Original>
             <German>-- Höher</German>
+            <Russian>-- Поднять</Russian>
             <Italian>-- Aumenta</Italian>
         </Key>
         <Key ID="STR_LOWER">
             <Original>-- Lower</Original>
             <German>-- Niedriger</German>
+            <Russian>-- Опустить</Russian>
             <Italian>-- Abbassa</Italian>
         </Key>
         <Key ID="STR_NOTIFICATION_GUER_INC_TITLE">
             <Original>Guerilla forces on the way.</Original>
             <German>Widerstandskämpfer sind unterwegs.</German>
+            <Russian>Партизанские силы уже в пути.</Russian>
             <Italian>Guerriglieri in arrivo.</Italian>
         </Key>
         <Key ID="STR_NOTIFICATION_GUER_INC">
             <Original>Guerilla forces are incoming to %1 from the %2.</Original>
             <German>Widerstandskämpfer nähern sich %1 aus %2.</German>
+            <Russian>Партизанские силы идут в %1 из %2.</Russian>
             <Italian>Guerriglieri in arrivo su %1 da %2.</Italian>
         </Key>
         <Key ID="STR_PARAMS_REVIVEOPTIONS">
             <Original>== REVIVE OPTIONS (Disregarded, if you play with ACE Medical) ==</Original>
             <German>== WIEDERBELEBUNGSEINSTELLUNGEN (Nicht berücksichtigt, wenn mit ACE Medical gespielt wird) ==</German>
             <Spanish>== OPCIONES DE REVIVE ==</Spanish>
-            <Russian>== ВОЗВРАТИТЬ ОПЦИИ ==</Russian>
+            <Russian>== ОПЦИИ ВОЗРОЖДЕНИЯ (Игнорируются, если вы играете с ACE Medical) ==</Russian>
             <Italian>== OPZIONI RIANIMAZIONE ==</Italian>
             <Chinesesimp>== 复活选项 ==</Chinesesimp>
             <Chinese>== 昏迷甦醒選項 ==</Chinese>
@@ -5703,60 +5746,72 @@
         <Key ID="STR_PARAMS_ARSENAL">
             <Original>Arsenal</Original>
             <German>Arsenal</German>
+            <Russian>Арсенал</Russian>
             <Italian>Arsenale</Italian>
         </Key>
         <Key ID="STR_PARAMS_ARSENAL_BI">
             <Original>BI arsenal</Original>
             <German>BI Arsenal</German>
+            <Russian>Арсенал BI</Russian>
             <Italian>BI Arsenale</Italian>
         </Key>
         <Key ID="STR_PARAMS_ARSENAL_ACE">
             <Original>ACE arsenal</Original>
             <German>ACE Arsenal</German>
+            <Russian>Арсенал ACE</Russian>
             <Italian>ACE Arsenale</Italian>
         </Key>
         <Key ID="STR_PARAMS_VICTORYCONDITION">
             <Original>Victory Condition</Original>
             <German>Siegesbedingung</German>
+            <Russian>Условие для победы</Russian>
         </Key>
         <Key ID="STR_PARAMS_VICTORYCONDITION_0">
             <Original>All capitals</Original>
             <German>Alle Hauptstädte</German>
+            <Russian>Все столицы</Russian>
         </Key>
         <Key ID="STR_PARAMS_VICTORYCONDITION_1">
             <Original>All capitals and military bases</Original>
             <German>Alle Hauptstädte und Militärbasen</German>
+            <Russian>Все столицы и военные базы</Russian>
         </Key>
         <Key ID="STR_PARAMS_VICTORYCONDITION_2">
             <Original>All capitals and 60% of the sectors</Original>
             <German>Alle Hauptstädte und 60% der Sektoren</German>
+            <Russian>Все столицы и 60% секторов</Russian>
         </Key>
         <Key ID="STR_PARAMS_VICTORYCONDITION_3">
             <Original>All capitals and 80% of the sectors</Original>
             <German>Alle Hauptstädte und 80% der Sektoren</German>
+            <Russian>Все столицы и 80% секторов</Russian>
         </Key>
         <Key ID="STR_PARAMS_VICTORYCONDITION_4">
             <Original>All sectors</Original>
             <German>Alle Sektoren</German>
+            <Russian>Все секторы</Russian>
         </Key>
         <Key ID="STR_VICTORY_TITLE">
             <Original>CAMPAIGN COMPLETED</Original>
             <German>KAMPAGNE ABGESCHLOSSEN</German>
+            <Russian>КАМПАНИЯ ВЫПОЛНЕНА</Russian>
         </Key>
         <Key ID="STR_VICTORY_TEXT">
             <Original>You have liberated the area from the enemy oppression.</Original>
             <German>Du hast das Gebiet von der feindlichen Unterdrückung befreit.</German>
+            <Russian>Вы освободили территорию от угнетения врага.</Russian>
         </Key>
         <Key ID="STR_STATS_PLAYTIME">
             <Original>Playtime: %1 days, %2 hours, %3 minutes and %4 seconds</Original>
             <German>Spielzeit: %1 Tage, %2 Stunden, %3 Minuten und %4 Sekunden</German>
+            <Russian>Игровое время: %1 дней, %2 часов, %3 минут и %4 секунд</Russian>
         </Key>
         <Key ID="STR_STATS_OPFOR_K_INF">
             <Original>OPFOR infantry killed: %1</Original>
             <French>Infanterie OPFOR tuée: %1</French>
             <German>OPFOR Infanterie getötet: %1</German>
             <Spanish>Infantería OPFOR eliminada: %1</Spanish>
-            <Russian>OPFOR пехоты убито: %1</Russian>
+            <Russian>Пехоты OPFOR убито: %1</Russian>
             <Italian>Fanteria OPFOR ha ucciso: %1</Italian>
             <Chinesesimp>被击杀的敌军步兵： %1</Chinesesimp>
             <Chinese>被擊殺的敵方步兵： %1</Chinese>
@@ -5768,7 +5823,7 @@
             <French>Infanterie OPFOR tuée par les joueurs: %1</French>
             <German>OPFOR Infanterie von Spielern getötet: %1</German>
             <Spanish>Infantería OPFOR eliminada por jugadores: %1</Spanish>
-            <Russian>OPFOR пехоты убито игроками: %1</Russian>
+            <Russian>Пехоты OPFOR убито игроками: %1</Russian>
             <Italian>Fanteria OPFOR uccisa da: %1</Italian>
             <Chinesesimp>被玩家击杀的敌军步兵： %1</Chinesesimp>
             <Chinese>被玩家擊殺的敵方步兵： %1</Chinese>
@@ -5780,7 +5835,7 @@
             <French>Vehicules OPFOR détruits: %1</French>
             <German>OPFOR Fahrzeuge zerstört: %1</German>
             <Spanish>Vehículos OPFOR destruídos: %1</Spanish>
-            <Russian>OPFOR техники уничтожено: %1</Russian>
+            <Russian>Техники OPFOR уничтожено: %1</Russian>
             <Italian>Veicolo OPFOR distrutto: %1</Italian>
             <Chinesesimp>敌军被摧毁的载具： %1</Chinesesimp>
             <Chinese>敵軍被摧毀的載具： %1</Chinese>
@@ -5792,7 +5847,7 @@
             <French>Vehicules OPFOR détruits par les joueurs: %1</French>
             <German>OPFOR Fahrzeuge von Spielern zerstört: %1</German>
             <Spanish>Vehículos OPFOR destruídos por jugadores: %1</Spanish>
-            <Russian>OPFOR техники уничтожено игроками: %1</Russian>
+            <Russian>Техники OPFOR уничтожено игроками: %1</Russian>
             <Italian>Veicolo OPFOR distrutto da: %1</Italian>
             <Chinesesimp>被玩家摧毁的敌军载具： %1</Chinesesimp>
             <Chinese>被玩家摧毀的敵軍載具： %1</Chinese>
@@ -5804,7 +5859,7 @@
             <French>Soldats BLUFOR recrutés: %1</French>
             <German>BLUFOR Soldaten rekrutiert: %1</German>
             <Spanish>Soldados BLUFOR reclutados: %1</Spanish>
-            <Russian>BLUFOR солдат призвано: %1</Russian>
+            <Russian>Солдат BLUFOR призвано: %1</Russian>
             <Italian>Soldato BLUFOR reclutato: %1</Italian>
             <Chinesesimp>我军招募的士兵： %1</Chinesesimp>
             <Chinese>我軍招募的士兵： %1</Chinese>
@@ -5816,7 +5871,7 @@
             <French>Infanterie BLUFOR tuée: %1</French>
             <German>BLUFOR Infanterie getötet: %1</German>
             <Spanish>Infantería BLUFOR eliminada: %1</Spanish>
-            <Russian>BLUFOR пехоты убито: %1</Russian>
+            <Russian>Пехоты BLUFOR убито: %1</Russian>
             <Italian>Fanteria BLUFOR ha ucciso: %1</Italian>
             <Chinesesimp>被击杀的我军步兵： %1</Chinesesimp>
             <Chinese>被擊殺的我方步兵： %1</Chinese>
@@ -5828,7 +5883,7 @@
             <French>Vehicules BLUFOR construits: %1</French>
             <German>BLUFOR Fahrzeuge gebaut: %1</German>
             <Spanish>Vehículos BLUFOR construidos: %1</Spanish>
-            <Russian>BLUFOR техники построено: %1</Russian>
+            <Russian>Техники BLUFOR построено: %1</Russian>
             <Italian>Veicolo BLUFOR creato: %1</Italian>
             <Chinesesimp>我军建造的载具： %1</Chinesesimp>
             <Chinese>我軍建造的載具： %1</Chinese>
@@ -5840,7 +5895,7 @@
             <French>Vehicules BLUFOR détruits: %1</French>
             <German>BLUFOR Fahrzeuge zerstört: %1</German>
             <Spanish>Vehículos BLUFOR destruídos: %1</Spanish>
-            <Russian>BLUFOR техники уничтожено: %1</Russian>
+            <Russian>Техники BLUFOR уничтожено: %1</Russian>
             <Italian>Veicolo BLUFOR distrutto: %1</Italian>
             <Chinesesimp>被摧毁的我军载具： %1</Chinesesimp>
             <Chinese>被摧毀的我方載具： %1</Chinese>
@@ -5852,7 +5907,7 @@
             <French>Joueurs morts: %1</French>
             <German>Spielertode: %1</German>
             <Spanish>Muertes del jugador: %1</Spanish>
-            <Russian>Смертей игрока: %1</Russian>
+            <Russian>Смертей игроков: %1</Russian>
             <Italian>Giocatori Deceduti: %1</Italian>
             <Chinesesimp>玩家死亡数： %1</Chinesesimp>
             <Chinese>玩家死亡數： %1</Chinese>
@@ -5864,7 +5919,7 @@
             <French>Tirs fratricides BLUFOR: %1</French>
             <German>BLUFOR Eigenbeschuss: %1</German>
             <Spanish>Incidentes de fuego amigo en BLUFOR: %1</Spanish>
-            <Russian>BLUFOR дружественный огонь: %1</Russian>
+            <Russian>Случаев дружественного огоня у BLUFOR: %1</Russian>
             <Italian>Fuoco amico tra i BLUFOR: %1</Italian>
             <Chinesesimp>我军友军误击事件： %1</Chinesesimp>
             <Chinese>友軍誤擊事件： %1</Chinese>
@@ -5874,14 +5929,17 @@
         <Key ID="STR_STATS_GUE_K_INF">
             <Original>Resistance fighters killed: %1</Original>
             <German>Widerstandskämpfer getötet: %1</German>
+            <Russian>Убито бойцов сопротивления: %1</Russian>
         </Key>
         <Key ID="STR_STATS_GUE_TK_INF">
             <Original>Allied resistance fighters killed: %1</Original>
             <German>Verbündete Widerstandskämpfer getötet: %1</German>
+            <Russian>Убито союзнических бойцов сопротивления: %1</Russian>
         </Key>
         <Key ID="STR_STATS_GUE_TK_INF_PL">
             <Original>Allied resistance fighters killed by players: %1</Original>
             <German>Verbündete Widerstandskämpfer von Spielern getötet: %1</German>
+            <Russian>Убито союзнических бойцов сопротивления игроками: %1</Russian>
         </Key>
         <Key ID="STR_STATS_CIV_K_INF">
             <Original>Civilians killed: %1</Original>
@@ -5910,22 +5968,27 @@
         <Key ID="STR_STATS_CIV_B_INF">
             <Original>Civilians healed: %1</Original>
             <German>Zivilisten versorgt: %1</German>
+            <Russian>Гражданских вылечено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_CIV_K_VEH">
             <Original>Civilian vehicles destroyed: %1</Original>
             <German>Zivile Fahrzeuge zerstört: %1</German>
+            <Russian>Транспорта гражданских уничтожено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_CIV_K_VEH_PL">
             <Original>Civilian vehicles destroyed by players: %1</Original>
             <German>Zivile Fahrzeuge von Spielern zerstört: %1</German>
+            <Russian>Транспорта гражданских уничтожено игроками: %1</Russian>
         </Key>
         <Key ID="STR_STATS_CIV_S_VEH">
             <Original>Civilian vehicles seized: %1</Original>
             <German>Zivile Fahrzeuge beschlagnahmt: %1</German>
+            <Russian>Транспорта гражданских захвачено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_CIV_K_BUILDINGS">
             <Original>Civilian buildings destroyed: %1</Original>
             <German>Zivile Gebäude zerstört: %1</German>
+            <Russian>Построек гражданских уничтожено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_VEH_RECYCLED">
             <Original>Vehicles recycled: %1</Original>
@@ -5942,33 +6005,39 @@
         <Key ID="STR_STATS_PROD_AMMO">
             <Original>Ammunitiond produced: %1</Original>
             <German>Munition hergestellt: %1</German>
+            <Russian>Произведено боеприпасов: %1</Russian>
         </Key>
         <Key ID="STR_STATS_SPENT_AMMO">
             <Original>Ammunitiond spent: %1</Original>
             <German>Munition verbraucht: %1</German>
+            <Russian>Боеприпасов потрачено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_PROD_FUEL">
             <Original>Fuel produced: %1</Original>
             <German>Kraftstoff hergestellt: %1</German>
+            <Russian>Произведено топлива: %1</Russian>
         </Key>
         <Key ID="STR_STATS_SPENT_FUEL">
             <Original>Fuel spent: %1</Original>
             <German>Kraftstoff verbraucht: %1</German>
+            <Russian>Топлива потрачено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_PROD_SUPPLY">
             <Original>Supplies produced: %1</Original>
             <German>Nachschub hergestellt: %1</German>
+            <Russian>Произведено припасов: %1</Russian>
         </Key>
         <Key ID="STR_STATS_SPENT_SUPPLY">
             <Original>Supllies spent: %1</Original>
             <German>Nachschub verbraucht: %1</German>
+            <Russian>Припасов потрачено: %1</Russian>
         </Key>
         <Key ID="STR_STATS_SECTORS_CAPTURED">
             <Original>Sectors liberated: %1</Original>
             <French>Secteurs libérés, delivrés: %1</French>
             <German>Sektoren befreit: %1</German>
             <Spanish>Sectores liberados: %1</Spanish>
-            <Russian>Зон освобождено: %1</Russian>
+            <Russian>Секторов освобождено: %1</Russian>
             <Italian>Settore liberato: %1</Italian>
             <Chinesesimp>解放的战区： %1</Chinesesimp>
             <Chinese>解放的戰區： %1</Chinese>
@@ -5980,7 +6049,7 @@
             <French>Secteurs perdus: %1</French>
             <German>Sektoren verloren: %1</German>
             <Spanish>Sectores perdidos: %1</Spanish>
-            <Russian>Зон потеряно: %1</Russian>
+            <Russian>Секторов потеряно: %1</Russian>
             <Italian>Settore perso: %1</Italian>
             <Chinesesimp>丢失的战区： %1</Chinesesimp>
             <Chinese>失去的戰區： %1</Chinese>
@@ -6016,7 +6085,7 @@
             <French>Objectifs secondaires accomplis: %1</French>
             <German>Sekundärziele erreicht: %1</German>
             <Spanish>Objetivos secundarios conseguidos: %1</Spanish>
-            <Russian>Вторичных заданий выполнено: %1</Russian>
+            <Russian>Дополнительных заданий выполнено: %1</Russian>
             <Italian>Obiettivo secondario completato: %1</Italian>
             <Chinesesimp>完成的次要目标： %1</Chinesesimp>
             <Chinese>完成的次要目標： %1</Chinese>
@@ -6144,11 +6213,13 @@
         </Key>
         <Key ID="STR_CLEARANCE_ACTION">
             <Original>-- Clear FOB area</Original>
+            <Russian>-- Очистить зону FOB</Russian>
             <German>-- FOB Gebiet räumen</German>
         </Key>
         <Key ID="STR_FOB_REPACKAGE_HINT">
             <Original>FOB repackaged.\nPossibly created clearance will be reverted upon server restart.</Original>
             <German>FOB eingepackt.\nEventuelle Gebietsräumung wird zum Serverneustart rückgängig gemacht.</German>
+            <Russian>FOB перепаковано.\nВозможно, созданное разрешение будет отменено после перезапуска сервера.</Russian>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
I added some missing russian translations (not all) and fixed typos in existing translations.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no  |
| Fixed issues | - |

### Description:
Added missing russian translations and fixed typos in **stringtable.xml**

### Successfully tested on:
- [x] Local MP