### PR TITLE
v0.96.7 - Fix mobile respawn flickering

### DIFF
--- a/Missionframework/scripts/shared/functions/F_getMobileRespawns.sqf
+++ b/Missionframework/scripts/shared/functions/F_getMobileRespawns.sqf
@@ -2,7 +2,7 @@ private _respawn_trucks_unsorted = vehicles select {
     (typeof _x == Respawn_truck_typename || typeof _x == huron_typename ) &&
     _x distance2d startbase > 500 &&
     !surfaceIsWater (getpos _x) &&
-    isTouchingGround _x &&
+    (isTouchingGround _x || {5 > ((getPos _x) select 2)}) &&
     alive _x &&
     speed _x < 5
 };


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no  |
| Fixed issues | - |

### Description:
Fix mobile respawn flickering introduced by removing height check and using `isTouchingGround`. Use both methods so the check should be still more reliable for vehicles with bad models.