### PR TITLE
Small 0.96.6 CUP Tweaks

### DIFF
--- a/Missionframework/presets/blufor/CUP_ACR_Desert.sqf
+++ b/Missionframework/presets/blufor/CUP_ACR_Desert.sqf
@@ -70,7 +70,6 @@ infantry_units = [
 ];
 
 light_vehicles = [
-    ["CUP_B_TowingTractor_CZ",50,0,25],                                 // Towing Tractor
     ["CUP_B_UAZ_Unarmed_ACR",100,0,50],                                 // UAZ
     ["CUP_B_UAZ_Open_ACR",100,0,50],                                    // UAZ (Open)
     ["CUP_B_UAZ_MG_ACR",100,40,50],                                     // UAZ (DShKM)
@@ -215,7 +214,7 @@ support_vehicles = [
     ["ACE_Box_82mm_Mo_Illum",50,10,0],
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
+    ["CUP_B_TowingTractor_CZ",50,0,25],                                 // Towing Tractor
     ["CUP_B_T810_Repair_CZ_DES",325,0,75],                              // Tatra T810 (Repair)
     ["CUP_B_T810_Refuel_CZ_DES",125,0,275],                             // Tatra T810 (Fuel)
     ["CUP_B_T810_Reammo_CZ_DES",125,200,75],                            // Tatra T810 (Ammo)

--- a/Missionframework/presets/blufor/CUP_ACR_Woodland.sqf
+++ b/Missionframework/presets/blufor/CUP_ACR_Woodland.sqf
@@ -70,7 +70,6 @@ infantry_units = [
 ];
 
 light_vehicles = [
-    ["CUP_B_TowingTractor_CZ",50,0,25],                                 // Towing Tractor
     ["CUP_B_UAZ_Unarmed_ACR",100,0,50],                                 // UAZ
     ["CUP_B_UAZ_Open_ACR",100,0,50],                                    // UAZ (Open)
     ["CUP_B_UAZ_MG_ACR",100,40,50],                                     // UAZ (DShKM)
@@ -212,7 +211,7 @@ support_vehicles = [
     ["ACE_Box_82mm_Mo_Illum",50,10,0],
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
+    ["CUP_B_TowingTractor_CZ",50,0,25],                                 // Towing Tractor
     ["CUP_B_T810_Repair_CZ_WDL",325,0,75],                              // Tatra T810 (Repair)
     ["CUP_B_T810_Refuel_CZ_WDL",125,0,275],                             // Tatra T810 (Fuel)
     ["CUP_B_T810_Reammo_CZ_WDL",125,200,75],                            // Tatra T810 (Ammo)

--- a/Missionframework/presets/blufor/CUP_BAF_Desert.sqf
+++ b/Missionframework/presets/blufor/CUP_BAF_Desert.sqf
@@ -223,7 +223,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_TowingTractor_GB",50,0,25],                                     // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                                 // CRV-6e Bobcat
     ["CUP_B_MTVR_Repair_USA",425,0,75],                                     // MTVR Repair
     ["CUP_B_MTVR_Refuel_USA",125,0,375],                                    // MTVR Refuel
     ["CUP_B_MTVR_Ammo_USA",125,300,75],                                     // MTVR Ammo

--- a/Missionframework/presets/blufor/CUP_BAF_Woodland.sqf
+++ b/Missionframework/presets/blufor/CUP_BAF_Woodland.sqf
@@ -223,7 +223,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_TowingTractor_GB",50,0,25],                                 // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["CUP_B_MTVR_Repair_USMC",425,0,75],                                // MTVR Repair
     ["CUP_B_MTVR_Refuel_USMC",125,0,375],                               // MTVR Refuel
     ["CUP_B_MTVR_Ammo_USMC",125,300,75],                                // MTVR Ammo

--- a/Missionframework/presets/blufor/CUP_CDF.sqf
+++ b/Missionframework/presets/blufor/CUP_CDF.sqf
@@ -69,7 +69,6 @@ infantry_units = [
 ];
 
 light_vehicles = [
-    ["CUP_B_Tractor_CDF",50,0,25],                                      // Towing Tractor
     ["CUP_B_UAZ_Unarmed_CDF",75,0,50],                                  // UAZ
     ["CUP_B_UAZ_MG_CDF",100,60,50],                                     // UAZ (DShKM)
     ["CUP_B_UAZ_AGS30_CDF",100,80,50],                                  // UAZ (AGS-30)
@@ -211,7 +210,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_Tractor_CDF",50,0,75],                                      // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["CUP_B_Kamaz_Repair_CDF",425,0,75],                                // Kamaz 5350 (Repair)
     ["CUP_B_Kamaz_Refuel_CDF",125,0,375],                               // Kamaz 5350 (Fuel)
     ["CUP_B_Kamaz_Reammo_CDF",125,300,75],                              // Kamaz 5350 (Ammo)

--- a/Missionframework/presets/blufor/CUP_USA_Desert.sqf
+++ b/Missionframework/presets/blufor/CUP_USA_Desert.sqf
@@ -68,7 +68,6 @@ infantry_units = [
 ];
 
 light_vehicles = [
-    ["CUP_B_TowingTractor_USA",50,0,25],                                // Towing Tractor
     ["CUP_B_HMMWV_Unarmed_USA",75,0,50],                                // HMMWV (Unarmed)
     ["CUP_B_HMMWV_M2_USA",75,60,50],                                    // HMMWV M2
     ["CUP_B_HMMWV_MK19_USA",75,80,50],                                  // HMMWV MK19
@@ -220,7 +219,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_TowingTractor_USA",50,0,75],                                // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["CUP_B_MTVR_Repair_USA",425,0,75],                                 // MTVR Repair
     ["CUP_B_MTVR_Refuel_USA",125,0,375],                                // MTVR Refuel
     ["CUP_B_MTVR_Ammo_USA",125,300,75],                                 // MTVR Ammo

--- a/Missionframework/presets/blufor/CUP_USA_Woodland.sqf
+++ b/Missionframework/presets/blufor/CUP_USA_Woodland.sqf
@@ -68,7 +68,6 @@ infantry_units = [
 ];
 
 light_vehicles = [
-    ["CUP_B_TowingTractor_USA",50,0,25],                                // Towing Tractor
     ["CUP_B_HMMWV_Unarmed_USA",75,0,50],                                // HMMWV (Unarmed)
     ["CUP_B_HMMWV_M2_USA",75,60,50],                                    // HMMWV M2
     ["CUP_B_HMMWV_MK19_USA",75,80,50],                                  // HMMWV MK19
@@ -222,7 +221,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_TowingTractor_USA",50,0,75],                                // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["CUP_B_MTVR_Repair_USMC",425,0,75],                                // MTVR Repair
     ["CUP_B_MTVR_Refuel_USMC",125,0,375],                               // MTVR Refuel
     ["CUP_B_MTVR_Ammo_USMC",125,300,75],                                // MTVR Ammo

--- a/Missionframework/presets/blufor/CUP_USMC_Desert.sqf
+++ b/Missionframework/presets/blufor/CUP_USMC_Desert.sqf
@@ -217,7 +217,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_TowingTractor_USMC",50,0,75],                               // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["CUP_B_MTVR_Repair_USA",425,0,75],                                 // MTVR Repair
     ["CUP_B_MTVR_Refuel_USA",125,0,375],                                // MTVR Refuel
     ["CUP_B_MTVR_Ammo_USA",125,300,75],                                 // MTVR Ammo

--- a/Missionframework/presets/blufor/CUP_USMC_Woodland.sqf
+++ b/Missionframework/presets/blufor/CUP_USMC_Woodland.sqf
@@ -218,7 +218,6 @@ support_vehicles = [
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
     ["CUP_B_TowingTractor_USMC",50,0,75],                               // Towing Tractor
-    ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["CUP_B_MTVR_Repair_USMC",425,0,75],                                // MTVR Repair
     ["CUP_B_MTVR_Refuel_USMC",125,0,375],                               // MTVR Refuel
     ["CUP_B_MTVR_Ammo_USMC",125,300,75],                                // MTVR Ammo

--- a/Missionframework/presets/blufor/apex.sqf
+++ b/Missionframework/presets/blufor/apex.sqf
@@ -74,7 +74,6 @@ infantry_units = [
 
 light_vehicles = [
     ["B_T_Quadbike_01_F",50,0,25],                                      // Quad Bike
-    ["CUP_B_TowingTractor_NATO",50,0,25],                               // Towing Tractor
     ["B_T_LSV_01_unarmed_F",75,0,50],                                   // Prowler
     ["B_T_LSV_01_armed_F",75,40,50],                                    // Prowler (HMG)
     ["B_T_LSV_01_AT_F",75,60,50],                                       // Prowler (AT)
@@ -298,6 +297,7 @@ support_vehicles = [
     ["ACE_Box_82mm_Mo_Illum",50,10,0],
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
+    ["CUP_B_TowingTractor_NATO",50,0,25],                               // Towing Tractor
     ["B_T_APC_Tracked_01_CRV_F",500,250,350],                           // CRV-6e Bobcat
     ["B_T_Truck_01_Repair_F",325,0,75],                                 // HEMTT Repair
     ["B_T_Truck_01_fuel_F",125,0,275],                                  // HEMTT Fuel

--- a/Missionframework/presets/blufor/custom.sqf
+++ b/Missionframework/presets/blufor/custom.sqf
@@ -80,7 +80,6 @@ infantry_units = [
 
 light_vehicles = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
-    ["CUP_B_TowingTractor_NATO",50,0,25],                               // Towing Tractor
     ["B_LSV_01_unarmed_F",75,0,50],                                     // Prowler
     ["B_LSV_01_armed_F",75,40,50],                                      // Prowler (HMG)
     ["B_LSV_01_AT_F",75,60,50],                                         // Prowler (AT)
@@ -304,6 +303,7 @@ support_vehicles = [
     ["ACE_Box_82mm_Mo_Illum",50,10,0],
     ["ACE_Wheel",10,0,0],
     ["ACE_Track",10,0,0],
+    ["CUP_B_TowingTractor_NATO",50,0,25],                               // Towing Tractor
     ["B_APC_Tracked_01_CRV_F",500,250,350],                             // CRV-6e Bobcat
     ["B_Truck_01_Repair_F",325,0,75],                                   // HEMTT Repair
     ["B_Truck_01_fuel_F",125,0,275],                                    // HEMTT Fuel

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ class Missions
 * Fixed: Potato 01 was created after server restart, even if there was one saved.
 * Fixed: Missing variable `stats_blufor_teamkills_by_players`. Also no separation between by players or not by players for teamkills anymore.
 * Fixed: Factory storages could disappear randomly on save load.
+* Fixed: Some Presets had CUP Towing Tractor in the wrong place or duplicated. [Eogos](https://github.com/Eogos)
+* Fixed: CUP Presets still had the Nemmera in the support vehicle section. [Eogos](https://github.com/Eogos)
 
 ### 0.96.5 (26th July 2019 due to Contacts Release)
 * Added: Contact DLC LDF preset.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ class Missions
 * Fixed: Potato 01 was created after server restart, even if there was one saved.
 * Fixed: Missing variable `stats_blufor_teamkills_by_players`. Also no separation between by players or not by players for teamkills anymore.
 * Fixed: Factory storages could disappear randomly on save load.
-* Fixed: Some Presets had CUP Towing Tractor in the wrong place or duplicated. [Eogos](https://github.com/Eogos)
+* Fixed: Some Presets had CUP Towing Tractor in the wrong place or duplicated. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: CUP Presets still had the Nemmera in the support vehicle section. [Eogos](https://github.com/Eogos)
 
 ### 0.96.5 (26th July 2019 due to Contacts Release)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ class Missions
 * Fixed: Missing variable `stats_blufor_teamkills_by_players`. Also no separation between by players or not by players for teamkills anymore.
 * Fixed: Factory storages could disappear randomly on save load.
 * Fixed: Some Presets had CUP Towing Tractor in the wrong place or duplicated. Thanks to [Eogos](https://github.com/Eogos)
-* Fixed: CUP Presets still had the Nemmera in the support vehicle section. [Eogos](https://github.com/Eogos)
+* Fixed: CUP Presets still had the Nemmera in the support vehicle section. Thanks to [Eogos](https://github.com/Eogos)
 
 ### 0.96.5 (26th July 2019 due to Contacts Release)
 * Added: Contact DLC LDF preset.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | No |
| Needs wipe? | No |
| Fixed issues | N/A |

### Description:

CUP Presets still had the Nemmera repair vehicle that I forgot to remove as well as had their towing tractors all over the place and sometimes even in two spots. This PR will fix those small issues.

### Content:
- [x] Fixed Towing Tractor location across all Presets
- [x] Removed Nemmera from all CUP Presets

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP
