### PR TITLE
v0.96.6 - Increasing sector despawn time

### DIFF
--- a/Missionframework/scripts/server/sector/manage_one_sector.sqf
+++ b/Missionframework/scripts/server/sector/manage_one_sector.sqf
@@ -283,7 +283,7 @@ if ((!(_sector in blufor_sectors)) && (([getmarkerpos _sector, [_opforcount] cal
 				private _additionalTickets = (_runningMinutes * BASE_TICKETS);
 
 				// clamp from 0 to "_maximum_additional_tickets"
-				_additionalTickets = (_additionalTickets max 0) min _maximum_additional_tickets
+				_additionalTickets = (_additionalTickets max 0) min _maximum_additional_tickets;
 
 				_sector_despawn_tickets = BASE_TICKETS + _additionalTickets;
 			};

--- a/Missionframework/scripts/server/sector/manage_one_sector.sqf
+++ b/Missionframework/scripts/server/sector/manage_one_sector.sqf
@@ -1,3 +1,11 @@
+// base amount of sector lifetime tickets
+// if there are no enemies one ticket is removed every SECTOR_TICK_TIME seconds
+// 12 * 5 = 60s by default
+#define BASE_TICKETS				12
+#define SECTOR_TICK_TIME			5
+// delay in minutes from which addional time will be added
+#define ADDITIONAL_TICKETS_DELAY	5
+
 params ["_sector"];
 
 waitUntil {!isNil "combat_readiness"};
@@ -19,7 +27,8 @@ private _squad2 = [];
 private _squad3 = [];
 private _squad4 = [];
 private _minimum_building_positions = 5;
-private _sector_despawn_tickets = 12;
+private _sector_despawn_tickets = BASE_TICKETS;
+private _maximum_additional_tickets = (KP_liberation_delayDespawnMax * 60 / SECTOR_TICK_TIME)
 private _popfactor = 1;
 private _guerilla = false;
 
@@ -162,7 +171,7 @@ if ((!(_sector in blufor_sectors)) && (([getmarkerpos _sector, [_opforcount] cal
 		_building_ai_max = 0;
 	};
 
-    _vehtospawn = _vehtospawn select {!(isNil "_x")};
+	_vehtospawn = _vehtospawn select {!(isNil "_x")};
 
 	if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector calculated -> _infsquad: %3 - _squad1: %4 - _squad2: %5 - _squad3: %6 - _squad4: %7 - _vehtospawn: %8 - _building_ai_max: %9", (markerText _sector), _sector, _infsquad, (count _squad1), (count _squad2), (count _squad3), (count _squad4), (count _vehtospawn), _building_ai_max];_text remoteExec ["diag_log",2];};
 
@@ -235,7 +244,10 @@ if ((!(_sector in blufor_sectors)) && (([getmarkerpos _sector, [_opforcount] cal
 
 	if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - populating done at %3", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};
 
+	private _activationTime = time;
+	// sector lifetime loop
 	while {!_stopit} do {
+		// sector was captured
 		if (([_sectorpos, _local_capture_size] call F_sectorOwnership == GRLIB_side_friendly) && (GRLIB_endgame == 0)) then {
 			if (isServer) then {
 				[_sector] spawn sector_liberated_remote_call;
@@ -266,7 +278,14 @@ if ((!(_sector in blufor_sectors)) && (([getmarkerpos _sector, [_opforcount] cal
 			if (([_sectorpos, (([_opforcount] call F_getCorrectedSectorRange) + 300), GRLIB_side_friendly] call F_getUnitsCount) == 0) then {
 				_sector_despawn_tickets = _sector_despawn_tickets - 1;
 			} else {
-				_sector_despawn_tickets = 12;
+				// start counting running minutes after ADDITIONAL_TICKETS_DELAY
+				private _runningMinutes = (floor ((time - _activationTime) / 60)) - ADDITIONAL_TICKETS_DELAY;
+				private _additionalTickets = (_runningMinutes * BASE_TICKETS);
+
+				// clamp from 0 to "_maximum_additional_tickets"
+				_additionalTickets = (_additionalTickets max 0) min _maximum_additional_tickets
+
+				_sector_despawn_tickets = BASE_TICKETS + _additionalTickets;
 			};
 
 			if (_sector_despawn_tickets <= 0) then {
@@ -282,7 +301,7 @@ if ((!(_sector in blufor_sectors)) && (([getmarkerpos _sector, [_opforcount] cal
 				active_sectors = active_sectors - [_sector]; publicVariable "active_sectors";
 			};
 		};
-		sleep 5;
+		sleep SECTOR_TICK_TIME;
 	};
 } else {
 	sleep 40;

--- a/Missionframework/scripts/server/sector/manage_one_sector.sqf
+++ b/Missionframework/scripts/server/sector/manage_one_sector.sqf
@@ -28,7 +28,7 @@ private _squad3 = [];
 private _squad4 = [];
 private _minimum_building_positions = 5;
 private _sector_despawn_tickets = BASE_TICKETS;
-private _maximum_additional_tickets = (KP_liberation_delayDespawnMax * 60 / SECTOR_TICK_TIME)
+private _maximum_additional_tickets = (KP_liberation_delayDespawnMax * 60 / SECTOR_TICK_TIME);
 private _popfactor = 1;
 private _guerilla = false;
 

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -50,6 +50,7 @@ if(isServer) then {
     GET_PARAM(KP_liberation_restart, "ServerRestart", 0);
     GET_PARAM(KP_liberation_respawn_cooldown, "RespawnCooldown", 900);
     GET_PARAM(KP_liberation_victoryCondition, "VictoryCondition", 0);
+    GET_PARAM(KP_liberation_delayDespawnMax, "DelayDespawnMax", 5);
 
     GET_PARAM_BOOL(KP_liberation_cr_param_buildings, "CR_Building", 0);
     GET_PARAM_BOOL(KP_liberation_ailogistics, "AiLogistics", 1);

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2422,6 +2422,9 @@
             <Portuguese>Remover carga do veículo requisitado</Portuguese>
             <Chinese>移除載具上的物品</Chinese>
         </Key>
+        <Key ID="STR_PARAM_DELAY_DESPAWN_MAX">
+            <Original>Maximum sector deactivation delay (starts increasing after 5th activation minute)</Original>
+        </Key>
         <Key ID="STR_DEPLOY_IN_PROGRESS">
             <Original>Deployment in progress...</Original>
             <French>Déploiement en cours...</French>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2424,6 +2424,7 @@
         </Key>
         <Key ID="STR_PARAM_DELAY_DESPAWN_MAX">
             <Original>Maximum sector deactivation delay (starts increasing after 5th activation minute)</Original>
+            <German>Maximale Verzögerung zur Sektor Deaktivierung (Beginnt nach 5 Minuten seit Aktivierung)</German>
         </Key>
         <Key ID="STR_DEPLOY_IN_PROGRESS">
             <Original>Deployment in progress...</Original>

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -264,6 +264,12 @@ class Params
         texts[] = { $STR_PARAMS_ENABLED, $STR_PARAMS_DISABLED };
         default = 1;
     };
+    class DelayDespawnMax {
+        title = $STR_PARAM_DELAY_DESPAWN_MAX;
+        values[] = {0,5,10,15,30};
+        texts[] = {$STR_PARAMS_DISABLED,"5","10", "15","30"};
+        default = 5;
+    };
     class Spacer3 {
         title = "";
         values[] = { "" };

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -266,8 +266,8 @@ class Params
     };
     class DelayDespawnMax {
         title = $STR_PARAM_DELAY_DESPAWN_MAX;
-        values[] = {0,5,10,15,30};
-        texts[] = {$STR_PARAMS_DISABLED,"5","10", "15","30"};
+        values[] = {0,5,10,15,20,25,30};
+        texts[] = {$STR_PARAMS_DISABLED, "5", "10", "15", "20", "25", "30"};
         default = 5;
     };
     class Spacer3 {

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ class Missions
 * Added: [Swedish Forces Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=826911897) transport configs. Thanks to [Dahlgren](https://github.com/Dahlgren)
 * Added: Parameter to enable/disable the vanilla A3 dynamic fog behavior. Default enabled, so `fucking_set_fog.sqf` isn't running by default.
 * Added: Parameter to decide to start the campaign with a FOB container (default, like before) or a FOB truck.
+* Added: Sector despawn scaling. The longer sector is activated the longer it de-activates. Configurable as parameter, 5min additional delay max by default.
 * Updated: Russian localization. Thanks to [DjHaski](https://github.com/DjHaski)
 * Tweaked: Initial FOB box doesn't have equipment in the inventory anmore.
 * Tweaked: Height check for mobile respawn now relies on `isTouchingGround` instead of z value of position.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | - |

### Description:
Makes sector despawn time more dynamic by increasing the time of sector deactivation delay by multiplying default deactivation time by the amount of minutes the sector was activated, starting from fifth activation minute. 

Increased despawn time is added to base despawn time.

```
IF minutes_running < 5:
    despawn_time = BASE_DESPAWN_TIME
ELSE
    despawn_time = BASE_DESPAWN_TIME + ((minutes_running - 5) * BASE_DESPAWN_TIME )
```

`BASE_DESPAWN_TIME` is ~60s by default (depending on scheduler load)

### Content:
- [x] Increasing despawn time functionality
- [x] Maximum increased despawn time parameter, 5 mins default

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP


### Compatibility checked with:
* Nothing
