### PR TITLE
Prisoners of War

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,6 +66,7 @@
         "KPLIB_param_sectorActRange",
         "KPLIB_param_sectorCap",
         "KPLIB_param_sectorCapRange",
+        "KPLIB_param_sectorCapRatio",
         "KPLIB_param_stamina",
         "KPLIB_param_subCommanderZeusMode",
         "KPLIB_param_timeMulti",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,8 @@
         "KPLIB_param_aceResupply",
         "KPLIB_param_ammoInfluence",
         "KPLIB_param_arsenalType",
+        "KPLIB_param_captiveIntel",
+        "KPLIB_param_captiveIntelRandom",
         "KPLIB_param_clearVehicleCargo",
         "KPLIB_param_commanderZeusMode",
         "KPLIB_param_copyDistance",

--- a/Missionframework/KPLIB_functions.hpp
+++ b/Missionframework/KPLIB_functions.hpp
@@ -4,7 +4,7 @@
     File: KPLIB_functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-16
-    Last Update: 2019-06-22
+    Last Update: 2019-09-10
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -30,5 +30,6 @@ class KPLIB {
     #include "modules\24_enemy\functions.hpp"
     #include "modules\26_cratefiller\functions.hpp"
     #include "modules\27_mission\functions.hpp"
+    #include "modules\28_captive\functions.hpp"
     #include "modules\90_missions\functions.hpp"
 };

--- a/Missionframework/modules/01_common/fnc/fn_common_addAction.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_addAction.sqf
@@ -4,7 +4,7 @@
     File: fn_common_addAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-05
-    Last Update: 2019-03-30
+    Last Update: 2019-09-19
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: Yes
 
@@ -13,10 +13,10 @@
         This should be used if adding an action to an object to ensure the localization is correct.
 
     Parameter(s):
-        _target - Object to add the action to                                   [OBJECT, defaults to objNull]
-        _string - Stringtable string key for the action                         [STRING, defaults to ""]
-        _args   - Array of all other arguments for addAction without the title  [ARRAY, defaults to []]
-        _color  - Hex code of desired color e.g. #FF8000. Optional.             [STRING, defaults to ""]
+        _target - Object to add the action to                                       [OBJECT, defaults to objNull]
+        _string - Stringtable string key or string/variable array for the action    [STRING/ARRAY, defaults to ""]
+        _args   - Array of all other arguments for addAction without the title      [ARRAY, defaults to []]
+        _color  - Hex code of desired color e.g. #FF8000. Optional.                 [STRING, defaults to ""]
 
     Returns:
         Action added [BOOL]
@@ -24,7 +24,7 @@
 
 params [
     ["_target", objNull, [objNull]],
-    ["_string", "", [""]],
+    ["_string", "", ["", []]],
     ["_args", [], [[]], []],
     ["_color", "", [""]]
 ];
@@ -32,8 +32,14 @@ params [
 // Leave if there are parameters missing
 if (isNull _target || _string isEqualTo "" || _args isEqualTo []) exitWith {false};
 
-// Localize local to clients language
-_string = localize _string;
+// Check if given string is string key or formatted text
+if (_string isEqualType "") then {
+    // Localize local to clients language
+    _string = localize _string;
+} else {
+    _string set [0, localize (_string select 0)];
+    _string = format _string;
+};
 
 // Add color, if provided
 if !(_color isEqualTo "") then {

--- a/Missionframework/modules/01_common/fnc/fn_common_addAction.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_addAction.sqf
@@ -4,7 +4,7 @@
     File: fn_common_addAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-05
-    Last Update: 2019-09-24
+    Last Update: 2019-09-28
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: Yes
 
@@ -30,15 +30,14 @@ params [
 ];
 
 // Leave if there are parameters missing
-if (isNull _target || _string isEqualTo "" || _args isEqualTo []) exitWith {false};
+if (isNull _target || _string isEqualTo "" || _args isEqualTo []) exitWith {-1};
 
 // Check if given string is string key or formatted text
 if (_string isEqualType "") then {
     // Localize local to clients language
     _string = localize _string;
 } else {
-    _string set [0, localize (_string select 0)];
-    _string = format _string;
+    _string = format [localize (_string select 0), _string select 1];
 };
 
 // Add color, if provided

--- a/Missionframework/modules/01_common/fnc/fn_common_addAction.sqf
+++ b/Missionframework/modules/01_common/fnc/fn_common_addAction.sqf
@@ -4,7 +4,7 @@
     File: fn_common_addAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-12-05
-    Last Update: 2019-09-19
+    Last Update: 2019-09-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: Yes
 
@@ -19,7 +19,7 @@
         _color  - Hex code of desired color e.g. #FF8000. Optional.                 [STRING, defaults to ""]
 
     Returns:
-        Action added [BOOL]
+        Action ID [NUMBER]
 */
 
 params [
@@ -51,6 +51,4 @@ private _actionArray = [_string];
 _actionArray append _args;
 
 // Add action to target
-_target addAction _actionArray;
-
-true
+_target addAction _actionArray

--- a/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
@@ -31,9 +31,14 @@ private _handler = [
         // If there are no enemy units in two times the capture range and friendly units are in capture range
         // capture the sector
         if (
-            ({side _x isEqualTo KPLIB_preset_sideF} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange])) >
-            ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange]))
-            * KPLIB_param_sectorCapRatio
+            (
+                ({side _x isEqualTo KPLIB_preset_sideF} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange])) >
+                ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange * 2]))
+                * KPLIB_param_sectorCapRatio
+            ) && (
+                ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["Tank", KPLIB_param_sectorCapRange * 2]))
+                isEqualTo 0
+            )
         ) then {
             [format ["Sector %1 (%2) captured", markerText _sector, _sector], "CORE", true] call KPLIB_fnc_common_log;
 

--- a/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
@@ -4,7 +4,7 @@
     File: fn_core_handleSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-06
-    Last Update: 2019-09-10
+    Last Update: 2019-09-28
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -33,10 +33,10 @@ private _handler = [
         if (
             (
                 ({side _x isEqualTo KPLIB_preset_sideF} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange])) >
-                ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange * 2]))
+                ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange * 1.5]))
                 * KPLIB_param_sectorCapRatio
             ) && (
-                ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["Tank", KPLIB_param_sectorCapRange * 2]))
+                ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["Tank", KPLIB_param_sectorCapRange * 1.5]))
                 isEqualTo 0
             )
         ) then {

--- a/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
@@ -4,7 +4,7 @@
     File: fn_core_handleSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-06
-    Last Update: 2019-09-28
+    Last Update: 2019-09-29
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -28,17 +28,18 @@ private _handler = [
         // Per Tick
         _this getVariable "params" params ["_sector", "_sectorPos"];
 
-        // If there are no enemy units in two times the capture range and friendly units are in capture range
+        // If the enemy units within capture range are outnumbered and there are no enemy tanks
         // capture the sector
+        // ToDo: optimize
         if (
             (
                 ({side _x isEqualTo KPLIB_preset_sideF} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange])) >
                 ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange * 1.5]))
                 * KPLIB_param_sectorCapRatio
-            ) && (
+            ) && {
                 ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["Tank", KPLIB_param_sectorCapRange * 1.5]))
                 isEqualTo 0
-            )
+            }
         ) then {
             [format ["Sector %1 (%2) captured", markerText _sector, _sector], "CORE", true] call KPLIB_fnc_common_log;
 

--- a/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_handleSector.sqf
@@ -4,7 +4,7 @@
     File: fn_core_handleSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-06
-    Last Update: 2019-04-22
+    Last Update: 2019-09-10
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -31,8 +31,9 @@ private _handler = [
         // If there are no enemy units in two times the capture range and friendly units are in capture range
         // capture the sector
         if (
-            !([_sectorPos, 2 * KPLIB_param_sectorCapRange, [KPLIB_preset_sideE]] call KPLIB_fnc_core_areUnitsNear)
-            && {[_sectorPos, KPLIB_param_sectorCapRange] call KPLIB_fnc_core_areUnitsNear}
+            ({side _x isEqualTo KPLIB_preset_sideF} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange])) >
+            ({side _x isEqualTo KPLIB_preset_sideE} count (_sectorPos nearEntities ["AllVehicles", KPLIB_param_sectorCapRange]))
+            * KPLIB_param_sectorCapRatio
         ) then {
             [format ["Sector %1 (%2) captured", markerText _sector, _sector], "CORE", true] call KPLIB_fnc_common_log;
 

--- a/Missionframework/modules/02_core/fnc/fn_core_settings.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_settings.sqf
@@ -4,7 +4,7 @@
     File: fn_core_settings.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-11-11
-    Last Update: 2019-06-15
+    Last Update: 2019-09-10
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -57,6 +57,19 @@
     [localize "STR_KPLIB_SETTINGS_SECTOR_SECRANGE", localize "STR_KPLIB_SETTINGS_SECTOR_SECRANGE_TT"],
     localize "STR_KPLIB_SETTINGS_SECTOR",
     [100, 200, 150, 0],
+    1,
+    {}
+] call CBA_Settings_fnc_init;
+
+// KPLIB_param_sectorCapRatio
+// Ratio of enemy units to friendly units, which is needed to capture a sector.
+// Default: 1.5
+[
+    "KPLIB_param_sectorCapRatio",
+    "SLIDER",
+    [localize "STR_KPLIB_SETTINGS_SECTOR_SECRATIO", localize "STR_KPLIB_SETTINGS_SECTOR_SECRATIO_TT"],
+    localize "STR_KPLIB_SETTINGS_SECTOR",
+    [1, 10, 1.5, 1],
     1,
     {}
 ] call CBA_Settings_fnc_init;

--- a/Missionframework/modules/02_core/fnc/fn_core_setupPlayerActions.sqf
+++ b/Missionframework/modules/02_core/fnc/fn_core_setupPlayerActions.sqf
@@ -4,7 +4,7 @@
     File: fn_common_setupPlayerActions.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-05-28
-    Last Update: 2019-04-22
+    Last Update: 2019-09-12
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -19,7 +19,7 @@
 */
 
 // Actions avalible LOCALLY to player
-if(hasInterface) then {
+if (hasInterface) then {
     // FOB redeploy action
     private _fobRedeployCondition = '_target isEqualTo _originalTarget && !(_originalTarget getVariable ["KPLIB_fob", ""] isEqualTo "")';
     private _actionArray = [localize "STR_KPLIB_ACTION_REDEPLOY", {["KPLIB_respawn_requested", _this] call CBA_fnc_localEvent}, nil, -801, false, true, "", _fobRedeployCondition, 10];

--- a/Missionframework/modules/15_build/README.md
+++ b/Missionframework/modules/15_build/README.md
@@ -99,3 +99,6 @@ Furthermore it handles the saving/loading of all objects which are buildable/spa
 
 ### Scripts
 No scripts will be started by this module
+
+### Implemented permissions
+* Build menu

--- a/Missionframework/modules/16_garrison/README.md
+++ b/Missionframework/modules/16_garrison/README.md
@@ -50,3 +50,6 @@ It'll also provide functions to change garrison data and a garrison management d
 
 ### Scripts
 No scripts will be started by this module
+
+### Implemented permissions
+* Garrison management

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_changeOwner.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_changeOwner.sqf
@@ -30,13 +30,6 @@ private _persistentGarrisonRef = [_sector] call KPLIB_fnc_garrison_getGarrison;
 // Switch owner
 private _newOwner = [2, 0] select ((_persistentGarrisonRef select 1) isEqualTo 2);
 
-// Clear the garrison units on sector change to BLUFOR, to ensure that captives won't be Deleted
-if (_newOwner isEqualTo 2) then {
-    _persistentGarrisonRef set [2, []];
-    _persistentGarrisonRef set [3, []];
-    _persistentGarrisonRef set [4, []];
-};
-
 // Update persistent garrison
 _persistentGarrisonRef set [1, _newOwner];
 

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_changeOwner.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_changeOwner.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_changeOwner.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-23
-    Last Update: 2019-03-30
+    Last Update: 2019-09-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: Yes
 
@@ -29,6 +29,13 @@ private _persistentGarrisonRef = [_sector] call KPLIB_fnc_garrison_getGarrison;
 
 // Switch owner
 private _newOwner = [2, 0] select ((_persistentGarrisonRef select 1) isEqualTo 2);
+
+// Clear the garrison units on sector change to BLUFOR, to ensure that captives won't be Deleted
+if (_newOwner isEqualTo 2) then {
+    _persistentGarrisonRef set [2, []];
+    _persistentGarrisonRef set [3, []];
+    _persistentGarrisonRef set [4, []];
+};
 
 // Update persistent garrison
 _persistentGarrisonRef set [1, _newOwner];

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_changeOwner.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_changeOwner.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_changeOwner.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-23
-    Last Update: 2019-09-16
+    Last Update: 2019-09-28
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: Yes
 

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -40,7 +40,7 @@ private _heavyVeh = [];
         deleteVehicle _x;
         _infantry = _infantry + 1;
     };
-} forEach ((_activeGarrisonRef select 2) select {!(_x getVariable ["KPLIB_captured, false"])});
+} forEach ((_activeGarrisonRef select 2) select {!(_x getVariable ["KPLIB_captured", false])});
 
 /* !NOTE!
     With the current despawn checks for the vehicles, the vehicle won't be deleted if it's a wreck or the crew bailed out due to damage.
@@ -54,7 +54,7 @@ private _heavyVeh = [];
         if (!((crew _x) isEqualTo []) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
             _vehicle = _x;
             _lightVeh pushBack (typeOf _x);
-            {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured, false"])});
+            {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured", false])});
         };
         deleteVehicle _x;
     };
@@ -65,7 +65,7 @@ private _heavyVeh = [];
     if ((alive _x) && !((crew _x) isEqualTo []) && !(_x getVariable ["KPLIB_captured", false])) then {
         _vehicle = _x;
         _heavyVeh pushBack (typeOf _x);
-        {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured, false"])});
+        {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured", false])});
         deleteVehicle _vehicle;
     };
 } forEach (_activeGarrisonRef select 4);
@@ -76,7 +76,7 @@ private _heavyVeh = [];
         deleteVehicle _x;
         _infantry = _infantry + 1;
     };
-} forEach ((_activeGarrisonRef select 5) select {!(_x getVariable ["KPLIB_captured, false"])});
+} forEach ((_activeGarrisonRef select 5) select {!(_x getVariable ["KPLIB_captured", false])});
 
 // Update persistent garrison data
 if ((_activeGarrisonRef select 1) isEqualTo (_persistentGarrisonRef select 1)) then {

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_despawn.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-20
-    Last Update: 2019-09-16
+    Last Update: 2019-09-29
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -54,7 +54,10 @@ private _heavyVeh = [];
         if (!((crew _x) isEqualTo []) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
             _vehicle = _x;
             _lightVeh pushBack (typeOf _x);
-            {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured", false])});
+            {
+                _handledCrew pushBack _x;
+                _vehicle deleteVehicleCrew _x;
+            } forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured", false])});
         };
         deleteVehicle _x;
     };
@@ -65,7 +68,10 @@ private _heavyVeh = [];
     if ((alive _x) && !((crew _x) isEqualTo []) && !(_x getVariable ["KPLIB_captured", false])) then {
         _vehicle = _x;
         _heavyVeh pushBack (typeOf _x);
-        {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured", false])});
+        {
+            _handledCrew pushBack _x;
+            _vehicle deleteVehicleCrew _x;
+        } forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured", false])});
         deleteVehicle _vehicle;
     };
 } forEach (_activeGarrisonRef select 4);

--- a/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
+++ b/Missionframework/modules/16_garrison/fnc/fn_garrison_despawn.sqf
@@ -4,7 +4,7 @@
     File: fn_garrison_despawn.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-10-20
-    Last Update: 2019-05-04
+    Last Update: 2019-09-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -40,7 +40,7 @@ private _heavyVeh = [];
         deleteVehicle _x;
         _infantry = _infantry + 1;
     };
-} forEach (_activeGarrisonRef select 2);
+} forEach ((_activeGarrisonRef select 2) select {!(_x getVariable ["KPLIB_captured, false"])});
 
 /* !NOTE!
     With the current despawn checks for the vehicles, the vehicle won't be deleted if it's a wreck or the crew bailed out due to damage.
@@ -54,7 +54,7 @@ private _heavyVeh = [];
         if (!((crew _x) isEqualTo []) && !(_x in (KPLIB_preset_vehTransPlE + KPLIB_preset_vehLightUnarmedPlE))) then {
             _vehicle = _x;
             _lightVeh pushBack (typeOf _x);
-            {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach (crew _x);
+            {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured, false"])});
         };
         deleteVehicle _x;
     };
@@ -65,7 +65,7 @@ private _heavyVeh = [];
     if ((alive _x) && !((crew _x) isEqualTo []) && !(_x getVariable ["KPLIB_captured", false])) then {
         _vehicle = _x;
         _heavyVeh pushBack (typeOf _x);
-        {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach (crew _x);
+        {_handledCrew pushBack _x; _vehicle deleteVehicleCrew _x;} forEach ((crew _x) select {!(_x getVariable ["KPLIB_captured, false"])});
         deleteVehicle _vehicle;
     };
 } forEach (_activeGarrisonRef select 4);
@@ -76,7 +76,7 @@ private _heavyVeh = [];
         deleteVehicle _x;
         _infantry = _infantry + 1;
     };
-} forEach (_activeGarrisonRef select 5);
+} forEach ((_activeGarrisonRef select 5) select {!(_x getVariable ["KPLIB_captured, false"])});
 
 // Update persistent garrison data
 if ((_activeGarrisonRef select 1) isEqualTo (_persistentGarrisonRef select 1)) then {

--- a/Missionframework/modules/26_cratefiller/README.md
+++ b/Missionframework/modules/26_cratefiller/README.md
@@ -116,3 +116,6 @@ Calls KPLIB_fnc_cratefiller_presets to process the new white- and blacklist
 
 ### Scripts
 No scripts will be started by this module
+
+### Implemented permissions
+* Cratefiller

--- a/Missionframework/modules/27_mission/README.md
+++ b/Missionframework/modules/27_mission/README.md
@@ -89,3 +89,6 @@ Processes a mission start or abort dependent on the passed arguments
 
 ### Scripts
 No scripts will be started by this module
+
+### Implemented permissions
+* Mission dialog

--- a/Missionframework/modules/28_captive/README.md
+++ b/Missionframework/modules/28_captive/README.md
@@ -1,0 +1,19 @@
+# KP Liberation Module Description
+
+## Misison Module
+
+
+### Dependencies
+
+
+### Consumed events
+
+
+### Emitted events
+
+
+### Functions
+
+
+### Scripts
+No scripts will be started by this module

--- a/Missionframework/modules/28_captive/README.md
+++ b/Missionframework/modules/28_captive/README.md
@@ -1,19 +1,108 @@
 # KP Liberation Module Description
 
-## Misison Module
-
+## Captive Module
+This module handles the prisoners of war.
+It'll check for remaining soldiers on sector capture and ensure that they'll surrender and can get handled through interactions.
 
 ### Dependencies
-
+* Common
 
 ### Consumed events
+**KPLIB_sector_captured** (server side)
+Calls KPLIB_fnc_captive_checkSector to search and handle remaining units
 
+**KPLIB_captive_arrested** (server side)
+Plays the arrest moves for captives to ensure that the moves are handled at the correct locality
+
+**ace_captiveStatusChanged** (server side)
+Calls KPLIB_fnc_captive_setAceCaptive to handle the ace captive system and integrate the lib stuff to the captives
+
+**KPLIB_captive_load** (global)
+Move the captive into the vehicle cargo
+
+**KPLIB_captive_unload** (global)
+Move the captive out of the vehicle cargo
+
+**KPLIB_captive_loaded** (client side)
+Handles the captive load, to ensure that the actions get applied and remove accordingly
+
+**KPLIB_captive_unloaded** (client side)
+Removes the unload action from the vehicle
 
 ### Emitted events
+**KPLIB_captive_surrendered** (global)
+Emitted when a unit surrenders
 
+**KPLIB_captive_arrested** (global)
+Emitted when a surrendered unit gets arrested
+
+**KPLIB_captive_load** (target event)
+Emitted when a captive should get loaded
+
+**KPLIB_captive_loaded** (global)
+Emitted when a captive gets loaded
+
+**KPLIB_captive_unload** (target event)
+Emitted when a captive should get unloaded
+
+**KPLIB_captive_unloaded** (global)
+Emitted when a captive gets unloaded
+
+**KPLIB_captive_interrogated** (global)
+Emitted when a captive gets interrogated
 
 ### Functions
+* KPLIB_fnc_captive_addCaptiveAction
 
+  *Adds all needed actions to a surrendered unit.*
+
+* KPLIB_fnc_captive_checkSector
+
+  *Checks the given sector for remaining enemys and let them surrender.*
+
+* KPLIB_fnc_captive_escort
+
+  *ttach a captive to the escorting player.*
+
+* KPLIB_fnc_captive_interrogate
+
+  *Interrogates the unit, adds intel and deletes it.*
+
+* KPLIB_fnc_captive_loadCaptive
+
+  *Loads given unit into the nearest vehicle cargo seat.*
+
+* KPLIB_fnc_captive_postInit
+
+  *Module post initialization.*
+
+* KPLIB_fnc_captive_preInit
+
+  *Module pre initialization.*
+
+* KPLIB_fnc_captive_setAceCaptive
+
+  *Checks for ACE handcuffed units and rebinds them into the Liberation captive system.*
+
+* KPLIB_fnc_captive_setCaptive
+
+  *Sets an unit into captive mode.*
+
+* KPLIB_fnc_captive_setSurrender
+
+  *Given unit surrenders.*
+
+* KPLIB_fnc_captive_settings
+
+  *CBA Settings initialization for this module*
+
+* KPLIB_fnc_captive_stopEscort
+
+  *Detach a captive from the escorting player.*
+
+* KPLIB_fnc_captive_unloadCaptive
+
+  *Unloads the give unit and removes the action from the vehicle.*
 
 ### Scripts
 No scripts will be started by this module

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -31,7 +31,7 @@ if !(KPLIB_ace_enabled) then {
     // Add arrest action
     [
         _unit,
-        "STR_KPLIB_ACTION_ARREST",
+        ["STR_KPLIB_ACTION_ARREST", name _unit],
         [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, nil, -800, false, true, "", "(_target getVariable [""KPLIB_surrender"", false]) && !(_target getVariable [""KPLIB_captive"", false])", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_addCaptiveAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-11
+    Last Update: 2019-09-12
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -36,5 +36,11 @@ if !(KPLIB_ace_enabled) then {
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 };
 
+// Add interrogate action near FOB
+[
+    _unit,
+    "arrest",
+    [{[10] call KPLIB_fnc_resources_addIntel;}, true, -800, false, true, "", "count (_target nearEntities [KPLIB_preset_fobBuildingF, 25]) isEqualTo 1", 10]
+] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_addCaptiveAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-24
+    Last Update: 2019-09-25
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -59,8 +59,8 @@ if !(KPLIB_ace_enabled) then {
 // Add interrogate action near FOB
 [
     _unit,
-    "interrogate captive",
-    [{[10] call KPLIB_fnc_resources_addIntel; deleteVehicle _unit;}, nil, -800, false, true, "", "count (_target nearEntities [KPLIB_preset_fobBuildingF, 25]) isEqualTo 1", 10]
+    ["STR_KPLIB_ACTION_INTERROGATE", name _unit],
+    [{[_this select 0] call KPLIB_fnc_captive_interrogate;}, nil, -800, false, true, "", "!((nearestObjects [_target ,[KPLIB_preset_fobBuildingF], 25]) isEqualTo [])", 10]
 ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -31,15 +31,15 @@ if !(KPLIB_ace_enabled) then {
     // Add arrest action
     [
         _unit,
-        "arrest",
-        [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, true, -800, false, true, "", "_target getVariable [KPLIB_surrender, false]", 10]
+        "STR_KPLIB_ACTION_ARREST",
+        [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_surrender"", false]", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add escort action
     [
         _unit,
         "escort",
-        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add stop escort action
@@ -47,14 +47,14 @@ if !(KPLIB_ace_enabled) then {
     [
         _unit,
         "drop captive",
-        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add move in vehicle action
     [
         _unit,
         "move in cargo",
-        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add move out vehicle action
@@ -62,7 +62,7 @@ if !(KPLIB_ace_enabled) then {
     [
         _unit,
         "move out cargo",
-        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 };
 
@@ -70,7 +70,7 @@ if !(KPLIB_ace_enabled) then {
 [
     _unit,
     "interrogate captive",
-    [{[10] call KPLIB_fnc_resources_addIntel; deleteVehicle _unit;}, true, -800, false, true, "", "count (_target nearEntities [KPLIB_preset_fobBuildingF, 25]) isEqualTo 1", 10]
+    [{[10] call KPLIB_fnc_resources_addIntel; deleteVehicle _unit;}, nil, -800, false, true, "", "count (_target nearEntities [KPLIB_preset_fobBuildingF, 25]) isEqualTo 1", 10]
 ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_addCaptiveAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-16
+    Last Update: 2019-09-19
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -32,7 +32,7 @@ if !(KPLIB_ace_enabled) then {
     [
         _unit,
         "STR_KPLIB_ACTION_ARREST",
-        [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_surrender"", false]", 10]
+        [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, nil, -800, false, true, "", "(_target getVariable [""KPLIB_surrender"", false]) && !(_target getVariable [""KPLIB_captive"", false])", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add escort action

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_addCaptiveAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-12
+    Last Update: 2019-09-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -27,20 +27,50 @@ if (isNull _unit) exitWith {
     false
 };
 
-// Add arrest action without active ACE
 if !(KPLIB_ace_enabled) then {
+    // Add arrest action
     [
         _unit,
         "arrest",
         [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, true, -800, false, true, "", "_target getVariable [KPLIB_surrender, false]", 10]
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+
+    // Add escort action
+    [
+        _unit,
+        "escort",
+        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+
+    // Add stop escort action
+    // This action will be moved to the escorting unit later
+    [
+        _unit,
+        "drop captive",
+        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+
+    // Add move in vehicle action
+    [
+        _unit,
+        "move in cargo",
+        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+
+    // Add move out vehicle action
+    // This action will be moved to the vehicle later
+    [
+        _unit,
+        "move out cargo",
+        [{}, true, -800, false, true, "", "_target getVariable [KPLIB_captive, false]", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 };
 
 // Add interrogate action near FOB
 [
     _unit,
-    "arrest",
-    [{[10] call KPLIB_fnc_resources_addIntel;}, true, -800, false, true, "", "count (_target nearEntities [KPLIB_preset_fobBuildingF, 25]) isEqualTo 1", 10]
+    "interrogate captive",
+    [{[10] call KPLIB_fnc_resources_addIntel; deleteVehicle _unit;}, true, -800, false, true, "", "count (_target nearEntities [KPLIB_preset_fobBuildingF, 25]) isEqualTo 1", 10]
 ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -1,0 +1,40 @@
+/*
+    KPLIB_fnc_captive_addCaptiveAction
+
+    File: fn_captive_addCaptiveAction.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-11
+    Last Update: 2019-09-11
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Adds all needed actions to a surrendered unit.
+
+    Parameter(s):
+        _unit - Unit to set in captive mode [OBJECT, defaults to objNull]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit) exitWith {
+    false
+};
+
+// Add arrest action without active ACE
+if !(KPLIB_ace_enabled) then {
+    [
+        _unit,
+        "arrest",
+        [{[_this select 0] call KPLIB_fnc_captive_setCaptive;}, true, -800, false, true, "", "_target getVariable [KPLIB_surrender, false]", 10]
+    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+};
+
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_addCaptiveAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-19
+    Last Update: 2019-09-21
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -12,7 +12,7 @@
         Adds all needed actions to a surrendered unit.
 
     Parameter(s):
-        _unit - Unit to set in captive mode [OBJECT, defaults to objNull]
+        _unit - Unit to apply the actions [OBJECT, defaults to objNull]
 
     Returns:
         Function reached the end [BOOL]
@@ -38,8 +38,8 @@ if !(KPLIB_ace_enabled) then {
     // Add escort action
     [
         _unit,
-        "escort",
-        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
+        ["STR_KPLIB_ACTION_ESCORT", name _unit],
+        [{[_this select 0, _this select 1] call KPLIB_fnc_captive_escort;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false] && !(_this getVariable [""KPLIB_isEscorting"", false])", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add stop escort action

--- a/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_addCaptiveActions.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_addCaptiveAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-21
+    Last Update: 2019-09-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -39,31 +39,21 @@ if !(KPLIB_ace_enabled) then {
     [
         _unit,
         ["STR_KPLIB_ACTION_ESCORT", name _unit],
-        [{[_this select 0, _this select 1] call KPLIB_fnc_captive_escort;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false] && !(_this getVariable [""KPLIB_isEscorting"", false])", 10]
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
-
-    // Add stop escort action
-    // This action will be moved to the escorting unit later
-    [
-        _unit,
-        "drop captive",
-        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
+        [{[_this select 0, _this select 1] call KPLIB_fnc_captive_escort;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false] && !(_this getVariable [""KPLIB_captive_isEscorting"", false])", 10]
     ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
 
     // Add move in vehicle action
-    [
-        _unit,
-        "move in cargo",
-        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+    [_unit, {
+        private _id = [
+            _this,
+            ["STR_KPLIB_ACTION_LOADCAPTIVE", name _this],
+            [{[_this select 0] call KPLIB_fnc_captive_loadCaptive;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false] && ({(_x emptyPositions ""cargo"") > 0} count (_target nearEntities [[""LandVehicle"", ""Air""], 5])) > 0", 10]
+        ] call KPLIB_fnc_common_addAction;
 
-    // Add move out vehicle action
-    // This action will be moved to the vehicle later
-    [
-        _unit,
-        "move out cargo",
-        [{}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false]", 10]
-    ] remoteExecCall ["KPLIB_fnc_common_addAction", 0, _unit];
+        // Store the load action to switch the locality when escorting
+        _this setVariable ["KPLIB_captive_loadID", _id];
+    }] remoteExecCall ["call", 0, _unit];
+
 };
 
 // Add interrogate action near FOB

--- a/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_checkSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-10
+    Last Update: 2019-09-11
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -31,7 +31,7 @@ private _sectorPos = getMarkerPos _sector;
 
 // Check the sector for remaining units
 {
-
+    [_x] call KPLIB_fnc_captive_setCaptive;
 } forEach (_sectorPos nearEntities ["Man", KPLIB_param_sectorCapRange * 2]) select {side _x isEqualTo KPLIB_preset_sideE};
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_checkSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-11
+    Last Update: 2019-09-12
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -32,6 +32,6 @@ private _sectorPos = getMarkerPos _sector;
 // Check the sector for remaining units
 {
     [_x] call KPLIB_fnc_captive_setSurrender;
-} forEach (_sectorPos nearEntities ["Man", KPLIB_param_sectorCapRange * 2]) select {side _x isEqualTo KPLIB_preset_sideE};
+} forEach ((_sectorPos nearEntities ["Man", KPLIB_param_sectorCapRange * 2]) select {side _x isEqualTo KPLIB_preset_sideE});
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
@@ -1,0 +1,37 @@
+/*
+    KPLIB_fnc_captive_checkSector
+
+    File: fn_captive_checkSector.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-10
+    Last Update: 2019-09-10
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Checks the given sector for remaining enemys and sets them into captive mode.
+
+    Parameter(s):
+        _sector - Sector marker [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_sector", "", [""]]
+];
+
+// Exit if no sector is given
+if (_sector isEqualTo "") exitWith {
+    false
+};
+
+private _sectorPos = getMarkerPos _sector;
+
+// Check the sector for remaining units
+{
+
+} forEach (_sectorPos nearEntities ["Man", KPLIB_param_sectorCapRange * 2]) select {side _x isEqualTo KPLIB_preset_sideE};
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
@@ -4,12 +4,12 @@
     File: fn_captive_checkSector.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-12
+    Last Update: 2019-09-28
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
     Description:
-        Checks the given sector for remaining enemys and sets them into captive mode.
+        Checks the given sector for remaining enemys and lets them surrender.
 
     Parameter(s):
         _sector - Sector marker [STRING, defaults to ""]

--- a/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_checkSector.sqf
@@ -31,7 +31,7 @@ private _sectorPos = getMarkerPos _sector;
 
 // Check the sector for remaining units
 {
-    [_x] call KPLIB_fnc_captive_setCaptive;
+    [_x] call KPLIB_fnc_captive_setSurrender;
 } forEach (_sectorPos nearEntities ["Man", KPLIB_param_sectorCapRange * 2]) select {side _x isEqualTo KPLIB_preset_sideE};
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_escort.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_escort.sqf
@@ -1,0 +1,46 @@
+/*
+    KPLIB_fnc_captive_escort
+
+    File: fn_captive_escort.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-21
+    Last Update: 2019-09-21
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Attach a captive to the escorting player.
+
+    Parameter(s):
+        _unit       - Unit which will be escorted   [OBJECT, defaults to objNull]
+        _escort     - Escorting player              [OBJECT, defaults to objNull]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]],
+    ["_escort", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit || isNull _escort) exitWith {
+    false
+};
+
+// Set variable on escort
+_escort setVariable ["KPLIB_isEscorting", true, true];
+_escort setVariable ["KPLIB_escorting", _unit, true];
+
+// Attach the captive to the player
+_unit attachTo [_escort, [0, 1, 0]];
+
+// Add the action to release the captive
+[
+    _escort,
+    ["STR_KPLIB_ACTION_STOPESCORT", name _unit],
+    [{[_this select 0, _this select 2] call KPLIB_fnc_captive_stopEscort;}, nil, -800, false, true, "","", 10]
+] call KPLIB_fnc_common_addAction;
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_escort.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_escort.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_escort.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-21
-    Last Update: 2019-09-21
+    Last Update: 2019-09-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -30,17 +30,29 @@ if (isNull _unit || isNull _escort) exitWith {
 };
 
 // Set variable on escort
-_escort setVariable ["KPLIB_isEscorting", true, true];
-_escort setVariable ["KPLIB_escorting", _unit, true];
+_escort setVariable ["KPLIB_captive_isEscorting", true, true];
+_escort setVariable ["KPLIB_captive_escorting", _unit, true];
 
 // Attach the captive to the player
 _unit attachTo [_escort, [0, 1, 0]];
 
+// Switch the load action from unit to player
+_unit removeAction (_unit getVariable ["KPLIB_captive_loadID", 9000]);
+private _id = [
+    _escort,
+    ["STR_KPLIB_ACTION_LOADCAPTIVE", name _unit],
+    [{[_this select 3] call KPLIB_fnc_captive_loadCaptive;}, _unit, -800, false, true, "", "({(_x emptyPositions ""cargo"") > 0} count (_target nearEntities [[""LandVehicle"", ""Air""], 5])) > 0", 10]
+] call KPLIB_fnc_common_addAction;
+_unit setVariable ["KPLIB_captive_loadID", _id];
+
 // Add the action to release the captive
-[
+private _id = [
     _escort,
     ["STR_KPLIB_ACTION_STOPESCORT", name _unit],
     [{[_this select 0, _this select 2] call KPLIB_fnc_captive_stopEscort;}, nil, -800, false, true, "","", 10]
 ] call KPLIB_fnc_common_addAction;
+
+// Write the id into the player
+_escort setVariable ["KPLIB_stopEscort_id", _id];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_interrogate.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_interrogate.sqf
@@ -1,0 +1,42 @@
+/*
+    KPLIB_fnc_captive_interrogate
+
+    File: fn_captive_interrogate.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-25
+    Last Update: 2019-09-25
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Interrogates the unit, adds intel and deletes it.
+
+    Parameter(s):
+        _unit - Unit to load in vehicle [OBJECT, defaults to objNull]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit) exitWith {
+    false
+};
+
+// Calculate the intel gain
+private _intel = KPLIB_param_captiveIntel;
+if !(KPLIB_param_captiveIntelRandom isEqualTo 0) then {
+    _intel = _intel + ((round (random (KPLIB_param_captiveIntelRandom * 2))) - KPLIB_param_captiveIntelRandom);
+};
+
+// Add the intel
+[_intel] call KPLIB_fnc_resources_addIntel;
+
+// Delete the unit
+deleteVehicle _unit;
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_interrogate.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_interrogate.sqf
@@ -39,4 +39,7 @@ if !(KPLIB_param_captiveIntelRandom isEqualTo 0) then {
 // Delete the unit
 deleteVehicle _unit;
 
+// Emit global event
+["KPLIB_captive_interrogated", [_unit]] call CBA_fnc_globalEvent;
+
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_loadCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_loadCaptive.sqf
@@ -1,0 +1,57 @@
+/*
+    KPLIB_fnc_captive_loadCaptive
+
+    File: fn_captive_loadCaptive.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-22
+    Last Update: 2019-09-24
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Loads given unit into the nearest vehicle cargo seat.
+
+    Parameter(s):
+        _unit - Unit to load in vehicle [OBJECT, defaults to objNull]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit) exitWith {
+    false
+};
+
+// Get the nearest vehicle
+private _vehicle = ((_unit nearEntities [["LandVehicle", "Air"], 5]) select {(_x emptyPositions "cargo") > 0}) select 0;
+
+// Check if the unit is getting escorted
+if !(isNull attachedTo _unit) then {
+    detach _unit;
+
+    // Set variable on escorting unit
+    player setVariable ["KPLIB_captive_isEscorting", false, true];
+    player setVariable ["KPLIB_captive_escorting", objNull, true];
+
+    // Switch the load action from player to unitAddons
+    player removeAction (_unit getVariable ["KPLIB_captive_loadID", 9000]);
+    private _id = [
+        _unit,
+        ["STR_KPLIB_ACTION_LOADCAPTIVE", name _unit],
+        [{[_this select 0] call KPLIB_fnc_captive_loadCaptive;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false] && ({(_x emptyPositions ""cargo"") > 0} count (_target nearEntities [[""LandVehicle"", ""Air""], 5])) > 0", 10]
+    ] call KPLIB_fnc_common_addAction;
+    _unit setVariable ["KPLIB_captive_loadID", _id];
+};
+
+// Emit target event to move the unit into the vehicle
+["KPLIB_captive_load", [_unit, _vehicle], _unit] call CBA_fnc_targetEvent;
+
+// Emit global event
+["KPLIB_captive_loaded", [_unit, _vehicle]] call CBA_fnc_globalEvent;
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_postInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_postInit.sqf
@@ -1,0 +1,41 @@
+/*
+    KPLIB_fnc_captive_postInit
+
+    File: fn_captive_postInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-10
+    Last Update: 2019-09-10
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        The postInit function of a module takes care of starting/executing the modules functions or scripts.
+        Basically it starts/initializes the module functionality to make all provided features usable.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module postInit finished [BOOL]
+*/
+
+if (isServer) then {["Module initializing...", "POST] [CAPTIVE", true] call KPLIB_fnc_common_log;};
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {["Module initialized", "POST] [CAPTIVE", true] call KPLIB_fnc_common_log;};
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_preInit.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-11
+    Last Update: 2019-09-12
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -29,7 +29,7 @@ if (isServer) then {
     ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_captive_checkSector;}] call CBA_fnc_addEventHandler;
 
     // Check for handcuffed enemys
-    ["call CBA_fnc_addEventHandler;", {[_this select 0, _this select 1, _this select 2] call KPLIB_fnc_captive_setAceCaptive}] call CBA_fnc_addEventHandler;
+    ["ace_captiveStatusChanged", {[_this select 0, _this select 1, _this select 2] call KPLIB_fnc_captive_setAceCaptive}] call CBA_fnc_addEventHandler;
 
 };
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -1,0 +1,51 @@
+/*
+    KPLIB_fnc_captive_preInit
+
+    File: fn_captive_preInit.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-10
+    Last Update: 2019-09-10
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        The preInit function defines global variables, adds event handlers and set some vital settings which are used in this module.
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Module preInit finished [BOOL]
+*/
+
+if (isServer) then {["Module initializing...", "PRE] [CAPTIVE", true] call KPLIB_fnc_common_log;};
+
+/*
+    ----- Module Globals -----
+*/
+
+
+/*
+    ----- Module Initialization -----
+*/
+
+
+
+// Server section (dedicated and player hosted)
+if (isServer) then {
+
+};
+
+// HC section
+if (!hasInterface && !isDedicated) then {
+
+};
+
+// Player section
+if (hasInterface) then {
+
+};
+
+if (isServer) then {["Module initialized", "PRE] [CAPTIVE", true] call KPLIB_fnc_common_log;};
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_preInit.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-10
+    Last Update: 2019-09-11
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -25,8 +25,11 @@ if (isServer) then {
     ----- Module Initialization -----
 */
 
-    // Set captives on sector capture
+    // Units surrender on sector capture
     ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_captive_checkSector;}] call CBA_fnc_addEventHandler;
+
+    // Check for handcuffed enemys
+    ["call CBA_fnc_addEventHandler;", {[_this select 0, _this select 1, _this select 2] call KPLIB_fnc_captive_setAceCaptive}] call CBA_fnc_addEventHandler;
 
 };
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_preInit.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-12
+    Last Update: 2019-09-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -34,6 +34,61 @@ if (isServer) then {
     // Check for handcuffed enemys
     ["ace_captiveStatusChanged", {[_this select 0, _this select 1, _this select 2] call KPLIB_fnc_captive_setAceCaptive}] call CBA_fnc_addEventHandler;
 
+};
+
+// Add load captive EH
+["KPLIB_captive_load", {
+    params [
+        ["_unit", objNull, [objNull]],
+        ["_vehicle", objNull, [objNull]]
+    ];
+    // Move unit in vehicle cargo
+    _unit moveInCargo _vehicle;
+}] call CBA_fnc_addEventHandler;
+
+// Add unload captive EH
+["KPLIB_captive_unload", {
+    params [
+        ["_unit", objNull, [objNull]],
+        ["_vehicle", objNull, [objNull]]
+    ];
+    // Unload the unit
+    moveOut _unit;
+    _unit switchMove "AmovPercMstpSnonWnonDnon_EaseIn";
+}] call CBA_fnc_addEventHandler;
+
+// Player section
+if (hasInterface) then {
+
+    // Add EH for the captive unload action
+    ["KPLIB_captive_loaded", {
+        params [
+            ["_unit", objNull, [objNull]],
+            ["_vehicle", objNull, [objNull]]
+        ];
+        // Remove the stop escort action if available
+        player removeAction (player getVariable ["KPLIB_stopEscort_id", 9000]);
+
+        // Add the unload action to the vehicle
+        private _id = [
+            _vehicle,
+            ["STR_KPLIB_ACTION_UNLOADCAPTIVE", name _unit],
+            [{[_this select 3, _this select 0] call KPLIB_fnc_captive_unloadCaptive;}, _unit, -800, false, true, "", "", 10]
+        ] call KPLIB_fnc_common_addAction;
+
+        // Save id in unit
+        _unit setVariable ["KPLIB_captive_unloadID", _id]
+    }] call CBA_fnc_addEventHandler;
+
+    // Add EH to remove the unload action
+    ["KPLIB_captive_unloaded", {
+        params [
+            ["_unit", objNull, [objNull]],
+            ["_vehicle", objNull, [objNull]]
+        ];
+        // Remove the unload action from the vehicle
+        _vehicle removeAction (_unit getVariable ["KPLIB_captive_unloadID", 9000]);
+    }] call CBA_fnc_addEventHandler;
 };
 
 if (isServer) then {["Module initialized", "PRE] [CAPTIVE", true] call KPLIB_fnc_common_log;};

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_preInit.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-26
+    Last Update: 2019-09-29
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -63,6 +63,26 @@ if (isServer) then {
     _unit switchMove "AmovPercMstpSnonWnonDnon_EaseIn";
 }] call CBA_fnc_addEventHandler;
 
+// Emit lib captive event on ace event to ensure compatibilty
+["ace_captives_moveInCaptive", {
+    params [
+        ["_unit", objNull, [objNull]],
+        ["_vehicle", objNull, [objNull]]
+    ];
+    // Emit global event
+    ["KPLIB_captive_loaded", [_unit, _vehicle]] call CBA_fnc_globalEvent;
+}] call CBA_fnc_addEventHandler;
+
+// Emit lib captive event on ace event to ensure compatibilty
+["ace_captives_moveOutCaptive", {
+    params [
+        ["_unit", objNull, [objNull]]
+    ];
+    // Emit global event
+    ["KPLIB_captive_unloaded", [_unit]] call CBA_fnc_globalEvent;
+}] call CBA_fnc_addEventHandler;
+
+
 // Player section
 if (hasInterface) then {
 
@@ -72,6 +92,8 @@ if (hasInterface) then {
             ["_unit", objNull, [objNull]],
             ["_vehicle", objNull, [objNull]]
         ];
+        // Exit the function on missing vehicle, due to an emitted event through ace
+        if (isNull _vehicle) exitWith {};
         // Remove the stop escort action if available
         player removeAction (player getVariable ["KPLIB_stopEscort_id", 9000]);
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -18,31 +18,15 @@
         Module preInit finished [BOOL]
 */
 
-if (isServer) then {["Module initializing...", "PRE] [CAPTIVE", true] call KPLIB_fnc_common_log;};
-
-/*
-    ----- Module Globals -----
-*/
-
+if (isServer) then {
+    ["Module initializing...", "PRE] [CAPTIVE", true] call KPLIB_fnc_common_log;
 
 /*
     ----- Module Initialization -----
 */
 
-
-
-// Server section (dedicated and player hosted)
-if (isServer) then {
-
-};
-
-// HC section
-if (!hasInterface && !isDedicated) then {
-
-};
-
-// Player section
-if (hasInterface) then {
+    // Set captives on sector capture
+    ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_captive_checkSector;}] call CBA_fnc_addEventHandler;
 
 };
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_preInit.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-24
+    Last Update: 2019-09-26
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -30,6 +30,12 @@ if (isServer) then {
 
     // Units surrender on sector capture
     ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_captive_checkSector;}] call CBA_fnc_addEventHandler;
+
+    // Unit animation on arrest
+    ["KPLIB_captive_arrested", {
+        _this select 0 playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";
+        _this select 0 playMove "AmovPercMstpSnonWnonDnon_EaseIn";
+    }] call CBA_fnc_addEventHandler;
 
     // Check for handcuffed enemys
     ["ace_captiveStatusChanged", {[_this select 0, _this select 1, _this select 2] call KPLIB_fnc_captive_setAceCaptive}] call CBA_fnc_addEventHandler;

