### PR TITLE
KA weapons poison gas grenades compatibility

### DIFF
--- a/Missionframework/kp_liberation_config.sqf
+++ b/Missionframework/kp_liberation_config.sqf
@@ -200,6 +200,7 @@ GRLIB_battlegroup_cap = 150;                                            // Cap f
 GRLIB_patrol_cap = 150;                                                 // Cap for enemy patrols.
 
 KP_liberation_cr_kill_penalty = 5;                                      // Civil Reputation penalty for killing a civilian.
+KP_liberation_cr_gas_kill_penalty = 10;                                 // Civil Reputation penalty for killing a civilian by poison gas.
 KP_liberation_cr_building_penalty = 3;                                  // Civil Reputation penalty for destroying/damaging a building.
 KP_liberation_cr_vehicle_penalty = 2;                                   // Civil Reputation penalty for stealing a civilian vehicle.
 KP_liberation_cr_resistance_penalty = 3;                                // Civil Reputation penalty for killing a friendly resistance soldier.

--- a/Missionframework/scripts/shared/functions/F_kp_cr_globalMsg.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_cr_globalMsg.sqf
@@ -9,5 +9,6 @@ switch (_msgType) do {
 	case 3: {systemChat (format [localize "STR_CR_RESISTANCE_KILLMSG", (_data select 0)]);};
 	case 4: {systemChat (format [localize "STR_CR_HEALMSG", (_data select 0)]);};
 	case 5: {["lib_asymm_guerilla_incoming", _data] call BIS_fnc_showNotification;};
-	default {private _text = format ["[KP LIBERATION] [ERROR] [CIVREP] globalMsg without valid msgType"];_text remoteExec ["diag_log",2];};
+	case 6: {systemChat (format [localize "STR_CR_KILLMSG_GAS", (_data select 0)]);};
+default {private _text = format ["[KP LIBERATION] [ERROR] [CIVREP] globalMsg without valid msgType"];_text remoteExec ["diag_log",2];};
 };

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -5901,6 +5901,10 @@
             <Portuguese>Um civil de nome %1 foi morto!</Portuguese>
             <Korean>민간인 %가 사망하였다!</Korean>
         </Key>
+        <Key ID="STR_CR_KILLMSG_GAS">
+            <Original>WAR CRIME! A civilian named %1 was killed by poison gas!</Original>
+            <German>KRIEGSVERBRECHEN! Ein Zivilist mit Namen %1 wurde durch Giftgas getötet!</German>
+        </Key>
         <Key ID="STR_CR_VEHICLEMSG">
             <Original>A civilian's vehicle was seized!</Original>
             <German>Ein Zivilfahrzeug wurde beschlagnahmt!</German>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? |  no |
| New feature? |  no <!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> |
| Fixed issues | #... <!-- #-prefixed issue number(s), if any --> |

### Description:

When using poison gas grenades or grenade launcher poison gas grenades from the KA Weapons Pack, killed civilians will not be counted as killed by the player.
This is changed with the lines added.
To work correctly, not the original https://steamcommunity.com/sharedfiles/filedetails/? id=1369953203 KA Weapons Pack has to be used, but the version changed by me (here the link to it, as soon as I uploaded it on Steam)

### Content:
- [ ] Content part

<!--
Add things which are part of this pull request as checkboxes
to show if it's already finished and already part of the pull request.
-->

### Successfully tested on:
- [ x] Local MP
- [ ] Dedicated MP

<!--
As soon as you've tested your feature on the listed environment you can check the checkbox.
It has to work without any issues and errors in your own tests.
Especially if you open a PR as WIP and not after you've fully finished your work, remember to update the states accordingly.
-->

### Compatibility checked with:
* ACE
* Mod XYZ

<!--
Add a list of Mods you've checked. This should only contain mods which really affect the feature.
So for a feature like e.g. "hint on entering a sector area" you don't list/test compatibility with RHS, ACE, Achilles, etc.
Also listing CBA isn't necessary, as it's a general dependency in Liberation.
-->
