### PR TITLE
V0.96.6 dynamic building ai range

### DIFF
--- a/Missionframework/scripts/server/ai/building_defence_ai.sqf
+++ b/Missionframework/scripts/server/ai/building_defence_ai.sqf
@@ -6,34 +6,34 @@ private _move_is_disabled = true;
 private _resume_movement = false;
 
 while {_move_is_disabled && local _unit && alive _unit && !(captive _unit)} do {
-	private _hostilecount = {alive _x && side _x == GRLIB_side_friendly} count ((getpos _unit) nearEntities [["Man"], 40]);
+    private _hostilecount = {alive _x && side _x == GRLIB_side_friendly} count ((getpos _unit) nearEntities [["Man"], 40]);
 
-	if ((_hostilecount > 0) || (damage _unit > 0.25)) then {
-		_resume_movement = true;
-	};
+    if ((_hostilecount > 0) || (damage _unit > 0.25)) then {
+        _resume_movement = true;
+    };
 
-	if (_sector != "") then {
-		if (_sector in blufor_sectors) then {
-			_resume_movement = true;
-		};
-	};
+    if (_sector != "") then {
+        if (_sector in blufor_sectors) then {
+            _resume_movement = true;
+        };
+    };
 
-	if (_resume_movement) then {
-		if (_move_is_disabled) then {
-			_move_is_disabled = false;
-			_unit enableAI "MOVE";
-			_unit setUnitPos "AUTO";
-		};
-	};
+    if (_resume_movement) then {
+        if (_move_is_disabled) then {
+            _move_is_disabled = false;
+            _unit enableAI "MOVE";
+            _unit setUnitPos "AUTO";
+        };
+    };
 
-	if (_move_is_disabled) then {
-		private _target = assignedTarget _unit;
-		if(!(isnull _target)) then {
-			private _vd = (getPosASL _target) vectorDiff (getpos _unit);
-			private _newdir = (_vd select 0) atan2 (_vd select 1);
-			if (_newdir < 0) then {_dir = 360 + _newdir};
-			_unit setdir (_newdir);
-		};
-	};
-	sleep 5;
+    if (_move_is_disabled) then {
+        private _target = assignedTarget _unit;
+        if(!(isnull _target)) then {
+            private _vd = (getPosASL _target) vectorDiff (getpos _unit);
+            private _newdir = (_vd select 0) atan2 (_vd select 1);
+            if (_newdir < 0) then {_dir = 360 + _newdir};
+            _unit setdir (_newdir);
+        };
+    };
+    sleep 5;
 };

--- a/Missionframework/scripts/server/ai/building_defence_ai.sqf
+++ b/Missionframework/scripts/server/ai/building_defence_ai.sqf
@@ -3,27 +3,30 @@ params ["_unit", ["_sector", ""]];
 _unit setUnitPos "UP";
 _unit disableAI "MOVE";
 private _move_is_disabled = true;
-private _resume_movement = false;
+private _hostiles = 0;
+private _ratio = 0.4;
+private _range = 40;
 
 while {_move_is_disabled && local _unit && alive _unit && !(captive _unit)} do {
-    private _hostilecount = {alive _x && side _x == GRLIB_side_friendly} count ((getpos _unit) nearEntities [["Man"], 40]);
 
-    if ((_hostilecount > 0) || (damage _unit > 0.25)) then {
-        _resume_movement = true;
+    if !(_sector isEqualTo "") then {
+        _ratio = [_sector] call F_getForceRatio;
     };
 
-    if (_sector != "") then {
-        if (_sector in blufor_sectors) then {
-            _resume_movement = true;
-        };
-    };
+    _range = floor (linearConversion [0, 1, _ratio, 0, GRLIB_capture_size / 3 * 2, true]);
 
-    if (_resume_movement) then {
-        if (_move_is_disabled) then {
-            _move_is_disabled = false;
-            _unit enableAI "MOVE";
-            _unit setUnitPos "AUTO";
-        };
+    _hostiles = ((getPos _unit) nearEntities [["Man"], _range]) select {side _x == GRLIB_side_friendly};
+
+    if (_move_is_disabled &&
+        {
+            (_sector in blufor_sectors) ||
+            {!(_hostiles isEqualTo [])} ||
+            {damage _unit > 0.25}
+        }
+    ) then {
+        _move_is_disabled = false;
+        _unit enableAI "MOVE";
+        _unit setUnitPos "AUTO";
     };
 
     if (_move_is_disabled) then {

--- a/Missionframework/scripts/shared/functions/F_kp_createClearance.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createClearance.sqf
@@ -9,8 +9,8 @@ params [
 if (save_is_loaded && {(KP_liberation_clearances findIf {(_x select 0) isEqualTo _centerPos}) != -1}) exitWith {false};
 
 {
+    _x switchLight "OFF";
     _x hideObjectGlobal true;
-    _x enableSimulationGlobal false;
     _x allowDamage false;
 } forEach (nearestTerrainObjects [_centerPos, [], _radius, false, true]);
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ class Missions
 * Tweaked: Initial FOB box doesn't have equipment in the inventory anmore.
 * Tweaked: Height check for mobile respawn now relies on `isTouchingGround` instead of z value of position.
 * Tweaked: Transport config heights on M977 vehicles. Thanks to [FishAI](https://github.com/FishAI)
+* Tweaked: AI in building now has a dynamic radius to look for enemies until they start moving again depending on blufor/opfor ratio in sector.
 * Fixed: Potato 01 was created after server restart, even if there was one saved.
 * Fixed: Missing variable `stats_blufor_teamkills_by_players`. Also no separation between by players or not by players for teamkills anymore.
 * Fixed: Factory storages could disappear randomly on save load.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ class Missions
 * Fixed: CUP Presets still had the Nemmera in the support vehicle section. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: FOB resources weren't updated in build dialog, when building infantry units.
 * Fixed: Some missing parameter information in the map screens parameter overview.
+* Fixed: After creating a clearance at a FOB some light sources could remain.
 
 ### 0.96.5 (26th July 2019 due to Contacts Release)
 * Added: Contact DLC LDF preset.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | #662 |

### Description:
With this addition the enemies in buildings are not bound to a fixed 40m search radius for blufor soldiers until they resume their normal movement.
It's now bound to the opfor/blufor ratio and increases if the amount of blufor in relation to the amount of living opfor soldiers raise. It goes up to a maximum if 2/3 of the sectors capture range, set in the config file. (~120m search radius max)
This should make it easier to clean cities if there are only some few enemies left hidden in buildings.

Also a small fix for the remaining light sources after creating a clearance. (#662)

### Content:
- [x] Dynamic range for near enemy search of building ai
- [x] Fixed light sources are still on after creating a clearance

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP