### PR TITLE
v0.96.7 - Save mines placed around FOBs

### DIFF
--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -585,9 +585,9 @@ while {true} do {
         } forEach (_allBlueGroups select {(_fobPos distance2D (leader _x)) < (GRLIB_fob_range * 2)});
 
         // Save all mines around FOB
-        private _fobMines = allMines inAreaArray [GRLIB_fob_range * 2, GRLIB_fob_range * 2];
+        private _fobMines = allMines inAreaArray [_fobPos, GRLIB_fob_range * 2, GRLIB_fob_range * 2];
         _allMines pushBack (_fobMines apply {[
-            getPosWorld _x;;
+            getPosWorld _x,
             [vectorDirVisual _x, vectorUpVisual _x],
             typeOf _x
         ]});

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -34,6 +34,8 @@ private _resourceStorages = [];
 private _stats = [];
 // Collection array for the enemy weights
 private _weights = [];
+// All mines around FOBs
+private _allMines = [];
 
 /*
     --- Globals ---
@@ -168,6 +170,7 @@ if (!isNil "greuh_liberation_savegame") then {
         KP_liberation_production                    = greuh_liberation_savegame select 16;
         KP_liberation_production_markers            = greuh_liberation_savegame select 17;
         resources_intel                             = greuh_liberation_savegame select 18;
+        _allMines                                   = greuh_liberation_savegame param [19, []];
 
         stats_ammo_produced                         = _stats select  0;
         stats_ammo_spent                            = _stats select  1;
@@ -372,6 +375,16 @@ if (!isNil "greuh_liberation_savegame") then {
 
     if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved buildings placed";};
 
+    {
+        _x params ["_minePos", "_dirAndUp", "_class"];
+
+        private _mine = createMine [_class, _minePos, [], 0];
+        _mine setPosWorld _minePos;
+        _mine setVectorDirAndUp _dirAndUp;
+    } forEach _allMines;
+
+    if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved mines placed";};
+
     // Spawn saved resource storages and their content
     {
         _x params ["_class", "_pos", "_vecDir", "_vecUp", "_supply", "_ammo", "_fuel"];
@@ -532,6 +545,7 @@ while {true} do {
 
     private _allObjects = [];
     private _allStorages = [];
+    private _allMines = [];
 
     // Get all blufor groups
     private _allBlueGroups = allGroups select {
@@ -565,6 +579,14 @@ while {true} do {
             // Add to save array
             _aiGroups pushBack [getPosATL (leader _x), (_grpUnits apply {typeOf _x})];
         } forEach (_allBlueGroups select {(_fobPos distance2D (leader _x)) < (GRLIB_fob_range * 2)});
+
+        // Save all mines around FOB
+        private _fobMines = allMines inAreaArray [GRLIB_fob_range * 2, GRLIB_fob_range * 2];
+        _allMines pushBack (_fobMines apply {[
+            getPosWorld _x;;
+            [vectorDirVisual _x, vectorUpVisual _x],
+            typeOf _x
+        ]});
     } forEach GRLIB_all_fobs;
 
     // Save all fetched objects
@@ -686,7 +708,8 @@ while {true} do {
         KP_liberation_logistics,
         KP_liberation_production,
         KP_liberation_production_markers,
-        resources_intel
+        resources_intel,
+        _allMines
     ];
 
     // Write data in the severs profileNamespace

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -397,7 +397,7 @@ if (!isNil "greuh_liberation_savegame") then {
         if (_class in _classnamesToSave) then {
 
             // Create object without damage handling and simulation
-            private _object = createVehicle [_class, _pos, [], 0, "CAN_COLLIDE"];;
+            private _object = createVehicle [_class, _pos, [], 0, "CAN_COLLIDE"];
             _object allowdamage false;
             _object enableSimulation false;
 
@@ -598,7 +598,7 @@ while {true} do {
         // Position data
         private _savedpos = getPosWorld _x;
         private _savedvecdir = vectorDirVisual _x;
-        private _savedvecup = vectorUpVisual _x;;
+        private _savedvecup = vectorUpVisual _x;
         private _class = typeOf _x;
         private _hascrew = false;
 
@@ -618,9 +618,9 @@ while {true} do {
     // Save all storages and resources
     {
         // Position data
-        private _savedpos = getPosWorld _x;;
+        private _savedpos = getPosWorld _x;
         private _savedvecdir = vectorDirVisual _x;
-        private _savedvecup = vectorUpVisual _x;;
+        private _savedvecup = vectorUpVisual _x;
         private _class = typeof _x;
 
         // Resource variables

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -381,6 +381,10 @@ if (!isNil "greuh_liberation_savegame") then {
         private _mine = createMine [_class, _minePos, [], 0];
         _mine setPosWorld _minePos;
         _mine setVectorDirAndUp _dirAndUp;
+
+        // reveal mine to player side
+        GRLIB_side_friendly revealMine _mine;
+
     } forEach _allMines;
 
     if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved mines placed";};

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -586,7 +586,7 @@ while {true} do {
 
         // Save all mines around FOB
         private _fobMines = allMines inAreaArray [_fobPos, GRLIB_fob_range * 2, GRLIB_fob_range * 2];
-        _allMines pushBack (_fobMines apply {[
+        _allMines append (_fobMines apply {[
             getPosWorld _x,
             [vectorDirVisual _x, vectorUpVisual _x],
             typeOf _x

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -376,14 +376,16 @@ if (!isNil "greuh_liberation_savegame") then {
     if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved buildings placed";};
 
     {
-        _x params ["_minePos", "_dirAndUp", "_class"];
+        _x params ["_minePos", "_dirAndUp", "_class", "_known"];
 
         private _mine = createVehicle [_class, _minePos, [], 0];
         _mine setPosWorld _minePos;
         _mine setVectorDirAndUp _dirAndUp;
 
-        // reveal mine to player side
-        GRLIB_side_friendly revealMine _mine;
+        // reveal mine to player side if it was detected
+        if (_known) then {
+            GRLIB_side_friendly revealMine _mine;
+        };
 
     } forEach _allMines;
 
@@ -589,7 +591,8 @@ while {true} do {
         _allMines append (_fobMines apply {[
             getPosWorld _x,
             [vectorDirVisual _x, vectorUpVisual _x],
-            typeOf _x
+            typeOf _x,
+            _x mineDetectedBy GRLIB_side_friendly
         ]});
     } forEach GRLIB_all_fobs;
 

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -378,7 +378,7 @@ if (!isNil "greuh_liberation_savegame") then {
     {
         _x params ["_minePos", "_dirAndUp", "_class"];
 
-        private _mine = createMine [_class, _minePos, [], 0];
+        private _mine = createVehicle [_class, _minePos, [], 0];
         _mine setPosWorld _minePos;
         _mine setVectorDirAndUp _dirAndUp;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | - |

### Description:
Adds saving of mines around the FOBs.

### Content:
- [x] Saving of mines around FOBs
- [x] ~~Properly create mines if they are built via build menu~~ - If mine ammo class will be used they will be able to explode. Not changing build code.

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP

### Compatibility checked with:
* [ ] ACE