--- a/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_preInit.sqf
@@ -25,6 +25,9 @@ if (isServer) then {
     ----- Module Initialization -----
 */
 
+    // Process CBA Settings
+    [] call KPLIB_fnc_captive_settings;
+
     // Units surrender on sector capture
     ["KPLIB_sector_captured", {[_this select 0] call KPLIB_fnc_captive_checkSector;}] call CBA_fnc_addEventHandler;
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setAceCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-26
+    Last Update: 2019-09-28
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -38,5 +38,8 @@ if (_reason isEqualTo "SetHandcuffed" && _state) then {
     // Apply the actions on the unit
     [_unit] call KPLIB_fnc_captive_addCaptiveActions;
 };
+
+// Emit global event
+["KPLIB_captive_arrested", [_unit]] call CBA_fnc_globalEvent;
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setAceCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-11
+    Last Update: 2019-09-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -29,6 +29,11 @@ params [
 // Exit on missing object
 if (isNull _unit) exitWith {
     false
+};
+
+// Ensure that an ACE surrendered unit will be excluded from the garrison despawn
+if (_reason isEqualTo "SetSurrendered" && _state) then {
+    _unit setVariable ["KPLIB_captured", true];
 };
 
 if (_reason isEqualTo "SetHandcuffed" && _state) then {

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
@@ -1,0 +1,42 @@
+/*
+    KPLIB_fnc_
+
+    File: fn_captive_setAceCaptive.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-11
+    Last Update: 2019-09-11
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Checks for handcuffed units.
+
+    Parameter(s):
+        _unit   - Unit to set in captive mode   [OBJECT, defaults to objNull]
+        _state  - State of captive              [BOOLEAN, defaults to false]
+        _reason - Reason of the activated event [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]],
+    ["_state", false, [false]],
+    ["_reason", "", [""]]
+];
+
+// Exit on missing object
+if (isNull _unit) exitWith {
+    false
+};
+
+if (_reason isEqualTo "SetHandcuffed" && _state) then {
+    // Set variable on unit
+    _unit setVariable ["KPLIB_captive", true];
+
+    // Apply the actions on the unit
+    [_unit] call KPLIB_fnc_captive_addCaptiveActions;
+};
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
@@ -1,15 +1,15 @@
 /*
-    KPLIB_fnc_
+    KPLIB_fnc_captive_setAceCaptive
 
     File: fn_captive_setAceCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-25
+    Last Update: 2019-09-26
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
     Description:
-        Checks for handcuffed units.
+        Checks for ACE handcuffed units and rebinds them into the Liberation captive system.
 
     Parameter(s):
         _unit   - Unit to set in captive mode   [OBJECT, defaults to objNull]

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setAceCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setAceCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-16
+    Last Update: 2019-09-25
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -29,11 +29,6 @@ params [
 // Exit on missing object
 if (isNull _unit) exitWith {
     false
-};
-
-// Ensure that an ACE surrendered unit will be excluded from the garrison despawn
-if (_reason isEqualTo "SetSurrendered" && _state) then {
-    _unit setVariable ["KPLIB_captured", true];
 };
 
 if (_reason isEqualTo "SetHandcuffed" && _state) then {

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-19
+    Last Update: 2019-09-21
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -33,5 +33,8 @@ _unit setVariable ["KPLIB_captive", true, true];
 // Play the arrest move
 _unit playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";
 _unit playMove "AmovPercMstpSnonWnonDnon_EaseIn";
+
+// Emit global event
+["KPLIB_captive_arrested", [_unit]] call CBA_fnc_globalEvent;
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
@@ -27,27 +27,7 @@ if (isNull _unit) exitWith {
     false
 };
 
-if !(vehicle _unit isEqualTo _unit) then {
-    moveOut _unit;
-};
-
 // Set variable on unit
 _unit setVariable ["KPLIB_captive", true];
-
-// Remove some equipment of the unit
-removeAllWeapons _unit;
-removeHeadgear _unit;
-removeBackpack _unit;
-_unit setUnitPos "UP";
-if (KPLIB_ace_enabled) then {
-    [_unit, true] call ACE_captives_fnc_setSurrendered;
-} else {
-    _unit disableAI "ANIM";
-    _unit disableAI "MOVE";
-    _unit playmove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
-    _unit setCaptive true;
-};
-
-
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-11
+    Last Update: 2019-09-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -28,6 +28,6 @@ if (isNull _unit) exitWith {
 };
 
 // Set variable on unit
-_unit setVariable ["KPLIB_captive", true];
+_unit setVariable ["KPLIB_captive", true, true];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-16
+    Last Update: 2019-09-19
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -29,5 +29,9 @@ if (isNull _unit) exitWith {
 
 // Set variable on unit
 _unit setVariable ["KPLIB_captive", true, true];
+
+// Play the arrest move
+_unit playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";
+_unit playMove "AmovPercMstpSnonWnonDnon_EaseIn";
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
@@ -1,0 +1,53 @@
+/*
+    KPLIB_fnc_captive_setCaptive
+
+    File: fn_captive_setCaptive.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-11
+    Last Update: 2019-09-11
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Sets an unit into captive mode.
+
+    Parameter(s):
+        _unit - Unit to set in captive mode [OBJECT, defaults to objNull]
+
+    Returns:
+        Unit set into captive mode [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit) exitWith {
+    false
+};
+
+if !(vehicle _unit isEqualTo _unit) then {
+    moveOut _unit;
+};
+
+// Set variable on unit
+_unit setVariable ["KPLIB_captive", true];
+
+// Remove some equipment of the unit
+removeAllWeapons _unit;
+removeHeadgear _unit;
+removeBackpack _unit;
+_unit setUnitPos "UP";
+if (KPLIB_ace_enabled) then {
+    [_unit, true] call ACE_captives_fnc_setSurrendered;
+} else {
+    _unit disableAI "ANIM";
+    _unit disableAI "MOVE";
+    _unit playmove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
+    _unit setCaptive true;
+};
+
+
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setCaptive.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setCaptive.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-21
+    Last Update: 2019-09-26
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -29,10 +29,6 @@ if (isNull _unit) exitWith {
 
 // Set variable on unit
 _unit setVariable ["KPLIB_captive", true, true];
-
-// Play the arrest move
-_unit playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";
-_unit playMove "AmovPercMstpSnonWnonDnon_EaseIn";
 
 // Emit global event
 ["KPLIB_captive_arrested", [_unit]] call CBA_fnc_globalEvent;

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setSurrender.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-21
+    Last Update: 2019-09-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -47,6 +47,7 @@ if (KPLIB_ace_enabled) then {
     _unit disableAI "MOVE";
     _unit playMove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
     _unit setCaptive true;
+    _unit setBehaviour "CARELESS";
 
     // Apply the actions on the unit
     [_unit] call KPLIB_fnc_captive_addCaptiveActions;

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setSurrender.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-24
+    Last Update: 2019-09-25
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -52,6 +52,15 @@ if (KPLIB_ace_enabled) then {
     // Apply the actions on the unit
     [_unit] call KPLIB_fnc_captive_addCaptiveActions;
 };
+
+// Add a killed EH to the unit, to ensure that all actions will be removed
+_unit addEventHandler ["Killed", {
+    // Remove the unload action from the vehicle if the unit is in a vehicle
+    private _vehicle = objectParent _this select 0;
+    if !(isNull _vehicle) then {
+        _vehicle removeAction (_unit getVariable ["KPLIB_captive_unloadID", 9000]);
+    };
+}];
 
 // Emit global event
 ["KPLIB_captive_surrendered", [_unit]] call CBA_fnc_globalEvent;

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setSurrender.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-19
+    Last Update: 2019-09-21
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -12,7 +12,7 @@
         Given unit surrenders.
 
     Parameter(s):
-        _unit - Unit to set in captive mode [OBJECT, defaults to objNull]
+        _unit - Unit to set in surrender [OBJECT, defaults to objNull]
 
     Returns:
         Unit surrendered [BOOL]

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -54,11 +54,14 @@ if (KPLIB_ace_enabled) then {
 };
 
 // Add a killed EH to the unit, to ensure that all actions will be removed
-_unit addEventHandler ["Killed", {
+_unit addMPEventHandler ["MPKilled", {
+    // Remove all actions of the unit
+    removeAllActions (_this select 0);
+
     // Remove the unload action from the vehicle if the unit is in a vehicle
-    private _vehicle = objectParent _this select 0;
+    private _vehicle = objectParent (_this select 0);
     if !(isNull _vehicle) then {
-        _vehicle removeAction (_unit getVariable ["KPLIB_captive_unloadID", 9000]);
+        _vehicle removeAction ((_this select 0) getVariable ["KPLIB_captive_unloadID", 9000]);
     };
 }];
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -32,8 +32,8 @@ if !(vehicle _unit isEqualTo _unit) then {
 };
 
 // Set variable on unit
-_unit setVariable ["KPLIB_surrender", true];
-_unit setVariable ["KPLIB_captured", true];
+_unit setVariable ["KPLIB_surrender", true, true];
+_unit setVariable ["KPLIB_captured", true, true];
 
 // Remove some equipment of the unit
 removeAllWeapons _unit;

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setSurrender.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-11
+    Last Update: 2019-09-16
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -33,6 +33,7 @@ if !(vehicle _unit isEqualTo _unit) then {
 
 // Set variable on unit
 _unit setVariable ["KPLIB_surrender", true];
+_unit setVariable ["KPLIB_captured", true];
 
 // Remove some equipment of the unit
 removeAllWeapons _unit;

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -52,4 +52,7 @@ if (KPLIB_ace_enabled) then {
     [_unit] call KPLIB_fnc_captive_addCaptiveActions;
 };
 
+// Emit global event
+["KPLIB_captive_surrendered", [_unit]] call CBA_fnc_globalEvent;
+
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_setSurrender.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-11
-    Last Update: 2019-09-16
+    Last Update: 2019-09-19
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -45,7 +45,7 @@ if (KPLIB_ace_enabled) then {
 } else {
     _unit disableAI "ANIM";
     _unit disableAI "MOVE";
-    _unit playmove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
+    _unit playMove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
     _unit setCaptive true;
 
     // Apply the actions on the unit

--- a/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_setSurrender.sqf
@@ -1,0 +1,54 @@
+/*
+    KPLIB_fnc_captive_setSurrender
+
+    File: fn_captive_setSurrender.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-11
+    Last Update: 2019-09-11
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Given unit surrenders.
+
+    Parameter(s):
+        _unit - Unit to set in captive mode [OBJECT, defaults to objNull]
+
+    Returns:
+        Unit surrendered [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit) exitWith {
+    false
+};
+
+if !(vehicle _unit isEqualTo _unit) then {
+    moveOut _unit;
+};
+
+// Set variable on unit
+_unit setVariable ["KPLIB_surrender", true];
+
+// Remove some equipment of the unit
+removeAllWeapons _unit;
+removeHeadgear _unit;
+removeBackpack _unit;
+_unit setUnitPos "UP";
+if (KPLIB_ace_enabled) then {
+    [_unit, true] call ACE_captives_fnc_setSurrendered;
+} else {
+    _unit disableAI "ANIM";
+    _unit disableAI "MOVE";
+    _unit playmove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
+    _unit setCaptive true;
+
+    // Apply the actions on the unit
+    [_unit] call KPLIB_fnc_captive_addCaptiveActions;
+};
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_settings.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_settings.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_settings.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-12
-    Last Update: 2019-09-12
+    Last Update: 2019-09-25
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -18,6 +18,30 @@
         Function reached the end [BOOL]
 */
 
+// KPLIB_param_captiveIntel
+// Amount of intel which will be granted on interrogation.
+// Default: 10
+[
+    "KPLIB_param_captiveIntel",
+    "SLIDER",
+    [localize "STR_KPLIB_SETTINGS_CAPTIVE_INTELVALUE", localize "STR_KPLIB_SETTINGS_CAPTIVE_INTELVALUE_TT"],
+    localize "STR_KPLIB_SETTINGS_CAPTIVE",
+    [1, 100, 10, 1],
+    1,
+    {}
+] call CBA_Settings_fnc_init;
 
+// KPLIB_param_captiveIntelRandom
+// Amount of random intel modifier on interrogation.
+// Default: 5
+[
+    "KPLIB_param_captiveIntelRandom",
+    "SLIDER",
+    [localize "STR_KPLIB_SETTINGS_CAPTIVE_INTELRANDOM", localize "STR_KPLIB_SETTINGS_CAPTIVE_INTELRANDOM_TT"],
+    localize "STR_KPLIB_SETTINGS_CAPTIVE",
+    [0, 100, 5, 1],
+    1,
+    {}
+] call CBA_Settings_fnc_init;
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_settings.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_settings.sqf
@@ -1,0 +1,23 @@
+/*
+    KPLIB_fnc_captive_settings
+
+    File: fn_captive_settings.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-12
+    Last Update: 2019-09-12
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        CBA Settings initialization for this module
+
+    Parameter(s):
+        NONE
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_settings.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_settings.sqf
@@ -4,12 +4,12 @@
     File: fn_captive_settings.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-12
-    Last Update: 2019-09-25
+    Last Update: 2019-09-28
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
     Description:
-        CBA Settings initialization for this module
+        CBA Settings initialization for this module.
 
     Parameter(s):
         NONE

--- a/Missionframework/modules/28_captive/fnc/fn_captive_stopEscort.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_stopEscort.sqf
@@ -4,7 +4,7 @@
     File: fn_captive_stopEscort.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-21
-    Last Update: 2019-09-21
+    Last Update: 2019-09-24
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -30,16 +30,25 @@ if (isNull _escort || _id isEqualTo 0.068117098106117110107) exitWith {
 };
 
 // Get the captive
-private _unit = _escort getVariable ["KPLIB_escorting", objNull];
+private _unit = _escort getVariable ["KPLIB_captive_escorting", objNull];
 
 // Set variable on escort
-_escort setVariable ["KPLIB_isEscorting", false, true];
-_escort setVariable ["KPLIB_escorting", objNull, true];
+_escort setVariable ["KPLIB_captive_isEscorting", false, true];
+_escort setVariable ["KPLIB_captive_escorting", objNull, true];
 
 // Detach the captive from the player
 detach _unit;
 
 // Remove the action
 player removeAction _id;
+
+// Switch the load action from player to unitAddons
+player removeAction (_unit getVariable ["KPLIB_captive_loadID", 9000]);
+_id = [
+    _unit,
+    ["STR_KPLIB_ACTION_LOADCAPTIVE", name _unit],
+    [{[_this select 0] call KPLIB_fnc_captive_loadCaptive;}, nil, -800, false, true, "", "_target getVariable [""KPLIB_captive"", false] && ({(_x emptyPositions ""cargo"") > 0} count (_target nearEntities [[""LandVehicle"", ""Air""], 5])) > 0", 10]
+] call KPLIB_fnc_common_addAction;
+_unit setVariable ["KPLIB_captive_loadID", _id];
 
 true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_stopEscort.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_stopEscort.sqf
@@ -1,0 +1,45 @@
+/*
+    KPLIB_fnc_
+
+    File: fn_captive_stopEscort.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-21
+    Last Update: 2019-09-21
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Detach a captive from the escorting player.
+
+    Parameter(s):
+        _escort - Escorting player  [OBJECT, defaults to objNull]
+        _id     - ID of the action  [NUMBER, defaults to 0.068117098106117110107]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_escort", objNull, [objNull]],
+    ["_id", 0.068117098106117110107, [0]]
+];
+
+// Exit on missing object
+if (isNull _escort || _id isEqualTo 0.068117098106117110107) exitWith {
+    false
+};
+
+// Get the captive
+private _unit = _escort getVariable ["KPLIB_escorting", objNull];
+
+// Set variable on escort
+_escort setVariable ["KPLIB_isEscorting", false, true];
+_escort setVariable ["KPLIB_escorting", objNull, true];
+
+// Detach the captive from the player
+detach _unit;
+
+// Remove the action
+player removeAction _id;
+
+true

--- a/Missionframework/modules/28_captive/fnc/fn_captive_stopEscort.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_stopEscort.sqf
@@ -1,10 +1,10 @@
 /*
-    KPLIB_fnc_
+    KPLIB_fnc_captive_stopEscort
 
     File: fn_captive_stopEscort.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-21
-    Last Update: 2019-09-24
+    Last Update: 2019-09-26
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 

--- a/Missionframework/modules/28_captive/fnc/fn_captive_unloadCaptive.sqf
+++ b/Missionframework/modules/28_captive/fnc/fn_captive_unloadCaptive.sqf
@@ -1,0 +1,38 @@
+/*
+    KPLIB_fnc_captive_unloadCaptive
+
+    File: fn_captive_unloadCaptive.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-22
+    Last Update: 2019-09-24
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Unloads the give unit and removes the action from the vehicle.
+
+    Parameter(s):
+        _unit       - Unit to load in vehicle           [OBJECT, defaults to objNull]
+        _vehicle    - Vehicle which carries the unit    [OBJECT, defaults to objNull]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_unit", objNull, [objNull]],
+    ["_vehicle", objNull, [objNull]]
+];
+
+// Exit on missing object
+if (isNull _unit || isNull _vehicle) exitWith {
+    false
+};
+
+// Emit target event to move the unit out of the vehicle
+["KPLIB_captive_unload", [_unit, _vehicle], _unit] call CBA_fnc_targetEvent;
+
+// Emit global event
+["KPLIB_captive_unloaded", [_unit, _vehicle]] call CBA_fnc_globalEvent;
+
+true

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -12,7 +12,7 @@
         Defines for all functions, which are brought by this module.
 */
 
-class mission {
+class captive {
     file = "modules\28_captive\fnc";
 
     // Adds all needed actions to a surrendered unit

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-11
+    Last Update: 2019-09-12
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -36,5 +36,8 @@ class mission {
 
     // Given unit surrenders
     class captive_setSurrender {};
+
+    // CBA Settings for this module
+    class captive_settings {};
 
 };

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-21
+    Last Update: 2019-09-22
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -23,6 +23,9 @@ class captive {
 
     // Attach a captive to the escorting player
     class captive_escort {};
+
+    // Loads given unit into the nearest vehicle cargo seat
+    class captive_loadCaptive {};
 
     // Module post initialization
     class captive_postInit {
@@ -45,5 +48,8 @@ class captive {
 
     // Detach a captive from the escorting player
     class captive_stopEscort {};
+
+    // Unloads the give unit and removes the action from the vehicle
+    class captive_unloadCaptive {};
 
 };

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -15,6 +15,9 @@
 class mission {
     file = "modules\28_captive\fnc";
 
+    // Adds all needed actions to a surrendered unit
+    class captive_addCaptiveActions {};
+
     // Checks the given sector for remaining enemys and sets them into captive mode
     class captive_checkSector {};
 
@@ -30,5 +33,8 @@ class mission {
 
     // Sets an unit into captive mode
     class captive_setCaptive {};
+
+    // Given unit surrenders
+    class captive_setSurrender {};
 
 };

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-22
+    Last Update: 2019-09-25
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -23,6 +23,9 @@ class captive {
 
     // Attach a captive to the escorting player
     class captive_escort {};
+
+    // Interrogates the unit, adds intel and deletes it
+    class captive_interrogate {};
 
     // Loads given unit into the nearest vehicle cargo seat
     class captive_loadCaptive {};

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-12
+    Last Update: 2019-09-21
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -20,6 +20,9 @@ class captive {
 
     // Checks the given sector for remaining enemys and sets them into captive mode
     class captive_checkSector {};
+
+    // Attach a captive to the escorting player
+    class captive_escort {};
 
     // Module post initialization
     class captive_postInit {
@@ -39,5 +42,8 @@ class captive {
 
     // CBA Settings for this module
     class captive_settings {};
+
+    // Detach a captive from the escorting player
+    class captive_stopEscort {};
 
 };

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -15,6 +15,9 @@
 class mission {
     file = "modules\28_captive\fnc";
 
+    // Checks the given sector for remaining enemys and sets them into captive mode
+    class captive_checkSector {};
+
     // Module post initialization
     class captive_postInit {
         postInit = 1;

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -1,0 +1,28 @@
+/*
+    KP LIBERATION MODULE FUNCTIONS
+
+    File: functions.hpp
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2019-09-10
+    Last Update: 2019-09-10
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+    Public: No
+
+    Description:
+        Defines for all functions, which are brought by this module.
+*/
+
+class mission {
+    file = "modules\28_captive\fnc";
+
+    // Module post initialization
+    class captive_postInit {
+        postInit = 1;
+    };
+
+    // Module pre initialization
+    class captive_preInit {
+        preInit = 1;
+    };
+
+};

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-25
+    Last Update: 2019-09-26
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -39,6 +39,9 @@ class captive {
     class captive_preInit {
         preInit = 1;
     };
+
+    // Checks for ACE handcuffed units and rebinds them into the Liberation captive system
+    class captive_setAceCaptive {};
 
     // Sets an unit into captive mode
     class captive_setCaptive {};

--- a/Missionframework/modules/28_captive/functions.hpp
+++ b/Missionframework/modules/28_captive/functions.hpp
@@ -4,7 +4,7 @@
     File: functions.hpp
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-09-10
-    Last Update: 2019-09-10
+    Last Update: 2019-09-11
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
     Public: No
 
@@ -27,5 +27,8 @@ class mission {
     class captive_preInit {
         preInit = 1;
     };
+
+    // Sets an unit into captive mode
+    class captive_setCaptive {};
 
 };

--- a/Missionframework/modules/README.md
+++ b/Missionframework/modules/README.md
@@ -45,6 +45,7 @@ With these additions the intended complexity comes into the mission. It is highl
 25 Friendly Commander Managing Dialog
 26 Cratefiller
 27 Mission handling
+28 Prisoners of war
 ```
 ### TBA
 Mod specific compatibility modules

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -263,6 +263,10 @@
             <English>Move to aft deck</English>
             <German>Zum Achterdeck bewegen</German>
         </Key>
+        <Key ID="STR_KPLIB_ACTION_INTERROGATE">
+            <English>Interrogate %1</English>
+            <German>%1 verhören</German>
+        </Key>
         <Key ID="STR_KPLIB_ACTION_LOADCAPTIVE">
             <English>Load %1</English>
             <German>%1 einladen</German>
@@ -1928,6 +1932,29 @@
         <Key ID="STR_KPLIB_SETTINGS_MISSION_REFUND_TT">
             <English>Defines the mission abortion refund in percentage.</English>
             <German>Definiert die Rückerstattung in Prozent.</German>
+        </Key>
+
+        <!-- CAPTIVE CATEGORY -->
+        <Key ID="STR_KPLIB_SETTINGS_CAPTIVE">
+            <English>KPLIB - Captives</English>
+            <German>KPLIB - Gefangene</German>
+        </Key>
+        <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELVALUE">
+            <English>Intel grant on interrogation</English>
+            <German>Informationszuwachs bei einer Verhörung</German>
+        </Key>
+        <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELVALUE_TT">
+            <English>Defines the amount of granted intel on Interrogation.</English>
+            <German>Definiert die Menge an Informationen, die bei einer Verhörung erhalten werden.</German>
+        </Key>
+        <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELRANDOM">
+            <English>Random Intel modifier on interrogation</English>
+            <German>Zufälliger Modifikator des Informationszuwachs bei einer Verhörung</German>
+        </Key>
+        <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELRANDOM_TT">
+            <English>Defines the random intel modifier on Interrogation, a setting of 5 will gain 5 upto 15 (+-Value) intel with an intel value of 10.</English>
+            <German>Definiert den zufälligen Modifikator des Informationszuwachs bei einer Verhörung, bei einer EInstellung von 5, beträgt der Zuwachs 5 bis 15 bei einem standard Nachrichtenwert von 10.</German>
+        </Key>
     </Package>
 
 

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -203,6 +203,10 @@
             <Chinese>-- 管理員選單 --</Chinese>
             <German>-- Admin Menü --</German>
         </Key>
+        <Key ID="STR_KPLIB_ACTION_ARREST">
+            <English>Arrest</English>
+            <German>Festnehmen</German>
+        </Key>
         <Key ID="STR_KPLIB_ACTION_ARSENAL">
             <English>-- ARSENAL --</English>
             <Chinese>-- 軍火庫 --</Chinese>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -251,6 +251,10 @@
             <English>-- RANDOM FOB DEPLOYMENT --</English>
             <German>-- ZUFÄLLIGE FOB PLATZIERUNG --</German>
         </Key>
+        <Key ID="STR_KPLIB_ACTION_ESCORT">
+            <English>Escort %1</English>
+            <German>%1 eskortieren</German>
+        </Key>
         <Key ID="STR_KPLIB_ACTION_GARRISON_MENU">
             <English>-- GARRISON MANAGEMENT --</English>
             <German>-- GARNISONSVERWALTUNG --</German>
@@ -316,6 +320,10 @@
             <Italian>- IMPILA E ORDINA -</Italian>
             <Portuguese>- ORDENAR E CLASSIFICAR -</Portuguese>
             <Turkish>- SIRALA VE DÜZENLE -</Turkish>
+        </Key>
+        <Key ID="STR_KPLIB_ACTION_STOPESCORT">
+            <English>Park %1</English>
+            <German>%1 abstellen</German>
         </Key>
         <Key ID="STR_KPLIB_ACTION_STORECRATE">
             <English>- STORE CRATE -</English>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -263,6 +263,10 @@
             <English>Move to aft deck</English>
             <German>Zum Achterdeck bewegen</German>
         </Key>
+        <Key ID="STR_KPLIB_ACTION_LOADCAPTIVE">
+            <English>Load %1</English>
+            <German>%1 einladen</German>
+        </Key>
         <Key ID="STR_KPLIB_ACTION_LOADCRATE">
             <English>- LOAD CRATE -</English>
             <Chinese>- 裝載貨物 -</Chinese>
@@ -335,6 +339,10 @@
             <Russian>- ХРАНЕНИЕ МАГАЗИНА -</Russian>
             <Spanish>- CAJA DE ALMACENAJE -</Spanish>
             <Turkish>- KUTUYU DEPOLA -</Turkish>
+        </Key>
+        <Key ID="STR_KPLIB_ACTION_UNLOADCAPTIVE">
+            <English>Unload %1</English>
+            <German>%1 ausladen</German>
         </Key>
         <Key ID="STR_KPLIB_ACTION_UNLOADCRATE">
             <English>- UNLOAD CRATES -</English>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -330,8 +330,8 @@
             <Turkish>- SIRALA VE DÜZENLE -</Turkish>
         </Key>
         <Key ID="STR_KPLIB_ACTION_STOPESCORT">
-            <English>Park %1</English>
-            <German>%1 abstellen</German>
+            <English>Stop escorting %1</English>
+            <German>%1 loslassen</German>
         </Key>
         <Key ID="STR_KPLIB_ACTION_STORECRATE">
             <English>- STORE CRATE -</English>
@@ -1693,8 +1693,8 @@
             <German>Einheitenverhältnis zur Sektoreroberung</German>
         </Key>
         <Key ID="STR_KPLIB_SETTINGS_SECTOR_SECRATIO_TT">
-            <English>Ratio from enemy to frindly units, which is needed to capture a sector.</English>
-            <German>Verhältnis von feindlichen und freundlichen kräften, welches benötigt wird um einen Sektor zu erobern.</German>
+            <English>Ratio of friendly to enemy units, which is needed to capture a sector.</English>
+            <German>Verhältnis von freundlichen zu feindlichen Kräften, welches benötigt wird um einen Sektor zu erobern.</German>
         </Key>
 
         <!-- ZEUS CATEGORY -->
@@ -1940,20 +1940,20 @@
             <German>KPLIB - Gefangene</German>
         </Key>
         <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELVALUE">
-            <English>Intel grant on interrogation</English>
-            <German>Informationszuwachs bei einer Verhörung</German>
+            <English>Intel gain through interrogation</English>
+            <German>Informationszuwachs bei einem Verhör</German>
         </Key>
         <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELVALUE_TT">
-            <English>Defines the amount of granted intel on Interrogation.</English>
-            <German>Definiert die Menge an Informationen, die bei einer Verhörung erhalten werden.</German>
+            <English>Amount of intel gained through interrogation.</English>
+            <German>Menge an Informationen, die bei einem Verhör gewonnen werden.</German>
         </Key>
         <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELRANDOM">
-            <English>Random Intel modifier on interrogation</English>
-            <German>Zufälliger Modifikator des Informationszuwachs bei einer Verhörung</German>
+            <English>Intel randomization range</English>
+            <German>Zufallsbereich für den Informationszuwachs</German>
         </Key>
         <Key ID="STR_KPLIB_SETTINGS_CAPTIVE_INTELRANDOM_TT">
-            <English>Defines the random intel modifier on Interrogation, a setting of 5 will gain 5 upto 15 (+-Value) intel with an intel value of 10.</English>
-            <German>Definiert den zufälligen Modifikator des Informationszuwachs bei einer Verhörung, bei einer EInstellung von 5, beträgt der Zuwachs 5 bis 15 bei einem standard Nachrichtenwert von 10.</German>
+            <English>Randomization range for intel gain through interrogation. E.g. a value of 5 will grant you 5 - 15 intel for a base value of 10.</English>
+            <German>Zufallsbereich für den Informationszuwachs bei einem Verhör. Mit einem Wert von 5 liegt der effektive Zuwachs, bei einem Ausgangswert von 10, zwischen 5 und 15.</German>
         </Key>
     </Package>
 

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1664,6 +1664,14 @@
             <Chinese>在戰區中心半徑公尺內的單位可進行佔領</Chinese>
             <German>Radius in Metern vom Sektor aus, in dem sich eine Einheit befinden muss, um den Sektor zu erobern.</German>
         </Key>
+        <Key ID="STR_KPLIB_SETTINGS_SECTOR_SECRATIO">
+            <English>Sector Capture Unit Ratio</English>
+            <German>Einheitenverhältnis zur Sektoreroberung</German>
+        </Key>
+        <Key ID="STR_KPLIB_SETTINGS_SECTOR_SECRATIO_TT">
+            <English>Ratio from enemy to frindly units, which is needed to capture a sector.</English>
+            <German>Verhältnis von feindlichen und freundlichen kräften, welches benötigt wird um einen Sektor zu erobern.</German>
+        </Key>
 
         <!-- ZEUS CATEGORY -->
         <Key ID="STR_KPLIB_SETTINGS_ZEUS">

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -204,8 +204,8 @@
             <German>-- Admin Menü --</German>
         </Key>
         <Key ID="STR_KPLIB_ACTION_ARREST">
-            <English>Arrest</English>
-            <German>Festnehmen</German>
+            <English>Arrest %1</English>
+            <German>%1 festnehmen</German>
         </Key>
         <Key ID="STR_KPLIB_ACTION_ARSENAL">
             <English>-- ARSENAL --</English>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | #531 |

### Description:

This PR provides the first iteration of the PoW.
This ensures that leftover enemys on a sector capture will surrender and the player is able to interact with them.

### Content:
- [x] Implementation of the intel points (or similar wording) value
- [x] Chance for enemies to surrender under sensible circumstances
- [x] Event handling of surrendering enemies by providing capture actions (or ziptie with ACE), so the player can bring them to a FOB
- [x] Gaining of intel from the interrogation and also maybe chances to fire an additional event

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP

### Compatibility checked with:
- [x] ACE 3
