### PR TITLE
v0.96.7 - Hotfix - Object inits improvements

### DIFF
--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -8,6 +8,7 @@ if (!isServer) then {waitUntil {!isNil "KP_serverParamsFetched"};};
 [] call compileFinal preprocessFileLineNumbers "scripts\shared\fetch_params.sqf";
 [] call compileFinal preprocessFileLineNumbers "kp_liberation_config.sqf";
 [] call compileFinal preprocessFileLineNumbers "presets\init_presets.sqf";
+KPLIB_objectInitsCache = createSimpleObject ["a3\weapons_f\empty.p3d", [-7580, -7580, 0], true];
 [] call compileFinal preprocessFileLineNumbers "kp_objectInits.sqf";
 
 [] execVM "GREUH\scripts\GREUH_activate.sqf";

--- a/Missionframework/kp_objectInits.sqf
+++ b/Missionframework/kp_objectInits.sqf
@@ -17,7 +17,7 @@ KPLIB_objectInits = [
     [["Flag_White_F"], {_this setFlagTexture "res\flag_kp_co.paa";}],
 
     // Add helipads to zeus, as they can't be recycled after built
-    [["Land_HelipadSquare_F", "Land_HelipadCircle_F", "Land_HelipadRescue_F", "LAND_uns_Heli_pad", "Helipad", "LAND_uns_evac_pad", "LAND_uns_Heli_H"], {{[_x, [[_this], true]] remoteExecCall ["addCuratorEditableObjects", 2]} forEach allCurators;}],
+    [["Helipad_base_F", "LAND_uns_Heli_pad", "Helipad", "LAND_uns_evac_pad", "LAND_uns_Heli_H"], {{[_x, [[_this], true]] remoteExecCall ["addCuratorEditableObjects", 2]} forEach allCurators;}, true],
 
     // Add ViV action to FOB box
     [[FOB_box_typename], {_this call F_setFobMass; [_this] remoteExecCall ["F_setLoadableViV", 0, _this];}],

--- a/Missionframework/kp_objectInits.sqf
+++ b/Missionframework/kp_objectInits.sqf
@@ -1,6 +1,16 @@
-/* - Specific object init codes depending on classnames.
-Format = [Array of classnames as strings, Code to apply]
-_this is the reference to the object with the classname */
+/*
+    Specific object init codes depending on classnames.
+
+    Format = [Array of classnames as strings <ARRAY>, Code to apply <CODE>, Allow inheritance <BOOL>]
+        _this is the reference to the object with the classname
+
+    Example:
+        KPLIB_objectInits = [
+            [["O_soldierU_F"], {systemChat "CSAT urban soldier was spawned!"}],
+            [["CAManBase"], {systemChat format ["Some human named '%1' was spawned!", name _this]}, true]
+        ];
+];
+*/
 
 KPLIB_objectInits = [
     // Set KP logo on white flag

--- a/Missionframework/scripts/server/ai/troup_transport.sqf
+++ b/Missionframework/scripts/server/ai/troup_transport.sqf
@@ -14,7 +14,7 @@ if ((alive _troup_transport) && (alive (driver _troup_transport))) then {
 	while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
 
 	{
-		_x createUnit [_start_pos, _troupgrp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+		[_x, _start_pos, _troupgrp, "PRIVATE", 0.5] call F_createManagedUnit;
 	} foreach (["army"] call F_getAdaptiveSquadComp);
 
 	{ _x moveInCargo _troup_transport } foreach (units _troupgrp);

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -20,10 +20,9 @@ while {true} do {
 		private _house = (nearestObjects [[((getMarkerPos _sector select 0) - 100 + (random 200)), ((getMarkerPos _sector select 1) - 100 + (random 200))],["House", "Building"], 100]) select 0;
 
 		private _grp = createGroup [GRLIB_side_civilian, true];
-		private _informant = _grp createUnit [(selectRandom civilians), getMarkerPos _sector, [], 0, "NONE"];
+		private _informant = [selectRandom civilians, getMarkerPos _sector, _grp] call F_createManagedUnit;
 		private _waiting_time = KP_liberation_civinfo_duration;
 
-		_informant addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
 		_informant setPos (selectRandom (_house buildingPos -1));
 		_informant setUnitPos "UP";
 		sleep 1;

--- a/Missionframework/scripts/server/civinformant/tasks/civinfo_task.sqf
+++ b/Missionframework/scripts/server/civinformant/tasks/civinfo_task.sqf
@@ -14,9 +14,10 @@ _veh setDir (getDir _roadObj);
 } forEach ((getAllHitPointsDamage _veh) select 0);
 
 private _grp = createGroup [GRLIB_side_enemy, true];
-private _hvt = _grp createUnit [opfor_officer, getPos _roadObj, [], 30, "NONE"];
+private _hvt = [opfor_officer, getPos _roadObj, _grp, "CAPTAIN", 30] call F_createManagedUnit;
+
 for "_i" from 1 to 4 do {
-	(selectRandom militia_squad) createUnit [_grp, _grp, "this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]"];
+    [selectRandom militia_squad, _grp, _grp] call F_createManagedUnit;
 	sleep 0.1;
 };
 
@@ -46,7 +47,7 @@ private _marker_pos = [((((getPos _roadObj) select 0) + 200) - random 400),((((g
 private _time_remaining = KP_liberation_civinfo_task_duration;
 
 while {(alive _hvt) && _time_remaining > 0} do {
-	uiSleep 1;			
+	uiSleep 1;
 	private _player_near = false;
 	{
 		if (((_x distance _veh) < 1000) && (alive _x)) exitWith {_player_near = true};

--- a/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
+++ b/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
@@ -14,8 +14,7 @@ for "_i" from 1 to _count do {
 	while {(surfaceIsWater _pos) || ((count ([_pos, 30] call F_getNearbyPlayers)) > 0)} do {
 		_pos = (markerPos _sector) getPos [(50 + (random 200)), (random 360)];
 	};
-	private _civ = _grp createUnit [(selectRandom civilians), _pos, [], 0, "NONE"];
-	_civ addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+	private _civ = [selectRandom civilians, _pos, _grp] call F_createManagedUnit;
 	_civ setDir (random 360);
 	{_civ disableAI _x} forEach ["ANIM", "TARGET", "AUTOTARGET", "MOVE"];
 	removeAllItems _civ;

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -443,7 +443,7 @@ if (!isNil "greuh_liberation_savegame") then {
             _x params ["_spawnPos", "_units"];
             private _grp = createGroup [GRLIB_side_friendly, true];
             {
-                _x createUnit [[_spawnPos, _grp] select (_forEachIndex > 0), _grp, 'this addMPEventHandler ["MPKilled", {_this spawn kill_manager}]'];
+                [_x, [_spawnPos, _grp] select (_forEachIndex > 0), _grp] call F_createManagedUnit;
             } forEach _units;
         } forEach _aiGroups;
     } else {
@@ -455,7 +455,7 @@ if (!isNil "greuh_liberation_savegame") then {
                 private _unit = _x;
                 private _pos = [(_unit select 1) select 0, (_unit select 1) select 1, ((_unit select 1) select 2) + 0.2];
                 private _dir = _unit select 2;
-                (_unit select 0) createUnit [ _pos, _grp, 'this addMPEventHandler ["MPKilled", {_this spawn kill_manager}]'];
+                [(_unit select 0), _pos, _grp] call F_createManagedUnit;
                 private _nextobj = ((units _grp) select ((count (units _grp)) - 1));
                 _nextobj setDir _dir;
                 _nextobj setPosATL _pos;

--- a/Missionframework/scripts/server/patrols/manage_one_civilian_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_civilian_patrol.sqf
@@ -26,7 +26,7 @@ while { GRLIB_endgame == 0 } do {
 		if ( random 100 < 33) then {
 			_civnumber = 1 + (floor (random 2));
 			while { count units _grp < _civnumber } do {
-				(selectRandom civilians) createUnit [ markerpos _spawnsector, _grp, "this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+				[selectRandom civilians, markerPos _spawnsector, _grp, "PRIVATE", 0.5] call F_createManagedUnit;
 			};
 			_grpspeed = "LIMITED";
 		} else {
@@ -39,7 +39,7 @@ while { GRLIB_endgame == 0 } do {
 
 			_spawnpos = getpos _nearestroad;
 
-			(selectRandom civilians) createUnit [_spawnpos, _grp, "this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+			[selectRandom civilians, _spawnpos, _grp, "PRIVATE", 0.5] call F_createManagedUnit;
 			_civveh = (selectRandom civilian_vehicles) createVehicle _spawnpos;
 			_civveh setpos _spawnpos;
 			_civveh addMPEventHandler ['MPKilled', {_this spawn kill_manager}];

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -30,7 +30,7 @@ while { GRLIB_endgame == 0 } do {
 		_grp = createGroup [GRLIB_side_enemy, true];
 		_squad = ["army"] call F_getAdaptiveSquadComp;
 		{
-			_x createUnit [_sector_spawn_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+			[_x, _sector_spawn_pos, _grp, "PRIVATE", 0.5] call F_createManagedUnit;
 		} foreach _squad;
 	} else {
 

--- a/Missionframework/scripts/server/patrols/send_paratroopers.sqf
+++ b/Missionframework/scripts/server/patrols/send_paratroopers.sqf
@@ -21,7 +21,7 @@ _newvehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
 {_x addMPEventHandler ["MPKilled", {_this spawn kill_manager}];} forEach (crew _newvehicle);
 
 while {(count (units _para_group)) < 8} do {
-	opfor_paratrooper createUnit [getmarkerpos _spawnsector, _para_group, "this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]"];
+	[opfor_paratrooper, markerPos _spawnsector, _para_group] call F_createManagedUnit;
 };
 
 {removeBackpack _x; _x addBackPack "B_parachute"; _x moveInCargo _newvehicle;} forEach (units _para_group);

--- a/Missionframework/scripts/server/secondary/convoy_hijack.sqf
+++ b/Missionframework/scripts/server/secondary/convoy_hijack.sqf
@@ -76,7 +76,9 @@ _waypoint setWaypointType "CYCLE";
 _waypoint setWaypointCompletionRadius 50;
 
 private _troops_group = createGroup [GRLIB_side_enemy, true];
-{_x createUnit [_spawnpos, _troops_group,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];} foreach (["army"] call F_getAdaptiveSquadComp);
+{
+	[_x, _spawnpos, _troops_group, "PRIVATE", 0.5] call F_createManagedUnit;
+} foreach (["army"] call F_getAdaptiveSquadComp);
 {_x moveInCargo _troop_vehicle} foreach (units _troops_group);
 
 private _convoy_marker = createMarkerLocal [ format [ "convoymarker%1", round time], getpos _transport_vehicle ];

--- a/Missionframework/scripts/server/secondary/fob_hunting.sqf
+++ b/Missionframework/scripts/server/secondary/fob_hunting.sqf
@@ -85,10 +85,10 @@ while {(count _idxselected) < _defenders_amount && (count _idxselected) < (count
     ];
 
     _nextpos = [((_base_position select 0) + (_nextpos select 0)), ((_base_position select 1) + (_nextpos select 1)), (_nextpos select 2)];
-    _nextclass createUnit [_nextpos, _grpdefenders, "nextdefender = this; this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
-    nextdefender setdir _nextdir;
-    nextdefender setpos _nextpos;
-    [nextdefender] spawn building_defence_ai;
+    private _nextDefender = [_nextclass, _nextpos, _grpdefenders, "PRIVATE", 0.5] call F_createManagedUnit;
+    _nextDefender setdir _nextdir;
+    _nextDefender setpos _nextpos;
+    [_nextDefender] spawn building_defence_ai;
 } forEach _idxselected;
 
 private _sentryMax = ceil ((3 + (floor (random 4))) * (sqrt (GRLIB_unitcap)));
@@ -96,7 +96,7 @@ private _sentryMax = ceil ((3 + (floor (random 4))) * (sqrt (GRLIB_unitcap)));
 _grpsentry = createGroup [GRLIB_side_enemy, true];
 _base_sentry_pos = [(_base_position select 0) + ((_base_corners select 0) select 0), (_base_position select 1) + ((_base_corners select 0) select 1), 0];
 for [{_idx=0}, {_idx < _sentryMax}, {_idx=_idx+1}] do {
-    opfor_sentry createUnit [_base_sentry_pos, _grpsentry,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+    [opfor_sentry, _base_sentry_pos, _grpsentry, "PRIVATE", 0.5] call F_createManagedUnit;
 };
 
 while {(count (waypoints _grpsentry)) != 0} do {deleteWaypoint ((waypoints _grpsentry) select 0);};

--- a/Missionframework/scripts/server/secondary/search_and_rescue.sqf
+++ b/Missionframework/scripts/server/secondary/search_and_rescue.sqf
@@ -17,10 +17,13 @@ _helofire setpos (getpos _helowreck);
 
 private _pilotsGrp = createGroup [GRLIB_side_enemy, true];
 private _pilotsPos = (getpos _helowreck) getPos [25, random 360];
-pilot_classname createUnit [ _pilotsPos, _pilotsGrp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+
+[pilot_classname, _pilotsPos, _pilotsGrp, "PRIVATE", 0.5] call F_createManagedUnit;
 sleep 0.2;
-pilot_classname createUnit [_pilotsPos getPos [1, random 360], _pilotsGrp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+
+[pilot_classname, _pilotsPos getPos [1, random 360], _pilotsGrp, "PRIVATE", 0.5] call F_createManagedUnit;
 sleep 2;
+
 private _pilotUnits = units _pilotsGrp;
 {
 	[ _x, true ] spawn prisonner_ai;
@@ -36,7 +39,9 @@ private _patrolcorners = [
 	[ (getpos _helowreck select 0) - 40, (getpos _helowreck select 1) + 40, 0 ]
 ];
 
-{ _x createUnit [ _patrolcorners select 0, _grppatrol,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"]; } foreach (["army"] call F_getAdaptiveSquadComp);
+{
+	[_x, _patrolcorners select 0, _grppatrol, "PRIVATE", 0.5] call F_createManagedUnit;
+} foreach (["army"] call F_getAdaptiveSquadComp);
 
 while {(count (waypoints _grppatrol)) != 0} do {deleteWaypoint ((waypoints _grppatrol) select 0);};
 {
@@ -56,7 +61,7 @@ private _grpsentry = createGroup [GRLIB_side_enemy, true];
 private _nbsentry = 2 + (floor (random 3));
 
 for [ {_idx=0},{_idx < _nbsentry},{_idx=_idx+1} ] do {
-	opfor_sentry createUnit [_pilotsPos getPos [1, random 360], _grpsentry,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+	[opfor_sentry, _pilotsPos getPos [1, random 360], _grpsentry, "PRIVATE", 0.5] call F_createManagedUnit;
 };
 
 (leader _grpsentry) setDir (random 360);

--- a/Missionframework/scripts/server/sector/attack_in_progress_fob.sqf
+++ b/Missionframework/scripts/server/sector/attack_in_progress_fob.sqf
@@ -8,7 +8,9 @@ if ( _ownership != GRLIB_side_enemy ) exitWith {};
 
 if ( GRLIB_blufor_defenders ) then {
 	_grp = creategroup [GRLIB_side_friendly, true];
-	{ _x createUnit [ _thispos, _grp,'this addMPEventHandler ["MPKilled", {_this spawn kill_manager}]']; } foreach blufor_squad_inf;
+	{
+		[_x, _thispos, _grp] call F_createManagedUnit;
+	} foreach blufor_squad_inf;
 	sleep 3;
 	_grp setBehaviour "COMBAT";
 };

--- a/Missionframework/scripts/server/sector/attack_in_progress_sector.sqf
+++ b/Missionframework/scripts/server/sector/attack_in_progress_sector.sqf
@@ -13,7 +13,9 @@ if ( _sector in sectors_military ) then {
 
 if ( GRLIB_blufor_defenders ) then {
 	_grp = creategroup [GRLIB_side_friendly, true];
-	{ _x createUnit [ markerpos _sector, _grp,'this addMPEventHandler ["MPKilled", {_this spawn kill_manager}]']; } foreach _squad_type;
+	{
+		[_x, markerPos _sector, _grp] call F_createManagedUnit;
+	} foreach _squad_type;
 	sleep 3;
 	_grp setBehaviour "COMBAT";
 };

--- a/Missionframework/scripts/shared/functions/F_forceBluforCrew.sqf
+++ b/Missionframework/scripts/shared/functions/F_forceBluforCrew.sqf
@@ -9,7 +9,7 @@ if ( count crew _veh > 0 ) then {
 
 		_grp = createGroup [GRLIB_side_friendly, true];
 		while { count units _grp < 3 } do {
-			crewman_classname createUnit [ getPos _veh, _grp, 'this addMPEventHandler ["MPKilled", {_this spawn kill_manager}] '];
+			[crewman_classname, getPos _veh, _grp] call F_createManagedUnit;
 		};
 		((units _grp) select 0) moveInDriver _veh;
 		((units _grp) select 1) moveInGunner _veh;

--- a/Missionframework/scripts/shared/functions/F_kp_addObjectInit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_addObjectInit.sqf
@@ -21,7 +21,7 @@ params [["_object", objNull, [objNull]]];
 private _elements = KPLIB_objectInitsCache getVariable typeOf _object;
 
 // Find and cache matching objectInits
-if (isNil _elements) then {
+if (isNil "_elements") then {
     _elements = KPLIB_objectInits select {
         _x params ["_classes", "", ["_inheritance", false]];
 

--- a/Missionframework/scripts/shared/functions/F_kp_addObjectInit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_addObjectInit.sqf
@@ -18,7 +18,19 @@
 
 params [["_object", objNull, [objNull]]];
 
-private _elements = KPLIB_objectInits select {(toLower (typeOf _object)) in ((_x select 0) apply {toLower _x})};
+private _elements = KPLIB_objectInits select {
+    _x params ["_classes", "", ["_inheritance", false]];
+
+    if (_inheritance) then {
+        {
+            if (_object isKindOf _x) exitWith {true};
+            false
+        } forEach _classes // return
+    } else {
+        // return
+        (toLower (typeOf _object)) in (_classes apply {toLower _x})
+    };
+};
 
 if (_elements isEqualTo []) exitWith {
     false

--- a/Missionframework/scripts/shared/functions/F_kp_addObjectInit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_addObjectInit.sqf
@@ -18,18 +18,25 @@
 
 params [["_object", objNull, [objNull]]];
 
-private _elements = KPLIB_objectInits select {
-    _x params ["_classes", "", ["_inheritance", false]];
+private _elements = KPLIB_objectInitsCache getVariable typeOf _object;
 
-    if (_inheritance) then {
-        {
-            if (_object isKindOf _x) exitWith {true};
-            false
-        } forEach _classes // return
-    } else {
-        // return
-        (toLower (typeOf _object)) in (_classes apply {toLower _x})
+// Find and cache matching objectInits
+if (isNil _elements) then {
+    _elements = KPLIB_objectInits select {
+        _x params ["_classes", "", ["_inheritance", false]];
+
+        if (_inheritance) then {
+            {
+                if (_object isKindOf _x) exitWith {true};
+                false
+            } forEach _classes // return
+        } else {
+            // return
+            (toLower (typeOf _object)) in (_classes apply {toLower _x})
+        };
     };
+
+    KPLIB_objectInitsCache setVariable [typeOf _object, _elements];
 };
 
 if (_elements isEqualTo []) exitWith {

--- a/Missionframework/scripts/shared/functions/F_kp_createCrate.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createCrate.sqf
@@ -33,4 +33,7 @@ clearItemCargoGlobal _crate;
 
 if(KP_liberation_ace) then {[_crate, true, [0, 1.5, 0], 0] remoteExec ["ace_dragging_fnc_setCarryable"];};
 
+// Process KP object init
+[_crate] call F_addObjectInit;
+
 _crate

--- a/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
@@ -30,9 +30,17 @@ params [
     ["_placement", 0, [0]]
 ];
 
-private _unit = _group createUnit [_type, _spawnPos, [], _placement, "FORM"];
+// Create temp group, as we need to let the unit join the "correct side group".
+// If we use the "correct side group" for the createUnit, the group would switch to the side of the unit written in the config.
+private _groupTemp = createGroup [CIVILIAN, true];
+
+private _unit = _groupTemp createUnit [_type, _spawnPos, [], _placement, "FORM"];
 _unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
 _unit setRank _rank;
+
+// Joint to target group to preserve Side
+[_unit] joinSilent _group;
+deleteGroup _groupTemp;
 
 // Process KP object init
 [_unit] call F_addObjectInit;

--- a/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
@@ -34,8 +34,6 @@ private _unit = _group createUnit [_type, _spawnPos, [], "FORM"];
 _unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
 _unit setRank _rank;
 
-_x createUnit [_start_pos, _troupgrp,"this ", _placement, "private"];
-
 // Process KP object init
 [_unit] call F_addObjectInit;
 

--- a/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
@@ -1,0 +1,42 @@
+/*
+    F_createManagedUnit
+
+    File: F_kp_createManagedUnit.sqf
+    Author: veteran29 - https://github.com/veteran29
+    Date: 2019-10-04
+    Last Update: 2019-10-04
+
+    Description:
+        Creates unit managed by kill tracker.
+
+    Parameter(s):
+        0: STRING               - Type of unit. (Default "")
+        1: ARRAY|OBJECT|GROUP   - Where to spawn. (Default [0,0,0])
+        2: GROUP                - Group to add the unit to. (Default objNull)
+        3: STRING               - Unit rank. (Default "PRIVATE")
+        4: NUMBER               - Placement radius. (Default 0)
+
+    Example:
+
+
+    Returns:
+        OBJECT - Created unit
+*/
+params [
+    ["_type", "", [""]]
+    ["_spawnPos", [0,0,0], [[], objNull, grpNull], [2,3]],
+    ["_group", grpNull, [grpNull]],
+    ["_rank", "PRIVATE", [""]],
+    ["_placement", 0, [0]]
+];
+
+private _unit = _group createUnit [_type, _spawnPos, [], "FORM"];
+_unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+_unit setRank _rank;
+
+_x createUnit [_start_pos, _troupgrp,"this ", _placement, "private"];
+
+// Process KP object init
+[_unit] call F_addObjectInit;
+
+_unit // return

--- a/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
@@ -40,7 +40,7 @@ isNil {
     _unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
     _unit setRank _rank;
 
-    // Joint to target group to preserve Side
+    // Join to target group to preserve Side
     [_unit] joinSilent _group;
     deleteGroup _groupTemp;
 

--- a/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
@@ -23,14 +23,14 @@
         OBJECT - Created unit
 */
 params [
-    ["_type", "", [""]]
+    ["_type", "", [""]],
     ["_spawnPos", [0,0,0], [[], objNull, grpNull], [2,3]],
     ["_group", grpNull, [grpNull]],
     ["_rank", "PRIVATE", [""]],
     ["_placement", 0, [0]]
 ];
 
-private _unit = _group createUnit [_type, _spawnPos, [], "FORM"];
+private _unit = _group createUnit [_type, _spawnPos, [], _placement, "FORM"];
 _unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
 _unit setRank _rank;
 

--- a/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_createManagedUnit.sqf
@@ -30,19 +30,22 @@ params [
     ["_placement", 0, [0]]
 ];
 
-// Create temp group, as we need to let the unit join the "correct side group".
-// If we use the "correct side group" for the createUnit, the group would switch to the side of the unit written in the config.
-private _groupTemp = createGroup [CIVILIAN, true];
+private "_unit";
+isNil {
+    // Create temp group, as we need to let the unit join the "correct side group".
+    // If we use the "correct side group" for the createUnit, the group would switch to the side of the unit written in the config.
+    private _groupTemp = createGroup [CIVILIAN, true];
 
-private _unit = _groupTemp createUnit [_type, _spawnPos, [], _placement, "FORM"];
-_unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
-_unit setRank _rank;
+    _unit = _groupTemp createUnit [_type, _spawnPos, [], _placement, "FORM"];
+    _unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+    _unit setRank _rank;
 
-// Joint to target group to preserve Side
-[_unit] joinSilent _group;
-deleteGroup _groupTemp;
+    // Joint to target group to preserve Side
+    [_unit] joinSilent _group;
+    deleteGroup _groupTemp;
 
-// Process KP object init
-[_unit] call F_addObjectInit;
+    // Process KP object init
+    [_unit] call F_addObjectInit;
+};
 
 _unit // return

--- a/Missionframework/scripts/shared/functions/F_kp_spawnGuerillaGroup.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_spawnGuerillaGroup.sqf
@@ -26,8 +26,8 @@ private _vests = missionNamespace getVariable ("KP_liberation_guerilla_vests_" +
 private _headgear = missionNamespace getVariable ("KP_liberation_guerilla_headgear_" + str _tier);
 
 while {(count (units _grp) < _amount)} do {
-	private _unit = _grp createUnit [(selectRandom KP_liberation_guerilla_units), _pos, [], 5, "NONE"];
-	_unit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+	private _unit = [selectRandom KP_liberation_guerilla_units, _pos, _grp, "PRIVATE", 5] call F_createManagedUnit;
+
 	private _weapon = selectRandom _weapons;
 
 	removeAllWeapons _unit;

--- a/Missionframework/scripts/shared/functions/F_libSpawnMilitiaCrew.sqf
+++ b/Missionframework/scripts/shared/functions/F_libSpawnMilitiaCrew.sqf
@@ -3,7 +3,7 @@ params ["_vehicle"];
 private _grp = createGroup [GRLIB_side_enemy, true];
 private _vehcrew = [];
 while {count units _grp < 3} do {
-	(selectRandom militia_squad) createUnit [getpos _vehicle, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]"];
+	[selectRandom militia_squad, getPos _vehicle, _grp] call F_createManagedUnit;
 };
 ((units _grp) select 0) moveInDriver _vehicle;
 ((units _grp) select 1) moveInGunner _vehicle;

--- a/Missionframework/scripts/shared/functions/F_spawnBuildingSquad.sqf
+++ b/Missionframework/scripts/shared/functions/F_spawnBuildingSquad.sqf
@@ -25,9 +25,8 @@ while {count _position_indexes < count _squadtospawn} do {
 private _grp = createGroup [GRLIB_side_enemy, true];
 private _idxposit = 0;
 {
-	_x createUnit [_sectorpos, _grp];
-	private _nextunit = (units _grp) select ((count (units _grp)) -1);
-	_nextunit addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+	private _nextunit = [_x, _sectorpos, _grp] call F_createManagedUnit;
+
 	_nextunit setdir (random 360);
 	_nextunit setpos (_buildingpositions select (_position_indexes select _idxposit));
 	[_nextunit, _sector] spawn building_defence_ai;

--- a/Missionframework/scripts/shared/functions/F_spawnCivilians.sqf
+++ b/Missionframework/scripts/shared/functions/F_spawnCivilians.sqf
@@ -16,8 +16,8 @@ _nbcivs = _nbcivs * (sqrt (GRLIB_unitcap));
 while {_idx < _nbcivs} do {
 	private _spawnpos = [(((_sectorpos select 0) + (75 * _spread)) - (random (150 * _spread))),(((_sectorpos select 1) + (75 * _spread)) - (random (150 * _spread))),0];
 	private _grp = createGroup [GRLIB_side_civilian, true];
-	(civilians select (floor (random (count civilians)))) createUnit [_spawnpos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]"];
-	private _nextciv = ((units _grp) select 0);
+
+	private _nextciv = [selectRandom civilians, _spawnpos, _grp] call F_createManagedUnit;
 	_createdcivs pushBack _nextciv;
 	[_grp] call add_civ_waypoints;
 	_idx = _idx + 1;

--- a/Missionframework/scripts/shared/functions/F_spawnMilitaryPostSquad.sqf
+++ b/Missionframework/scripts/shared/functions/F_spawnMilitaryPostSquad.sqf
@@ -9,13 +9,14 @@ if (count _allposts > 0) then {
 	{
 		private _building_positions = [_x] call BIS_fnc_buildingPositions;
 		private _unitclasspost = opfor_marksman;
-		nextunit_post = objNull;
+
 		if (random 100 > 60) then {
 			_unitclasspost = opfor_machinegunner;
 		};
-		_unitclasspost createUnit [_squadpos, _grp, "nextunit_post = this; this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]"];
-		nextunit_post setdir (180 + (getdir _x));
-		nextunit_post setpos (_building_positions select 1);
+
+		private _nextunit_post = [_unitclasspost, _squadpos, _grp] call F_createManagedUnit;
+		_nextunit_post setdir (180 + (getdir _x));
+		_nextunit_post setpos (_building_positions select 1);
 
 	} forEach _allposts;
 

--- a/Missionframework/scripts/shared/functions/F_spawnRegularSquad.sqf
+++ b/Missionframework/scripts/shared/functions/F_spawnRegularSquad.sqf
@@ -13,7 +13,7 @@ private _grp = createGroup [GRLIB_side_enemy, true];
 
 {
 	if ((count (units _grp)) < _corrected_amount) then {
-		_x createUnit [_spawnpos, _grp, "this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]"];
+		[_x, _spawnpos, _grp] call F_createManagedUnit;
 	};
 	sleep 0.1;
 } forEach _squadies_to_spawn;

--- a/Missionframework/scripts/shared/liberation_functions.sqf
+++ b/Missionframework/scripts/shared/liberation_functions.sqf
@@ -57,6 +57,7 @@ F_cr_ace_action = compileFinal preprocessFileLineNumbers "scripts\shared\functio
 F_getResistanceTier = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_getResistanceTier.sqf";
 F_spawnGuerillaGroup = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_spawnGuerillaGroup.sqf";
 F_createCrate = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_createCrate.sqf";
+F_createManagedUnit = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_createManagedUnit.sqf";
 F_isClassUAV = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_isClassUAV.sqf";
 F_getWeaponComponents = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_getWeaponComponents.sqf";
 F_removeWeaponCargo = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_removeWeaponCargo.sqf";


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes  |
| Needs wipe? | no  |
| Fixed issues | - |

### Description:
Improvements for object inits. Added support for resource crates and units. To make handling of units initialization easier creation of units managed by liberation Kill-Tracker was moved into separate dedicated function

### Content:
- [x] Object inits support for resource crates
- [x] `F_createManagedUnit` function
- [x] `createUnit` usage replaced with `F_createManagedUnit` where applicable
- [x] Support for inheritance in `KP_objectInits`, 3rd argument, optional for BWC

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP


### Compatibility checked with:
* None
