### PR TITLE
V0.96.7 battlegroup tweaks

### DIFF
--- a/Missionframework/scripts/server/ai/battlegroup_ai.sqf
+++ b/Missionframework/scripts/server/ai/battlegroup_ai.sqf
@@ -7,19 +7,19 @@ if (isNil "reset_battlegroups_ai") then {reset_battlegroups_ai = false};
 
 sleep (5 + (random 5));
 
-private _objPos = ([getpos (leader _grp)] call F_getNearestBluforObjective) select 0;
+private _objPos = ([getPos (leader _grp)] call F_getNearestBluforObjective) select 0;
 
 [_objPos] remoteExec ["remote_call_incoming"];
 
-private _startpos = getpos (leader _grp);
+private _startpos = getPos (leader _grp);
 
 private _waypoint = [];
-while {((getpos (leader _grp)) distance _startpos) < 100} do {
+while {((getPos (leader _grp)) distance _startpos) < 100} do {
 
     while {!((waypoints _grp) isEqualTo [])} do {deleteWaypoint ((waypoints _grp) select 0);};
     {_x doFollow leader _grp} forEach units _grp;
 
-    _startpos = getpos (leader _grp);
+    _startpos = getPos (leader _grp);
 
     _waypoint = _grp addWaypoint [_objPos, 100];
     _waypoint setWaypointType "MOVE";

--- a/Missionframework/scripts/server/ai/battlegroup_ai.sqf
+++ b/Missionframework/scripts/server/ai/battlegroup_ai.sqf
@@ -2,7 +2,7 @@ _grp = _this select 0;
 _infantry = false;
 
 if ( count _this == 2 ) then {
-	_infantry = true;
+    _infantry = true;
 };
 
 if (isNil "reset_battlegroups_ai" ) then { reset_battlegroups_ai = false };
@@ -11,44 +11,44 @@ sleep (3 + (random 3));
 
 while { ( count units _grp != 0 ) && ( GRLIB_endgame == 0 ) } do {
 
-	sleep (5 + (random 5));
+    sleep (5 + (random 5));
 
-	private _objectivepos = ([getpos (leader _grp)] call F_getNearestBluforObjective) select 0;
+    private _objectivepos = ([getpos (leader _grp)] call F_getNearestBluforObjective) select 0;
 
-	[_objectivepos] remoteExec ["remote_call_incoming"];
+    [_objectivepos] remoteExec ["remote_call_incoming"];
 
-	private _startpos = getpos (leader _grp);
+    private _startpos = getpos (leader _grp);
 
-	while { ((getpos (leader _grp)) distance _startpos) < 100 } do {
+    while { ((getpos (leader _grp)) distance _startpos) < 100 } do {
 
-		while {(count (waypoints _grp)) != 0} do {deleteWaypoint ((waypoints _grp) select 0);};
-		{_x doFollow leader _grp} foreach units _grp;
+        while {(count (waypoints _grp)) != 0} do {deleteWaypoint ((waypoints _grp) select 0);};
+        {_x doFollow leader _grp} foreach units _grp;
 
-		_startpos = getpos (leader _grp);
+        _startpos = getpos (leader _grp);
 
-		private _waypoint = _grp addWaypoint [_objectivepos, 100];
-		_waypoint setWaypointType "MOVE";
-		_waypoint setWaypointSpeed "NORMAL";
-		_waypoint setWaypointBehaviour "SAFE";
-		_waypoint setWaypointCombatMode "YELLOW";
-		_waypoint setWaypointCompletionRadius 30;
+        private _waypoint = _grp addWaypoint [_objectivepos, 100];
+        _waypoint setWaypointType "MOVE";
+        _waypoint setWaypointSpeed "NORMAL";
+        _waypoint setWaypointBehaviour "SAFE";
+        _waypoint setWaypointCombatMode "YELLOW";
+        _waypoint setWaypointCompletionRadius 30;
 
-		_waypoint = _grp addWaypoint [_objectivepos, 100];
-		_waypoint setWaypointType "SAD";
-		_waypoint = _grp addWaypoint [_objectivepos, 100];
-		_waypoint setWaypointType "SAD";
-		_waypoint = _grp addWaypoint [_objectivepos, 100];
-		_waypoint setWaypointType "SAD";
-		_waypoint = _grp addWaypoint [_objectivepos, 100];
-		_waypoint setWaypointType "CYCLE";
+        _waypoint = _grp addWaypoint [_objectivepos, 100];
+        _waypoint setWaypointType "SAD";
+        _waypoint = _grp addWaypoint [_objectivepos, 100];
+        _waypoint setWaypointType "SAD";
+        _waypoint = _grp addWaypoint [_objectivepos, 100];
+        _waypoint setWaypointType "SAD";
+        _waypoint = _grp addWaypoint [_objectivepos, 100];
+        _waypoint setWaypointType "CYCLE";
 
-		sleep 180;
-	};
+        sleep 180;
+    };
 
-	waitUntil {
-		sleep 5;
-		( { alive _x } count (units _grp) == 0) || reset_battlegroups_ai;
-	};
-	sleep (5 + (random 5));
-	reset_battlegroups_ai = false;
+    waitUntil {
+        sleep 5;
+        ( { alive _x } count (units _grp) == 0) || reset_battlegroups_ai;
+    };
+    sleep (5 + (random 5));
+    reset_battlegroups_ai = false;
 };

--- a/Missionframework/scripts/server/ai/battlegroup_ai.sqf
+++ b/Missionframework/scripts/server/ai/battlegroup_ai.sqf
@@ -1,54 +1,53 @@
-_grp = _this select 0;
-_infantry = false;
+params [
+    ["_grp", grpNull, [grpNull]]
+];
 
-if ( count _this == 2 ) then {
-    _infantry = true;
+if (isNull _grp) exitWith {};
+if (isNil "reset_battlegroups_ai") then {reset_battlegroups_ai = false};
+
+sleep (5 + (random 5));
+
+private _objPos = ([getpos (leader _grp)] call F_getNearestBluforObjective) select 0;
+
+[_objPos] remoteExec ["remote_call_incoming"];
+
+private _startpos = getpos (leader _grp);
+
+private _waypoint = [];
+while {((getpos (leader _grp)) distance _startpos) < 100} do {
+
+    while {!((waypoints _grp) isEqualTo [])} do {deleteWaypoint ((waypoints _grp) select 0);};
+    {_x doFollow leader _grp} forEach units _grp;
+
+    _startpos = getpos (leader _grp);
+
+    _waypoint = _grp addWaypoint [_objPos, 100];
+    _waypoint setWaypointType "MOVE";
+    _waypoint setWaypointSpeed "NORMAL";
+    _waypoint setWaypointBehaviour "SAFE";
+    _waypoint setWaypointCombatMode "YELLOW";
+    _waypoint setWaypointCompletionRadius 30;
+
+    _waypoint = _grp addWaypoint [_objPos, 100];
+    _waypoint setWaypointType "SAD";
+    _waypoint = _grp addWaypoint [_objPos, 100];
+    _waypoint setWaypointType "SAD";
+    _waypoint = _grp addWaypoint [_objPos, 100];
+    _waypoint setWaypointType "SAD";
+    _waypoint = _grp addWaypoint [_objPos, 100];
+    _waypoint setWaypointType "CYCLE";
+
+    sleep 90;
 };
 
-if (isNil "reset_battlegroups_ai" ) then { reset_battlegroups_ai = false };
+waitUntil {
+    sleep 5;
+    (((units _grp) select {alive _x}) isEqualTo []) || reset_battlegroups_ai
+};
 
-sleep (3 + (random 3));
+sleep (5 + (random 5));
+reset_battlegroups_ai = false;
 
-while { ( count units _grp != 0 ) && ( GRLIB_endgame == 0 ) } do {
-
-    sleep (5 + (random 5));
-
-    private _objectivepos = ([getpos (leader _grp)] call F_getNearestBluforObjective) select 0;
-
-    [_objectivepos] remoteExec ["remote_call_incoming"];
-
-    private _startpos = getpos (leader _grp);
-
-    while { ((getpos (leader _grp)) distance _startpos) < 100 } do {
-
-        while {(count (waypoints _grp)) != 0} do {deleteWaypoint ((waypoints _grp) select 0);};
-        {_x doFollow leader _grp} foreach units _grp;
-
-        _startpos = getpos (leader _grp);
-
-        private _waypoint = _grp addWaypoint [_objectivepos, 100];
-        _waypoint setWaypointType "MOVE";
-        _waypoint setWaypointSpeed "NORMAL";
-        _waypoint setWaypointBehaviour "SAFE";
-        _waypoint setWaypointCombatMode "YELLOW";
-        _waypoint setWaypointCompletionRadius 30;
-
-        _waypoint = _grp addWaypoint [_objectivepos, 100];
-        _waypoint setWaypointType "SAD";
-        _waypoint = _grp addWaypoint [_objectivepos, 100];
-        _waypoint setWaypointType "SAD";
-        _waypoint = _grp addWaypoint [_objectivepos, 100];
-        _waypoint setWaypointType "SAD";
-        _waypoint = _grp addWaypoint [_objectivepos, 100];
-        _waypoint setWaypointType "CYCLE";
-
-        sleep 180;
-    };
-
-    waitUntil {
-        sleep 5;
-        ( { alive _x } count (units _grp) == 0) || reset_battlegroups_ai;
-    };
-    sleep (5 + (random 5));
-    reset_battlegroups_ai = false;
+if (!((units _grp) isEqualTo []) && (GRLIB_endgame == 0)) then {
+    [_grp] spawn battlegroup_ai;
 };

--- a/Missionframework/scripts/server/ai/troup_transport.sqf
+++ b/Missionframework/scripts/server/ai/troup_transport.sqf
@@ -8,7 +8,7 @@ sleep 1;
 private _transGrp = (group (driver _transVeh));
 private _start_pos = getpos _transVeh;
 private _objPos =  ([getpos _transVeh] call F_getNearestBluforObjective) select 0;
-private _unload_distance = 800;
+private _unload_distance = 500;
 private _crewcount = count crew _transVeh;
 
 waitUntil {

--- a/Missionframework/scripts/server/ai/troup_transport.sqf
+++ b/Missionframework/scripts/server/ai/troup_transport.sqf
@@ -9,57 +9,57 @@ _initial_crewcount = count crew _troup_transport;
 waitUntil { sleep 0.2; !(alive _troup_transport) || !(alive (driver _troup_transport)) || (((_troup_transport distance _dat_objective) < _unload_distance) && (!(surfaceIsWater (getpos _troup_transport)))) };
 
 if ((alive _troup_transport) && (alive (driver _troup_transport))) then {
-	_troupgrp = createGroup [GRLIB_side_enemy, true];
+    _troupgrp = createGroup [GRLIB_side_enemy, true];
 
-	while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
+    while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
 
-	{
-		[_x, _start_pos, _troupgrp, "PRIVATE", 0.5] call F_createManagedUnit;
-	} foreach (["army"] call F_getAdaptiveSquadComp);
+    {
+        [_x, _start_pos, _troupgrp, "PRIVATE", 0.5] call F_createManagedUnit;
+    } foreach (["army"] call F_getAdaptiveSquadComp);
 
-	{ _x moveInCargo _troup_transport } foreach (units _troupgrp);
-	while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
+    { _x moveInCargo _troup_transport } foreach (units _troupgrp);
+    while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
 
-	sleep 3;
+    sleep 3;
 
-	_transport_waypoint =  _transport_group addWaypoint [getpos _troup_transport, 0,0];
-	_transport_waypoint setWaypointType "TR UNLOAD";
-	_transport_waypoint setWaypointCompletionRadius 200;
+    _transport_waypoint =  _transport_group addWaypoint [getpos _troup_transport, 0,0];
+    _transport_waypoint setWaypointType "TR UNLOAD";
+    _transport_waypoint setWaypointCompletionRadius 200;
 
-	_troops_waypoint = _troupgrp addWaypoint [getpos _troup_transport, 0];
-	_troops_waypoint setWaypointType "GETOUT";
-	_troops_waypoint setWaypointCompletionRadius 200;
+    _troops_waypoint = _troupgrp addWaypoint [getpos _troup_transport, 0];
+    _troops_waypoint setWaypointType "GETOUT";
+    _troops_waypoint setWaypointCompletionRadius 200;
 
-	_troops_waypoint synchronizeWaypoint [_transport_waypoint];
+    _troops_waypoint synchronizeWaypoint [_transport_waypoint];
 
-	{ unassignVehicle _troup_transport } forEach (units _troupgrp);
-	_troupgrp leaveVehicle _troup_transport;
-	(units _troupgrp) allowGetIn false;
+    { unassignVehicle _troup_transport } forEach (units _troupgrp);
+    _troupgrp leaveVehicle _troup_transport;
+    (units _troupgrp) allowGetIn false;
 
-	_troops_waypoint_2 = _troupgrp addWaypoint [getpos _troup_transport, 250];
-	_troops_waypoint_2 setWaypointType "MOVE";
-	_troops_waypoint_2 setWaypointCompletionRadius 5;
+    _troops_waypoint_2 = _troupgrp addWaypoint [getpos _troup_transport, 250];
+    _troops_waypoint_2 setWaypointType "MOVE";
+    _troops_waypoint_2 setWaypointCompletionRadius 5;
 
-	waitUntil { sleep 0.3; _initial_crewcount >= count crew _troup_transport };
+    waitUntil { sleep 0.3; _initial_crewcount >= count crew _troup_transport };
 
-	sleep 5;
+    sleep 5;
 
-	while {(count (waypoints _transport_group)) != 0} do {deleteWaypoint ((waypoints _transport_group) select 0);};
+    while {(count (waypoints _transport_group)) != 0} do {deleteWaypoint ((waypoints _transport_group) select 0);};
 
-	_waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
-	_waypoint2 setWaypointType "SAD";
-	_waypoint2 setWaypointSpeed "NORMAL";
-	_waypoint2 setWaypointBehaviour "COMBAT";
-	_waypoint2 setWaypointCombatMode "RED";
-	_waypoint2 setWaypointCompletionRadius 30;
+    _waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
+    _waypoint2 setWaypointType "SAD";
+    _waypoint2 setWaypointSpeed "NORMAL";
+    _waypoint2 setWaypointBehaviour "COMBAT";
+    _waypoint2 setWaypointCombatMode "RED";
+    _waypoint2 setWaypointCompletionRadius 30;
 
-	_waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
-	_waypoint2 setWaypointType "SAD";
+    _waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
+    _waypoint2 setWaypointType "SAD";
 
-	_waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
-	_waypoint2 setWaypointType "CYCLE";
+    _waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
+    _waypoint2 setWaypointType "CYCLE";
 
-	sleep 10;
+    sleep 10;
 
-	[_troupgrp, true] spawn battlegroup_ai;
+    [_troupgrp, true] spawn battlegroup_ai;
 };

--- a/Missionframework/scripts/server/ai/troup_transport.sqf
+++ b/Missionframework/scripts/server/ai/troup_transport.sqf
@@ -1,65 +1,74 @@
-_troup_transport = _this select 0;
-_transport_group = (group (driver _troup_transport));
-_start_pos = getpos _troup_transport;
-_dat_objective =  ([getpos _troup_transport] call F_getNearestBluforObjective) select 0;
-_unload_distance = 1000;
+params [
+    ["_transVeh", objNull, [objNull]]
+];
+
+if (isNull _transVeh) exitWith {};
 sleep 1;
-_initial_crewcount = count crew _troup_transport;
 
-waitUntil { sleep 0.2; !(alive _troup_transport) || !(alive (driver _troup_transport)) || (((_troup_transport distance _dat_objective) < _unload_distance) && (!(surfaceIsWater (getpos _troup_transport)))) };
+private _transGrp = (group (driver _transVeh));
+private _start_pos = getpos _transVeh;
+private _objPos =  ([getpos _transVeh] call F_getNearestBluforObjective) select 0;
+private _unload_distance = 1000;
+private _crewcount = count crew _transVeh;
 
-if ((alive _troup_transport) && (alive (driver _troup_transport))) then {
-    _troupgrp = createGroup [GRLIB_side_enemy, true];
+waitUntil {
+    sleep 0.2;
+    !(alive _transVeh) ||
+    !(alive (driver _transVeh)) ||
+    (((_transVeh distance _objPos) < _unload_distance) && !(surfaceIsWater (getpos _transVeh)))
+};
 
-    while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
+if ((alive _transVeh) && (alive (driver _transVeh))) then {
+    _infGrp = createGroup [GRLIB_side_enemy, true];
 
     {
-        [_x, _start_pos, _troupgrp, "PRIVATE", 0.5] call F_createManagedUnit;
+        [_x, _start_pos, _infGrp, "PRIVATE", 0.5] call F_createManagedUnit;
     } foreach (["army"] call F_getAdaptiveSquadComp);
 
-    { _x moveInCargo _troup_transport } foreach (units _troupgrp);
-    while {(count (waypoints _troupgrp)) != 0} do {deleteWaypoint ((waypoints _troupgrp) select 0);};
+    {_x moveInCargo _transVeh} forEach (units _infGrp);
+
+    while {(count (waypoints _infGrp)) != 0} do {deleteWaypoint ((waypoints _infGrp) select 0);};
 
     sleep 3;
 
-    _transport_waypoint =  _transport_group addWaypoint [getpos _troup_transport, 0,0];
-    _transport_waypoint setWaypointType "TR UNLOAD";
-    _transport_waypoint setWaypointCompletionRadius 200;
+    private _transVehWp =  _transGrp addWaypoint [getpos _transVeh, 0,0];
+    _transVehWp setWaypointType "TR UNLOAD";
+    _transVehWp setWaypointCompletionRadius 200;
 
-    _troops_waypoint = _troupgrp addWaypoint [getpos _troup_transport, 0];
-    _troops_waypoint setWaypointType "GETOUT";
-    _troops_waypoint setWaypointCompletionRadius 200;
+    private _infWp = _infGrp addWaypoint [getpos _transVeh, 0];
+    _infWp setWaypointType "GETOUT";
+    _infWp setWaypointCompletionRadius 200;
 
-    _troops_waypoint synchronizeWaypoint [_transport_waypoint];
+    _infWp synchronizeWaypoint [_transVehWp];
 
-    { unassignVehicle _troup_transport } forEach (units _troupgrp);
-    _troupgrp leaveVehicle _troup_transport;
-    (units _troupgrp) allowGetIn false;
+    {unassignVehicle _transVeh} forEach (units _infGrp);
+    _infGrp leaveVehicle _transVeh;
+    (units _infGrp) allowGetIn false;
 
-    _troops_waypoint_2 = _troupgrp addWaypoint [getpos _troup_transport, 250];
-    _troops_waypoint_2 setWaypointType "MOVE";
-    _troops_waypoint_2 setWaypointCompletionRadius 5;
+    private _infWp_2 = _infGrp addWaypoint [getpos _transVeh, 250];
+    _infWp_2 setWaypointType "MOVE";
+    _infWp_2 setWaypointCompletionRadius 5;
 
-    waitUntil { sleep 0.3; _initial_crewcount >= count crew _troup_transport };
+    waitUntil {sleep 0.5; _crewcount >= count crew _transVeh};
 
     sleep 5;
 
-    while {(count (waypoints _transport_group)) != 0} do {deleteWaypoint ((waypoints _transport_group) select 0);};
+    while {(count (waypoints _transGrp)) != 0} do {deleteWaypoint ((waypoints _transGrp) select 0);};
 
-    _waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
-    _waypoint2 setWaypointType "SAD";
-    _waypoint2 setWaypointSpeed "NORMAL";
-    _waypoint2 setWaypointBehaviour "COMBAT";
-    _waypoint2 setWaypointCombatMode "RED";
-    _waypoint2 setWaypointCompletionRadius 30;
+    _transVehWp = _transGrp addWaypoint [_objPos, 100];
+    _transVehWp setWaypointType "SAD";
+    _transVehWp setWaypointSpeed "NORMAL";
+    _transVehWp setWaypointBehaviour "COMBAT";
+    _transVehWp setWaypointCombatMode "RED";
+    _transVehWp setWaypointCompletionRadius 30;
 
-    _waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
-    _waypoint2 setWaypointType "SAD";
+    _transVehWp = _transGrp addWaypoint [_objPos, 100];
+    _transVehWp setWaypointType "SAD";
 
-    _waypoint2 = _transport_group addWaypoint [_dat_objective, 100];
-    _waypoint2 setWaypointType "CYCLE";
+    _transVehWp = _transGrp addWaypoint [_objPos, 100];
+    _transVehWp setWaypointType "CYCLE";
 
     sleep 10;
 
-    [_troupgrp, true] spawn battlegroup_ai;
+    [_infGrp] spawn battlegroup_ai;
 };

--- a/Missionframework/scripts/server/ai/troup_transport.sqf
+++ b/Missionframework/scripts/server/ai/troup_transport.sqf
@@ -8,7 +8,7 @@ sleep 1;
 private _transGrp = (group (driver _transVeh));
 private _start_pos = getpos _transVeh;
 private _objPos =  ([getpos _transVeh] call F_getNearestBluforObjective) select 0;
-private _unload_distance = 1000;
+private _unload_distance = 800;
 private _crewcount = count crew _transVeh;
 
 waitUntil {

--- a/Missionframework/scripts/server/battlegroup/random_battlegroups.sqf
+++ b/Missionframework/scripts/server/battlegroup/random_battlegroups.sqf
@@ -4,19 +4,19 @@ sleep ( 900 / GRLIB_csat_aggressivity );
 
 while { GRLIB_csat_aggressivity > 0.9 && GRLIB_endgame == 0 } do {
 
-	_sleeptime =  (2100 + (random 2100)) / (([] call  F_adaptiveOpforFactor) * GRLIB_csat_aggressivity);
+    _sleeptime =  (2100 + (random 2100)) / (([] call  F_adaptiveOpforFactor) * GRLIB_csat_aggressivity);
 
-	if ( combat_readiness >= 80 ) then { _sleeptime = _sleeptime * 0.75 };
-	if ( combat_readiness >= 90 ) then { _sleeptime = _sleeptime * 0.75 };
-	if ( combat_readiness >= 95 ) then { _sleeptime = _sleeptime * 0.75 };
+    if ( combat_readiness >= 80 ) then { _sleeptime = _sleeptime * 0.75 };
+    if ( combat_readiness >= 90 ) then { _sleeptime = _sleeptime * 0.75 };
+    if ( combat_readiness >= 95 ) then { _sleeptime = _sleeptime * 0.75 };
 
-	sleep _sleeptime;
+    sleep _sleeptime;
 
-	if ( !isNil "GRLIB_last_battlegroup_time" ) then {
-		waitUntil { sleep 5; time > ( GRLIB_last_battlegroup_time + ( 2100 / GRLIB_csat_aggressivity ) ) };
-	};
+    if ( !isNil "GRLIB_last_battlegroup_time" ) then {
+        waitUntil { sleep 5; time > ( GRLIB_last_battlegroup_time + ( 2100 / GRLIB_csat_aggressivity ) ) };
+    };
 
-	if ((count (allPlayers - entities "HeadlessClient_F") >= (10 / GRLIB_csat_aggressivity)) && ([] call F_opforCap < GRLIB_battlegroup_cap) && (combat_readiness >= 70) && (diag_fps > 15.0))  then {
-		[] spawn spawn_battlegroup;
-	};
+    if ((count (allPlayers - entities "HeadlessClient_F") >= (10 / GRLIB_csat_aggressivity)) && ([] call F_opforCap < GRLIB_battlegroup_cap) && (combat_readiness >= 70) && (diag_fps > 15.0))  then {
+        [] spawn spawn_battlegroup;
+    };
 };

--- a/Missionframework/scripts/server/battlegroup/random_battlegroups.sqf
+++ b/Missionframework/scripts/server/battlegroup/random_battlegroups.sqf
@@ -1,22 +1,29 @@
-private [ "_sleeptime", "_countplayers" ];
+private ["_sleeptime"];
 
-sleep ( 900 / GRLIB_csat_aggressivity );
-
-while { GRLIB_csat_aggressivity > 0.9 && GRLIB_endgame == 0 } do {
+uiSleep (900 / GRLIB_csat_aggressivity);
+while {GRLIB_csat_aggressivity > 0.9 && GRLIB_endgame == 0} do {
 
     _sleeptime =  (2100 + (random 2100)) / (([] call  F_adaptiveOpforFactor) * GRLIB_csat_aggressivity);
 
-    if ( combat_readiness >= 80 ) then { _sleeptime = _sleeptime * 0.75 };
-    if ( combat_readiness >= 90 ) then { _sleeptime = _sleeptime * 0.75 };
-    if ( combat_readiness >= 95 ) then { _sleeptime = _sleeptime * 0.75 };
+    if (combat_readiness >= 80) then {_sleeptime = _sleeptime * 0.75};
+    if (combat_readiness >= 90) then {_sleeptime = _sleeptime * 0.75};
+    if (combat_readiness >= 95) then {_sleeptime = _sleeptime * 0.75};
 
-    sleep _sleeptime;
+    uiSleep _sleeptime;
 
-    if ( !isNil "GRLIB_last_battlegroup_time" ) then {
-        waitUntil { sleep 5; time > ( GRLIB_last_battlegroup_time + ( 2100 / GRLIB_csat_aggressivity ) ) };
+    if (!isNil "GRLIB_last_battlegroup_time") then {
+        waitUntil {
+            uiSleep 5;
+            diag_tickTime > (GRLIB_last_battlegroup_time + (2100 / GRLIB_csat_aggressivity))
+        };
     };
 
-    if ((count (allPlayers - entities "HeadlessClient_F") >= (10 / GRLIB_csat_aggressivity)) && ([] call F_opforCap < GRLIB_battlegroup_cap) && (combat_readiness >= 70) && (diag_fps > 15.0))  then {
+    if (
+        (count (allPlayers - entities "HeadlessClient_F") >= (10 / GRLIB_csat_aggressivity)) &&
+        ([] call F_opforCap < GRLIB_battlegroup_cap) &&
+        (combat_readiness >= 70) &&
+        (diag_fps > 15.0)
+    )  then {
         [] spawn spawn_battlegroup;
     };
 };

--- a/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
+++ b/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
@@ -46,7 +46,7 @@ if !(_spawn_marker isEqualTo "") then {
 
         if ((_x in opfor_troup_transports) && ([] call F_opforCap < GRLIB_battlegroup_cap)) then {
             if (_vehicle isKindOf "Air") then {
-                [_spawn_marker, _vehicle] spawn send_paratroopers;
+                [([markerPos _spawn_marker] call F_getNearestBluforObjective) select 0, _vehicle] spawn send_paratroopers;
             } else {
                 [_vehicle] spawn troup_transport;
             };

--- a/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
+++ b/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
@@ -44,8 +44,12 @@ if !(_spawn_marker isEqualTo "") then {
         [_nextgrp] spawn battlegroup_ai;
         _bg_groups pushback _nextgrp;
 
-        if ((_x in opfor_troup_transports) &&  ([] call F_opforCap < GRLIB_battlegroup_cap)) then {
-            [_vehicle] spawn troup_transport;
+        if ((_x in opfor_troup_transports) && ([] call F_opforCap < GRLIB_battlegroup_cap)) then {
+            if (_vehicle isKindOf "Air") then {
+                [_spawn_marker, _vehicle] spawn send_paratroopers;
+            } else {
+                [_vehicle] spawn troup_transport;
+            };
         };
 
         _battlegroup_size = _battlegroup_size + 1;

--- a/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
+++ b/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
@@ -6,69 +6,69 @@ _bg_groups = [];
 last_battlegroup_size = 0;
 _spawn_marker = "";
 if ( count _this == 1 ) then {
-	_spawn_marker = [ 2000, 10000, false, _this select 0 ] call F_findOpforSpawnPoint;
+    _spawn_marker = [ 2000, 10000, false, _this select 0 ] call F_findOpforSpawnPoint;
 } else {
-	_spawn_marker = [ 2000, 10000, false ] call F_findOpforSpawnPoint;
+    _spawn_marker = [ 2000, 10000, false ] call F_findOpforSpawnPoint;
 };
 
 
 _vehicle_pool = opfor_battlegroup_vehicles;
 if ( combat_readiness < 50 ) then {
-	_vehicle_pool = opfor_battlegroup_vehicles_low_intensity;
+    _vehicle_pool = opfor_battlegroup_vehicles_low_intensity;
 };
 
 if ( _spawn_marker != "" ) then {
 
-	GRLIB_last_battlegroup_time = time;
+    GRLIB_last_battlegroup_time = time;
 
-	_selected_opfor_battlegroup = [];
-	_target_size = GRLIB_battlegroup_size * ([] call F_adaptiveOpforFactor) * (sqrt GRLIB_csat_aggressivity);
-	if ( _target_size >= 16 ) then { _target_size = 16; };
-	if ( combat_readiness < 60 ) then { _target_size = round (_target_size * 0.65) };
-	while { count _selected_opfor_battlegroup < _target_size } do {
-		_selected_opfor_battlegroup pushback (selectRandom _vehicle_pool);
-	};
+    _selected_opfor_battlegroup = [];
+    _target_size = GRLIB_battlegroup_size * ([] call F_adaptiveOpforFactor) * (sqrt GRLIB_csat_aggressivity);
+    if ( _target_size >= 16 ) then { _target_size = 16; };
+    if ( combat_readiness < 60 ) then { _target_size = round (_target_size * 0.65) };
+    while { count _selected_opfor_battlegroup < _target_size } do {
+        _selected_opfor_battlegroup pushback (selectRandom _vehicle_pool);
+    };
 
-	[_spawn_marker] remoteExec ["remote_call_battlegroup"];
+    [_spawn_marker] remoteExec ["remote_call_battlegroup"];
 
     if (worldName in KP_liberation_battlegroup_clearance) then {
         [markerpos _spawn_marker, 15] call F_createClearance;
     };
 
-	{
-		_nextgrp = createGroup [GRLIB_side_enemy, true];
-		_vehicle = [markerpos _spawn_marker, _x] call F_libSpawnVehicle;
-		sleep 0.5;
-		(crew _vehicle) joinSilent _nextgrp;
-		[_nextgrp] spawn battlegroup_ai;
-		_bg_groups pushback _nextgrp;
-		if ( ( _x in opfor_troup_transports ) &&  ( [] call F_opforCap < GRLIB_battlegroup_cap ) ) then {
-			[_vehicle] spawn troup_transport;
-		};
-		last_battlegroup_size = last_battlegroup_size + 1;
-	} foreach _selected_opfor_battlegroup;
+    {
+        _nextgrp = createGroup [GRLIB_side_enemy, true];
+        _vehicle = [markerpos _spawn_marker, _x] call F_libSpawnVehicle;
+        sleep 0.5;
+        (crew _vehicle) joinSilent _nextgrp;
+        [_nextgrp] spawn battlegroup_ai;
+        _bg_groups pushback _nextgrp;
+        if ( ( _x in opfor_troup_transports ) &&  ( [] call F_opforCap < GRLIB_battlegroup_cap ) ) then {
+            [_vehicle] spawn troup_transport;
+        };
+        last_battlegroup_size = last_battlegroup_size + 1;
+    } foreach _selected_opfor_battlegroup;
 
-	if ( GRLIB_csat_aggressivity > 0.9 ) then {
-		[([markerpos _spawn_marker] call F_getNearestBluforObjective) select 0] spawn spawn_air;
-	};
+    if ( GRLIB_csat_aggressivity > 0.9 ) then {
+        [([markerpos _spawn_marker] call F_getNearestBluforObjective) select 0] spawn spawn_air;
+    };
 
-	sleep 5;
+    sleep 5;
 
-	combat_readiness = combat_readiness - (round ((last_battlegroup_size / 2) + (random (last_battlegroup_size / 2))));
-	if ( combat_readiness < 0 ) then { combat_readiness = 0 };
+    combat_readiness = combat_readiness - (round ((last_battlegroup_size / 2) + (random (last_battlegroup_size / 2))));
+    if ( combat_readiness < 0 ) then { combat_readiness = 0 };
 
-	stats_hostile_battlegroups = stats_hostile_battlegroups + 1;
+    stats_hostile_battlegroups = stats_hostile_battlegroups + 1;
 
-	{
-		if ( local _x ) then {
-			_headless_client = [] call F_lessLoadedHC;
-			if ( !isNull _headless_client ) then {
-				_x setGroupOwner ( owner _headless_client );
-			};
-		};
-		sleep 3;
+    {
+        if ( local _x ) then {
+            _headless_client = [] call F_lessLoadedHC;
+            if ( !isNull _headless_client ) then {
+                _x setGroupOwner ( owner _headless_client );
+            };
+        };
+        sleep 3;
 
-	} foreach _bg_groups;
+    } foreach _bg_groups;
 };
 
 

--- a/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
+++ b/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
@@ -1,31 +1,29 @@
-if ( GRLIB_endgame == 1 ) exitWith {};
+params [
+    ["_spawn_marker", "", [""]]
+];
 
-private [ "_bg_groups", "_target_size", "_vehicle_pool" ];
-_bg_groups = [];
+if (GRLIB_endgame == 1) exitWith {};
 
-last_battlegroup_size = 0;
-_spawn_marker = "";
-if ( count _this == 1 ) then {
-    _spawn_marker = [ 2000, 10000, false, _this select 0 ] call F_findOpforSpawnPoint;
+if !(_spawn_marker isEqualTo "") then {
+    _spawn_marker = [2000, 10000, false, _spawn_marker] call F_findOpforSpawnPoint;
 } else {
-    _spawn_marker = [ 2000, 10000, false ] call F_findOpforSpawnPoint;
+    _spawn_marker = [2000, 10000, false] call F_findOpforSpawnPoint;
 };
 
+if !(_spawn_marker isEqualTo "") then {
 
-_vehicle_pool = opfor_battlegroup_vehicles;
-if ( combat_readiness < 50 ) then {
-    _vehicle_pool = opfor_battlegroup_vehicles_low_intensity;
-};
+    GRLIB_last_battlegroup_time = diag_tickTime;
 
-if ( _spawn_marker != "" ) then {
+    private _bg_groups = [];
+    private _battlegroup_size = 0;
+    private _vehicle_pool = [opfor_battlegroup_vehicles, opfor_battlegroup_vehicles_low_intensity] select (combat_readiness < 50);
+    private _selected_opfor_battlegroup = [];
 
-    GRLIB_last_battlegroup_time = time;
+    private _target_size = GRLIB_battlegroup_size * ([] call F_adaptiveOpforFactor) * (sqrt GRLIB_csat_aggressivity);
+    if (_target_size >= 16) then {_target_size = 16;};
+    if (combat_readiness < 60) then {_target_size = round (_target_size * 0.65);};
 
-    _selected_opfor_battlegroup = [];
-    _target_size = GRLIB_battlegroup_size * ([] call F_adaptiveOpforFactor) * (sqrt GRLIB_csat_aggressivity);
-    if ( _target_size >= 16 ) then { _target_size = 16; };
-    if ( combat_readiness < 60 ) then { _target_size = round (_target_size * 0.65) };
-    while { count _selected_opfor_battlegroup < _target_size } do {
+    while {count _selected_opfor_battlegroup < _target_size} do {
         _selected_opfor_battlegroup pushback (selectRandom _vehicle_pool);
     };
 
@@ -35,40 +33,42 @@ if ( _spawn_marker != "" ) then {
         [markerpos _spawn_marker, 15] call F_createClearance;
     };
 
+    private ["_nextgrp", "_vehicle"];
     {
         _nextgrp = createGroup [GRLIB_side_enemy, true];
         _vehicle = [markerpos _spawn_marker, _x] call F_libSpawnVehicle;
+
         sleep 0.5;
+
         (crew _vehicle) joinSilent _nextgrp;
         [_nextgrp] spawn battlegroup_ai;
         _bg_groups pushback _nextgrp;
-        if ( ( _x in opfor_troup_transports ) &&  ( [] call F_opforCap < GRLIB_battlegroup_cap ) ) then {
+
+        if ((_x in opfor_troup_transports) &&  ([] call F_opforCap < GRLIB_battlegroup_cap)) then {
             [_vehicle] spawn troup_transport;
         };
-        last_battlegroup_size = last_battlegroup_size + 1;
-    } foreach _selected_opfor_battlegroup;
 
-    if ( GRLIB_csat_aggressivity > 0.9 ) then {
+        _battlegroup_size = _battlegroup_size + 1;
+    } forEach _selected_opfor_battlegroup;
+
+    if (GRLIB_csat_aggressivity > 0.9) then {
         [([markerpos _spawn_marker] call F_getNearestBluforObjective) select 0] spawn spawn_air;
     };
 
     sleep 5;
 
-    combat_readiness = combat_readiness - (round ((last_battlegroup_size / 2) + (random (last_battlegroup_size / 2))));
-    if ( combat_readiness < 0 ) then { combat_readiness = 0 };
+    combat_readiness = combat_readiness - (round ((_battlegroup_size / 2) + (random (_battlegroup_size / 2))));
+    if (combat_readiness < 0) then {combat_readiness = 0};
 
     stats_hostile_battlegroups = stats_hostile_battlegroups + 1;
 
     {
-        if ( local _x ) then {
+        if (local _x) then {
             _headless_client = [] call F_lessLoadedHC;
-            if ( !isNull _headless_client ) then {
-                _x setGroupOwner ( owner _headless_client );
+            if (!isNull _headless_client) then {
+                _x setGroupOwner (owner _headless_client);
             };
         };
         sleep 3;
-
-    } foreach _bg_groups;
+    } forEach _bg_groups;
 };
-
-

--- a/Missionframework/scripts/server/patrols/send_paratroopers.sqf
+++ b/Missionframework/scripts/server/patrols/send_paratroopers.sqf
@@ -1,11 +1,17 @@
 params [
-    ["_targetsector", "", [""]],
+    ["_targetsector", "", ["",[]]],
     ["_chopper_type", objNull, [objNull]]
 ];
-private _targetpos = getMarkerPos _targetsector;
-private _spawnsector = ([sectors_airspawn, [_targetpos], {(markerpos _x) distance _input0}, "ASCEND"] call BIS_fnc_sortBy) select 0;
 
+if (_targetsector isEqualTo "") exitWith {};
+
+private _targetpos = _targetsector;
+if (_targetpos isEqualType "") then {
+    _targetpos = getMarkerPos _targetsector;
+};
+private _spawnsector = ([sectors_airspawn, [_targetpos], {(markerpos _x) distance _input0}, "ASCEND"] call BIS_fnc_sortBy) select 0;
 private _newvehicle = objNull;
+private _pilot_group = grpNull;
 if (isNull _chopper_type) then {
     _chopper_type = selectRandom opfor_choppers;
 
@@ -13,17 +19,18 @@ if (isNull _chopper_type) then {
         _chopper_type = selectRandom opfor_choppers;
     };
 
-    private _newvehicle = createVehicle [_chopper_type, markerpos _spawnsector, [], 0, "FLY"];
+    _newvehicle = createVehicle [_chopper_type, markerpos _spawnsector, [], 0, "FLY"];
     createVehicleCrew _newvehicle;
     sleep 0.1;
 
-    private _pilot_group = createGroup [GRLIB_side_enemy, true];
+    _pilot_group = createGroup [GRLIB_side_enemy, true];
     (crew _newvehicle) joinSilent _pilot_group;
 
     _newvehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
     {_x addMPEventHandler ["MPKilled", {_this spawn kill_manager}];} forEach (crew _newvehicle);
 } else {
     _newvehicle = _chopper_type;
+    _pilot_group = group _newvehicle;
 };
 
 private _para_group = createGroup [GRLIB_side_enemy, true];
@@ -80,7 +87,7 @@ _pilot_group setCurrentWaypoint [_para_group, 1];
 _newvehicle flyInHeight 100;
 
 waitUntil {sleep 1;
-    !(alive _newvehicle) || (damage _newvehicle > 0.2 ) || (_newvehicle distance _targetpos < 400 )
+    !(alive _newvehicle) || (damage _newvehicle > 0.2 ) || (_newvehicle distance _targetpos < 400)
 };
 
 _newvehicle flyInHeight 100;

--- a/Missionframework/scripts/server/patrols/send_paratroopers.sqf
+++ b/Missionframework/scripts/server/patrols/send_paratroopers.sqf
@@ -1,27 +1,35 @@
-params ["_targetsector"];
+params [
+    ["_targetsector", "", [""]],
+    ["_chopper_type", objNull, [objNull]]
+];
 private _targetpos = getMarkerPos _targetsector;
 private _spawnsector = ([sectors_airspawn, [_targetpos], {(markerpos _x) distance _input0}, "ASCEND"] call BIS_fnc_sortBy) select 0;
 
-private _chopper_type = selectRandom opfor_choppers;
+private _newvehicle = objNull;
+if (isNull _chopper_type) then {
+    _chopper_type = selectRandom opfor_choppers;
 
-while {!(_chopper_type in opfor_troup_transports)} do {
-	_chopper_type = selectRandom opfor_choppers;
+    while {!(_chopper_type in opfor_troup_transports)} do {
+        _chopper_type = selectRandom opfor_choppers;
+    };
+
+    private _newvehicle = createVehicle [_chopper_type, markerpos _spawnsector, [], 0, "FLY"];
+    createVehicleCrew _newvehicle;
+    sleep 0.1;
+
+    private _pilot_group = createGroup [GRLIB_side_enemy, true];
+    (crew _newvehicle) joinSilent _pilot_group;
+
+    _newvehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+    {_x addMPEventHandler ["MPKilled", {_this spawn kill_manager}];} forEach (crew _newvehicle);
+} else {
+    _newvehicle = _chopper_type;
 };
-
-private _newvehicle = createVehicle [_chopper_type, markerpos _spawnsector, [], 0, "FLY"];
-createVehicleCrew _newvehicle;
-sleep 0.1;
-
-private _pilot_group = createGroup [GRLIB_side_enemy, true];
-(crew _newvehicle) joinSilent _pilot_group;
 
 private _para_group = createGroup [GRLIB_side_enemy, true];
 
-_newvehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
-{_x addMPEventHandler ["MPKilled", {_this spawn kill_manager}];} forEach (crew _newvehicle);
-
 while {(count (units _para_group)) < 8} do {
-	[opfor_paratrooper, markerPos _spawnsector, _para_group] call F_createManagedUnit;
+    [opfor_paratrooper, markerPos _spawnsector, _para_group] call F_createManagedUnit;
 };
 
 {removeBackpack _x; _x addBackPack "B_parachute"; _x moveInCargo _newvehicle;} forEach (units _para_group);
@@ -72,15 +80,15 @@ _pilot_group setCurrentWaypoint [_para_group, 1];
 _newvehicle flyInHeight 100;
 
 waitUntil {sleep 1;
-	!(alive _newvehicle) || (damage _newvehicle > 0.2 ) || (_newvehicle distance _targetpos < 400 )
+    !(alive _newvehicle) || (damage _newvehicle > 0.2 ) || (_newvehicle distance _targetpos < 400 )
 };
 
 _newvehicle flyInHeight 100;
 
 {
-	unassignVehicle _x;
-	moveout _x;
-	sleep 0.5;
+    unassignVehicle _x;
+    moveout _x;
+    sleep 0.5;
 } forEach (units _para_group);
 
 _newvehicle flyInHeight 100;

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ class Missions
 * Updated: Updated CUP presets to be inline with October 2019 stable build of CUP mods. Thanks to [Eogos](https://github.com/Eogos)
 * Tweaked: Default blacklist now only holds the static and tent backpacks.
 * Tweaked: Scripted server restart now automatically recognizes the OS of the server. More info in the [Wiki article](https://github.com/KillahPotatoes/KP-Liberation/wiki/EN_FAQ#how-does-the-scripted-server-restart-work)
+* Tweaked: Infantry for battlegroup transport vehicles are now spawned closer to the objective.
+* Tweaked: Transport helicopters in battlegroups are now correctly send paratroopers.
 * Fixed: Some CUP presets had free buildable arsenals. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Wrong boat in CUP USMC Woodland preset. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Object inits will fire on units not only vehicles.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ class Missions
 * Tweaked: Default blacklist now only holds the static and tent backpacks.
 * Tweaked: Scripted server restart now automatically recognizes the OS of the server. More info in the [Wiki article](https://github.com/KillahPotatoes/KP-Liberation/wiki/EN_FAQ#how-does-the-scripted-server-restart-work)
 * Tweaked: Infantry for battlegroup transport vehicles are now spawned closer to the objective.
-* Tweaked: Transport helicopters in battlegroups are now correctly send paratroopers.
+* Tweaked: Transport helicopters in battlegroups are now correctly dropping paratroopers.
 * Fixed: Some CUP presets had free buildable arsenals. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Wrong boat in CUP USMC Woodland preset. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Object inits will fire on units not only vehicles.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ class Missions
 * Added: Steam UID whitelist in config to grant access to commander actions even if not in that slot.
 * Added: Applied mission parameters are logged in server rpt.
 * Updated: Updated CUP presets to be inline with October 2019 stable build of CUP mods. Thanks to [Eogos](https://github.com/Eogos)
+* Updated: Turkish translation. Thanks to [654wak654](https://github.com/654wak654)
 * Tweaked: Default blacklist now only holds the static and tent backpacks.
 * Tweaked: Scripted server restart now automatically recognizes the OS of the server. More info in the [Wiki article](https://github.com/KillahPotatoes/KP-Liberation/wiki/EN_FAQ#how-does-the-scripted-server-restart-work)
 * Tweaked: Infantry for battlegroup transport vehicles are now spawned closer to the objective.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | #622 |

### Description:
Some format tweaks to the old battlegroup scripts. Also spawns the infantry for battlegroup transport land vehicles closer (1000m reduced to 500m) at the target destination. Furthermore we never catched helicopters added to battlegroup arrays and to transport array in opfor presets. Now if a battlegroup vehicle is also in the transport array, it'll either use the troop transport script when not an air vehicle and spawns the send_paratroopers script, if it's an air vehicle.

### Content:
- [x] Indentation and format tweaks to some battlegroup scripts
- [x] Battlegroup infantry for transport are spawning closer to objective now
- [x] Troop transport detection in battlegroup spawn now detect if it's an air vehicle

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP