### PR TITLE
add backpack deployables from Contact DLC to arsenal blacklist

### DIFF
--- a/Missionframework/presets/arsenal/blacklist.sqf
+++ b/Missionframework/presets/arsenal/blacklist.sqf
@@ -112,7 +112,31 @@ KPLIB_preset_arsenal_blacklist = [
     "UK3CB_BAF_M6",
     "UK3CB_BAF_L111A1",
     "UK3CB_BAF_L134A1",
-    "UK3CB_BAF_Tripod"
+    "UK3CB_BAF_Tripod",
+    "I_E_HMG_01_A_Weapon_F",
+    "I_E_GMG_01_A_Weapon_F",
+    "I_E_HMG_01_Weapon_F",
+    "I_E_GMG_01_Weapon_F",
+    "I_E_HMG_01_high_Weapon_F",
+    "I_E_GMG_01_high_Weapon_F",
+    "I_E_HMG_01_support_high_F",
+    "I_E_HMG_01_support_F",
+    "I_E_Mortar_01_support_F",
+    "I_E_Mortar_01_Weapon_F",
+    "I_E_AA_01_weapon_F",
+    "I_E_AT_01_weapon_F",
+    "I_E_UAV_06_backpack_F",
+    "I_E_UAV_06_medical_backpack_F",
+    "I_E_UAV_01_backpack_F",
+    "C_IDAP_UGV_02_Demining_backack_F",
+    "I_UGV_02_Demining_backpack_F",
+    "O_UGV_02_Demining_backpack_F",
+    "I_E_UGV_02_Demining_backpack_F",
+    "B_UGV_02_Demining_backpack_F",
+    "I_UGV_02_Science_backpack_F",
+    "O_UGV_02_Science_backpack_F",
+    "I_E_UGV_02_Science_backpack_F",
+    "B_UGV_02_Science_backpack_F"
 ];
 
 /*-------------------------------


### PR DESCRIPTION
Bug fix?  New feature?  Sort of in-between.  Addresses a regression (ability to make free turrets/robots and sell them) due to the new DLC adding items not covered by the existing arsenal blacklist.
Needs wipe? | no
Fixed issues | none in the tracker for this issue

### Description:
Adds all Contact DLC backpack slot items that correspond to assemble-able turrets or bots to the default arsenal blacklist, in keeping with the pattern of such items in previous DLCs and the base game being in the list.

### Successfully tested on:
- [ ] Local MP
- [X] Dedicated MP

<!--
As soon as you've tested your feature on the listed environment you can check the checkbox.
It has to work without any issues and errors in your own tests.
Especially if you open a PR as WIP and not after you've fully finished your work, remember to update the states accordingly.
-->

My server uses a long list of mods but this is a simple change that should not impact mod interaction at all.
