### PR TITLE
First Draft - Civilian Presence System

### DIFF
--- a/Missionframework/modules/01_common/fnc/fn_common_createUnit.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_createUnit.sqf
@@ -25,7 +25,8 @@ params [
     ["_grp", grpNull, [grpNull]],
     ["_classname", "", [""]],
     ["_spawnPos", KPLIB_zeroPos, [[]], [3]],
-    ["_addition", "NONE", [""]]
+    ["_addition", "NONE", [""]],
+    ["_agent", false, [false]]
 ];
 
 if (_grp isEqualTo grpNull || _classname isEqualTo "") exitWith {objNull};
@@ -33,9 +34,14 @@ if (_grp isEqualTo grpNull || _classname isEqualTo "") exitWith {objNull};
 // Create temp group, as we need to let the unit join the "correct side group".
 // If we use the "correct side group" for the createUnit, the group would switch to the side of the unit written in the config.
 private _grpTemp = createGroup [civilian, true];
-
+private _unit = objNull;
 // Create unit in temp group
-private _unit = _grpTemp createUnit [_classname, _spawnPos, [], 10, _addition];
+if (_asAgent) then {
+
+} else {
+    _unit = _grpTemp createUnit [_classname, _spawnPos, [], 10, _addition];
+};
+
 
 // Let unit join the "correct side group"
 [_unit] joinSilent _grp;

--- a/Missionframework/modules/01_common/fnc/fn_common_isSectorType.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_isSectorType.sqf
@@ -1,0 +1,45 @@
+/*
+    KPLIB_fnc_common_isSectorType
+
+    File: fn_common_isSectorType.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-04
+    Last Update: 2019-09-04
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: Yes
+
+    Description:
+        Given a sector return true if sector is of type to check for.
+
+    Parameter(s):
+        _sector - Sector we are checking [STRING, Defaults to ""]
+		_type - Sector Type to check against. [STRING, Defaults to ""]
+
+    Returns:
+        Boolean [BOOL]
+*/
+
+params [
+    ["_sector", "", [""]],
+	["_type", "", [""]]
+];
+
+// Get array of results that match _sector in requested list of sorted sectors
+switch (_type) do {
+    case "airspawn": {_result = KPLIB_sectors_airspawn select {_sector = _x;};};
+    case "military": {_result = KPLIB_sectors_military select {_sector = _x;};};
+    case "city": {_result = KPLIB_sectors_city select {_sector = _x;};};
+    case "factory": {_result = KPLIB_sectors_factory select {_sector = _x;};};
+    case "metropolis": {_result = KPLIB_sectors_metropolis select {_sector = _x;};};
+    case "spawn": {_result = KPLIB_sectors_spawn select {_sector = _x;};};
+    case "tower": {_result = KPLIB_sectors_tower select {_sector = _x;};};
+	default: {_result = [];}
+};
+
+// If result array is larger than 1, return true, else false.
+if (count _result > 0) then {
+	true;
+} else {
+	// ERROR LOG
+	false;
+};

--- a/Missionframework/modules/01_common/functions.hpp
+++ b/Missionframework/modules/01_common/functions.hpp
@@ -71,6 +71,9 @@ class common {
     // Logs given text to server rpt
     class common_log {};
 
+    // Checks if a sector is of a certain type.
+    class common_isSectorType {};
+
     // Initialize common module
     class common_preInit {
         preInit = 1;

--- a/Missionframework/modules/20_civilian/README.md
+++ b/Missionframework/modules/20_civilian/README.md
@@ -1,0 +1,14 @@
+# KP Liberation Module Description
+
+## Example Module
+This is an example module description.
+Used as template for new modules. Make sure to replace the `example` everywhere accordingly.
+
+### Dependencies
+* None
+
+### Functions
+
+
+### Scripts
+No scripts will be started by this module

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_despawn.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_despawn.sqf
@@ -1,0 +1,33 @@
+/*
+    KPLIB_fnc_civilian_despawn
+
+    File: fn_civilian_despawn.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-04
+    Last Update: 2019-09-04
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Handles the despawning of the sector civilians.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+
+params [
+    ["_sector", "", [""]]
+];
+
+if (isServer) then {[format ["Despawn for %1", _sector], "GARRISON", true] call KPLIB_fnc_common_log;};
+
+// Initialize local variables
+
+// Depspawn civs on foot
+
+// Return
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_despawn.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_despawn.sqf
@@ -23,7 +23,7 @@ params [
     ["_sector", "", [""]]
 ];
 
-if (isServer) then {[format ["Despawn for %1", _sector], "GARRISON", true] call KPLIB_fnc_common_log;};
+if (isServer) then {[format ["Despawn for %1", _sector], "CIVILIAN", true] call KPLIB_fnc_common_log;};
 
 // Initialize local variables
 

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_loadData.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_loadData.sqf
@@ -1,0 +1,34 @@
+/*
+    KPLIB_fnc_example_loadData
+
+    File: fn_example_loadData.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-04-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Loads data which is bound to this module from the given save data or initializes needed data for a new campaign.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+if (KPLIB_param_debug) then {["Example module loading...", "SAVE"] call KPLIB_fnc_common_log;};
+
+private _moduleData = ["example"] call KPLIB_fnc_init_getSaveData;
+
+// Check if there is a new campaign
+if (_moduleData isEqualTo []) then {
+    if (KPLIB_param_debug) then {["Example module data empty, creating new data...", "SAVE"] call KPLIB_fnc_common_log;};
+    // Nothing to do here
+} else {
+    // Otherwise start applying the saved data
+    if (KPLIB_param_debug) then {["Example module data found, applying data...", "SAVE"] call KPLIB_fnc_common_log;};
+};
+
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_loadData.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_loadData.sqf
@@ -1,7 +1,7 @@
 /*
-    KPLIB_fnc_example_loadData
+    KPLIB_fnc_civilian_loadData
 
-    File: fn_example_loadData.sqf
+    File: fn_civilian_loadData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-02-02
     Last Update: 2019-04-23
@@ -18,17 +18,17 @@
         Function reached the end [BOOL]
 */
 
-if (KPLIB_param_debug) then {["Example module loading...", "SAVE"] call KPLIB_fnc_common_log;};
+if (KPLIB_param_debug) then {["Civilian module loading...", "SAVE"] call KPLIB_fnc_common_log;};
 
-private _moduleData = ["example"] call KPLIB_fnc_init_getSaveData;
+private _moduleData = ["Civilian"] call KPLIB_fnc_init_getSaveData;
 
 // Check if there is a new campaign
 if (_moduleData isEqualTo []) then {
-    if (KPLIB_param_debug) then {["Example module data empty, creating new data...", "SAVE"] call KPLIB_fnc_common_log;};
+    if (KPLIB_param_debug) then {["Civilian module data empty, creating new data...", "SAVE"] call KPLIB_fnc_common_log;};
     // Nothing to do here
 } else {
     // Otherwise start applying the saved data
-    if (KPLIB_param_debug) then {["Example module data found, applying data...", "SAVE"] call KPLIB_fnc_common_log;};
+    if (KPLIB_param_debug) then {["Civilian module data found, applying data...", "SAVE"] call KPLIB_fnc_common_log;};
 };
 
 true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_postInit.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_postInit.sqf
@@ -1,0 +1,41 @@
+/*
+    KPLIB_fnc_civilian_postInit
+
+    File: fn_civilian_postInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-04-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        The postInit function of a module takes care of starting/executing the modules functions or scripts.
+        Basically it starts/initializes the module functionality to make all provided features usable.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module postInit finished [BOOL]
+*/
+
+if (isServer) then {["Module initializing...", "POST] [Civilian", true] call KPLIB_fnc_common_log;};
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {["Module initialized", "POST] [Civilian", true] call KPLIB_fnc_common_log;};
+
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_preInit.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_preInit.sqf
@@ -39,6 +39,15 @@ if (isServer) then {
 
     // Register save event handler
     ["KPLIB_doSave", {[] call KPLIB_fnc_civilian_saveData;}] call CBA_fnc_addEventHandler;
+
+    // Register sector activation event handler
+    ["KPLIB_sector_activated", {[_this select 0] call KPLIB_fnc_civilian_spawn;}] call CBA_fnc_addEventHandler;
+
+    // Register sector captured event handler
+    // ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_civilian_changeOpinion;}] call CBA_fnc_addEventHandler;
+
+    // Register sector deactivation event handler
+    ["KPLIB_sector_deactivated", {[_this select 0] call KPLIB_fnc_civilian_despawn;}] call CBA_fnc_addEventHandler;
 };
 
 // HC section

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_preInit.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_preInit.sqf
@@ -1,0 +1,56 @@
+/*
+    KPLIB_fnc_civilian_preInit
+
+    File: fn_civilian_preInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-04-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        The preInit function defines global variables, adds event handlers and set some vital settings which are used in this module.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module preInit finished [BOOL]
+*/
+
+if (isServer) then {["Module initializing...", "PRE] [Civilian", true] call KPLIB_fnc_common_log;};
+
+/*
+    ----- Module Globals -----
+*/
+
+
+/*
+    ----- Module Initialization -----
+*/
+
+// Process CBA Settings
+[] call KPLIB_fnc_civilian_settings;
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+    // Register load event handler
+    ["KPLIB_doLoad", {[] call KPLIB_fnc_civilian_loadData;}] call CBA_fnc_addEventHandler;
+
+    // Register save event handler
+    ["KPLIB_doSave", {[] call KPLIB_fnc_civilian_saveData;}] call CBA_fnc_addEventHandler;
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {["Module initialized", "PRE] [Civilian", true] call KPLIB_fnc_common_log;};
+
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_saveData.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_saveData.sqf
@@ -1,0 +1,30 @@
+/*
+    KPLIB_fnc_civilian_saveData
+
+    File: fn_civilian_saveData.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-04-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Fetches data which is bound to this module and send it to the global save data array.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+if (KPLIB_param_savedebug) then {["Civilian module saving...", "SAVE"] call KPLIB_fnc_common_log;};
+
+// Set module data to save and send it to the global save data array
+["Civilian",
+    [
+
+    ]
+] call KPLIB_fnc_init_setSaveData;
+
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_settings.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_settings.sqf
@@ -1,0 +1,38 @@
+-/*
+    KPLIB_fnc_civilian_settings
+
+    File: fn_civilian_settings.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-04-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        CBA Settings initialization for this module
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+/*
+    ----- EXAMPLE SETTINGS -----
+*/
+
+// KPLIB_param_example
+// This is an example setting.
+// Default: true
+[
+    "KPLIB_param_civilian_debug",
+    "CHECKBOX",
+    ["Civilian System Debug", "Enable Debug Settings For Civilian Module"],
+    "Civilian",
+    true,
+    1,
+    {}
+] call CBA_Settings_fnc_init;
+
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_spawn.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_spawn.sqf
@@ -1,0 +1,77 @@
+/*
+    KPLIB_fnc_civilian_spawn
+
+    File: fn_civilian_spawn.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2018-10-20
+    Last Update: 2019-04-23
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Handles the spawning of the sector civilians.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_sector", "", [""]]
+];
+
+if (isServer) then {[format ["Spawn Civilians for %1", _sector], "CIVILIAN", true] call KPLIB_fnc_common_log;};
+
+// If sector is not a town or metropolis, do nothing.
+if ([_sector, "city"] call KPLIB_fnc_common_isSectorType || [_sector, "metropolis"] call KPLIB_fnc_common_isSectorType ) then {
+	
+}
+
+
+// Initialize local variables
+private _civilianCount
+
+private _garrison = [_sector] call KPLIB_fnc_garrison_getGarrison;
+private _sectorOwner = _garrison select 1;
+private _sectorOwnerSide = sideEmpty;
+private _soldierCount = _garrison select 2;
+private _squadCount = floor (_soldierCount / 6);
+private _leftSolders = _soldierCount % 6;
+private _lightVehicles = _garrison select 3;
+private _heavyVehicles = _garrison select 4;
+
+// Create active garrison array entry
+KPLIB_garrison_active pushBack [_sector, _sectorOwner, [], [], [], []];
+
+// Get current sector owner
+switch (_sectorOwner) do {
+    case 0;
+    case 1: {_sectorOwnerSide = KPLIB_preset_sideE;};
+    case 2: {_sectorOwnerSide = KPLIB_preset_sideF;};
+    default {_sectorOwnerSide = KPLIB_preset_sideE;};
+};
+
+// Spawn full infantry squads
+for "_i" from 1 to _squadCount do {
+    // Spawn infantry squads with small delays. Otherwise it could cause a small freeze, when there >3 squads at a sector.
+    [{_this call KPLIB_fnc_garrison_spawnSectorInfantry;}, [_sector, _sectorOwner], _i] call CBA_fnc_waitAndExecute;
+};
+
+// Spawn remaining soldiers
+if (_leftSolders > 0) then {
+    [_sector, _sectorOwner, _leftSolders] call KPLIB_fnc_garrison_spawnSectorInfantry;
+};
+
+// Spawn light vehicles
+{
+    [{_this call KPLIB_fnc_garrison_spawnSectorVehicle;}, [_sector, _x, _sectorOwnerSide], _squadCount + _forEachIndex + 1] call CBA_fnc_waitAndExecute;
+} forEach _lightVehicles;
+
+// Spawn heavy vehicles
+{
+    [{_this call KPLIB_fnc_garrison_spawnSectorVehicle;}, [_sector, _x, _sectorOwnerSide, "heavy"], _squadCount + (count _lightvehicles) + _forEachIndex + 1] call CBA_fnc_waitAndExecute;
+} forEach _heavyVehicles;
+
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_spawn.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_spawn.sqf
@@ -25,11 +25,29 @@ params [
 if (isServer) then {[format ["Spawn Civilians for %1", _sector], "CIVILIAN", true] call KPLIB_fnc_common_log;};
 
 // If sector is not a town or metropolis, do nothing.
-if ([_sector, "city"] call KPLIB_fnc_common_isSectorType || [_sector, "metropolis"] call KPLIB_fnc_common_isSectorType ) then {
-
-}
+if !([_sector, "city"] call KPLIB_fnc_common_isSectorType || {[_sector, "metropolis"] call KPLIB_fnc_common_isSectorType} ) exitWith {
+	// RETURN
+	false;
+};
 
 // Initialize local variables
+private _sectorPos = getMarkerPos _sector;
+private _amount = 20; // staticly set to a higher number for testing
+private _civilianArray = [];
+private _spawnPos = _sectorPos getPos [random 200, random 360];
+
+// Avoid spawn position on water
+while {surfaceIsWater _spawnPos} do {
+    _spawnPos = _sectorPos getPos [random 150, random 360];
+};
+
+// Set array to select civilian classnames from
+_civilianArray = ["units", KPLIB_preset_sideC, true] call KPLIB_fnc_common_getPresetClass;
+
+// Grab some random civilian classnames
+for "_i" from 1 to _amount do {
+    _classnames pushBack (selectRandom _civilianArray);
+};
 
 // return
 true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_spawn.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_spawn.sqf
@@ -26,52 +26,10 @@ if (isServer) then {[format ["Spawn Civilians for %1", _sector], "CIVILIAN", tru
 
 // If sector is not a town or metropolis, do nothing.
 if ([_sector, "city"] call KPLIB_fnc_common_isSectorType || [_sector, "metropolis"] call KPLIB_fnc_common_isSectorType ) then {
-	
+
 }
 
-
 // Initialize local variables
-private _civilianCount
 
-private _garrison = [_sector] call KPLIB_fnc_garrison_getGarrison;
-private _sectorOwner = _garrison select 1;
-private _sectorOwnerSide = sideEmpty;
-private _soldierCount = _garrison select 2;
-private _squadCount = floor (_soldierCount / 6);
-private _leftSolders = _soldierCount % 6;
-private _lightVehicles = _garrison select 3;
-private _heavyVehicles = _garrison select 4;
-
-// Create active garrison array entry
-KPLIB_garrison_active pushBack [_sector, _sectorOwner, [], [], [], []];
-
-// Get current sector owner
-switch (_sectorOwner) do {
-    case 0;
-    case 1: {_sectorOwnerSide = KPLIB_preset_sideE;};
-    case 2: {_sectorOwnerSide = KPLIB_preset_sideF;};
-    default {_sectorOwnerSide = KPLIB_preset_sideE;};
-};
-
-// Spawn full infantry squads
-for "_i" from 1 to _squadCount do {
-    // Spawn infantry squads with small delays. Otherwise it could cause a small freeze, when there >3 squads at a sector.
-    [{_this call KPLIB_fnc_garrison_spawnSectorInfantry;}, [_sector, _sectorOwner], _i] call CBA_fnc_waitAndExecute;
-};
-
-// Spawn remaining soldiers
-if (_leftSolders > 0) then {
-    [_sector, _sectorOwner, _leftSolders] call KPLIB_fnc_garrison_spawnSectorInfantry;
-};
-
-// Spawn light vehicles
-{
-    [{_this call KPLIB_fnc_garrison_spawnSectorVehicle;}, [_sector, _x, _sectorOwnerSide], _squadCount + _forEachIndex + 1] call CBA_fnc_waitAndExecute;
-} forEach _lightVehicles;
-
-// Spawn heavy vehicles
-{
-    [{_this call KPLIB_fnc_garrison_spawnSectorVehicle;}, [_sector, _x, _sectorOwnerSide, "heavy"], _squadCount + (count _lightvehicles) + _forEachIndex + 1] call CBA_fnc_waitAndExecute;
-} forEach _heavyVehicles;
-
+// return
 true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_spawnCiv.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_spawnCiv.sqf
@@ -1,0 +1,33 @@
+/*
+    KPLIB_fnc_civilian_spawnCiv
+
+    File: fn_civilian_spawnCiv.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-04
+    Last Update: 2019-09-04
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Handles spawning of a individual civilian on foot.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+
+params [
+    ["_sector", "", [""]]
+];
+
+if (isServer) then {[format ["Despawn for %1", _sector], "CIVILIAN", true] call KPLIB_fnc_common_log;};
+
+// Initialize local variables
+
+// Spawn Civ
+
+// Return
+true

--- a/Missionframework/modules/20_civilian/fnc/fn_civilian_spawnVeh.sqf
+++ b/Missionframework/modules/20_civilian/fnc/fn_civilian_spawnVeh.sqf
@@ -1,0 +1,35 @@
+/*
+    KPLIB_fnc_civilian_spawnVeh
+
+    File: fn_civilian_spawnVeh.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-04
+    Last Update: 2019-09-04
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Handles spawning of a individual civilian vehicle empty, or manned.
+
+    Parameter(s):
+        _sector - Markername of the sector [STRING, defaults to ""]
+		_empty - Should veh be empty [BOOL, defaults to true]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+
+params [
+    ["_sector", "", [""]],
+	["_empty", true, [true]]
+];
+
+if (isServer) then {[format ["Despawn for %1", _sector], "CIVILIAN", true] call KPLIB_fnc_common_log;};
+
+// Initialize local variables
+
+// Spawn Veh
+
+// Return
+true

--- a/Missionframework/modules/20_civilian/functions.hpp
+++ b/Missionframework/modules/20_civilian/functions.hpp
@@ -32,4 +32,5 @@ class civilian {
 
     // CBA Settings for this module
     class civilian_settings {};
+    
 };

--- a/Missionframework/modules/20_civilian/functions.hpp
+++ b/Missionframework/modules/20_civilian/functions.hpp
@@ -1,0 +1,35 @@
+/*
+    KP LIBERATION MODULE FUNCTIONS
+
+    File: functions.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-02-02
+    Last Update: 2019-02-18
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+        Defines for all functions, which are brought by this module.
+*/
+
+class civilian {
+    file = "modules\20_civilian\fnc";
+
+    // Loads module specific data from the save
+    class civilian_loadData {};
+
+    // Module post initialization
+    class civilian_postInit {
+        postInit = 1;
+    };
+
+    // Module pre initialization
+    class civilian_preInit {
+        preInit = 1;
+    };
+
+    // Saves module specific data for the save
+    class civilian_saveData {};
+
+    // CBA Settings for this module
+    class civilian_settings {};
+};

--- a/Missionframework/modules/20_civilian/functions.hpp
+++ b/Missionframework/modules/20_civilian/functions.hpp
@@ -32,5 +32,20 @@ class civilian {
 
     // CBA Settings for this module
     class civilian_settings {};
-    
+
+    // Despawn civilians on sector deactivation
+    class civilian_despawn {};
+
+    // Spawn civilians on sector activation
+    class civliian_spawn {};
+
+    // Spawn a single civ agent on foot
+    class civilian_spawnCiv {};
+
+    // Spawn a civilian vehicle (empty, or manned)
+    class civilian_spawnVeh {};
+
+    // Spawn a crowd of civilians in intersection??
+    class civilian_spawnCrowd {};
+
 };


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes <!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | untested <!-- set to yes if save needs to be wiped to use new feature --> |
| Fixed issues | #527  <!-- #-prefixed issue number(s), if any --> |

### Description:

This is the first draft of what will be the civilian presence module.
This module should handle the spawning of a ambient civilian presence when activating civilian type sectors.
This module will handle the civilian opinion of the BLUFOR faction.
This module will handle civilian agent logic (Wandering / Driving).


### Content:
- [ ] Civilian spawn on Sector Activation (Civilian Sector Type)
- [ ] Civilian vehicles spawn on Sector Activation (Empty / Driving)
- [ ] Civilians wander the sector.
- [ ] Civilian vehicles drive around the sector.
<!--
Add things which are part of this pull request as checkboxes
to show if it's already finished and already part of the pull request.
-->

### Successfully tested on:
- [ ] Local MP
- [ ] Dedicated MP

<!--
As soon as you've tested your feature on the listed environment you can check the checkbox.
It has to work without any issues and errors in your own tests.
Especially if you open a PR as WIP and not after you've fully finished your work, remember to update the states accordingly.
-->

### Compatibility checked with:

<!--
Add a list of Mods you've checked. This should only contain mods which really affect the feature.
So for a feature like e.g. "hint on entering a sector area" you don't list/test compatibility with RHS, ACE, Achilles, etc.
Also listing CBA isn't necessary, as it's a general dependency in Liberation.
-->
