### PR TITLE
Iron Front, IFA Liberation and CSA38 Cargo compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -321,5 +321,9 @@
                 "    Function reached the end [BOOL]"
             ]
         }
-    ]
+    ],
+    "todo-tree.general.statusBar": "tags",
+    "todo-tree.tree.showCountsInTree": true,
+    "todo-tree.tree.flat": true,
+    "todo-tree.tree.showInExplorer": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -322,8 +322,14 @@
             ]
         }
     ],
+    "todo-tree.highlights.defaultHighlight": {
+        "type": "tag",
+        "foreground": "yellow",
+        "background": "red",
+        "opacity": 50,
+        "iconColour": "green"
+    },
     "todo-tree.general.statusBar": "tags",
     "todo-tree.tree.showCountsInTree": true,
-    "todo-tree.tree.flat": true,
-    "todo-tree.tree.showInExplorer": false
+    "todo-tree.tree.flat": true
 }


### PR DESCRIPTION
add this code in the main Repo for crate compatibility for all the trucks in the following mods:
- Iron Front
- IFA Liberation
- CSA38 - Czechoslovak army 1938

	["LIB_US_NAC_GMC_Open", -6.5, [0,-1,0], [0,-2.6,0]],
	["LIB_US_GMC_Open", -6.5, [0,-1,0], [0,-2.6,0]],
	["LIB_US_GMC_Tent", -6.5, [0,-1,0], [0,-2.6,0]],
	["ifa3_gaz", -6.5, [-0.2,-1.1,0]],
	["ifa3_gaz2", -6.5, [-0.2,-1.1,0]],
	["ifa3_gazaa_IZ", -6.5, [0,-1,0]],
	["ifa3_gazaa_sap", -6.5, [-0.5,-1.4,0]],
	["ifa3_gazaa_eng", -6.5, [-0.5,-1.4,0]],
	["ifa3_gazaa", -6.5, [0,-1,0]],
	["LIB_AustinK5_Open", -6.5, [0,0,0], [0,-1.6,0]],
	["LIB_AustinK5_Tent", -6.5, [0,0,0], [0,-1.6,0]],
	["LIB_AustinK5_DR_Open", -6.5, [0,0,0], [0,-1.6,0]],
	["LIB_AustinK5_DR_Tent", -6.5, [0,0,0], [0,-1.6,0]],
	["LIB_DAK_M3_Halftrack", -6.5, [0,-1.3,-0.4]],
	["LIB_SOV_M3_Halftrack_w", -6.5, [0,-1.3,-0.4]],
	["LIB_SOV_M3_Halftrack", -6.5, [0,-1.3,-0.4]],
	["LIB_US_M3_Halftrack_w", -6.5, [0,-1.3,-0.4]],
	["LIB_US_M3_Halftrack", -6.5, [0,-1.3,-0.4]],
	["LIB_US_NAC_M3_Halftrack", -6.5, [0,-1.3,-0.4]],
	["LIB_OpelBlitz_Open_Y_Camo_w", -6.5, [0,-0.3,0.5], [0,-1.9,0.5]],
	["LIB_OpelBlitz_Tent_Y_Camo_w", -6.5, [0,-0.3,0.5], [0,-1.9,0.5]],
	["LIB_OpelBlitz_Open_Y_Camo", -6.5, [0,-0.3,0.5], [0,-1.9,0.5]],
	["LIB_OpelBlitz_Tent_Y_Camo", -6.5, [0,-0.3,0.5], [0,-1.9,0.5]],
	["LIB_DAK_OpelBlitz_Open", -6.5, [0,-0.3,0.5], [0,-1.9,0.5]],
	["LIB_DAK_OpelBlitz_Tent", -6.5, [0,-0.3,0.5], [0,-1.9,0.5]],
	["LIB_SdKfz_7", -6.5, [0.1,-0.8,-0.1], [0.1,-0.8,-0.1]],
	["LIB_SdKfz_7_w", -6.5, [0.1,-0.8,-0.1], [0.1,-0.8,-0.1]],
	["LIB_DAK_SdKfz_7", -6.5, [0.1,-0.8,-0.1], [0.1,-0.8,-0.1]],
	["LIB_US6_Open_Cargo", -6.5, [0,-0.7,0.7], [0,-2.3,0.7]],
	["LIB_US6_Open", -6.5, [0,-0.7,0.7], [0,-2.3,0.7]],
	["LIB_US6_Tent_Cargo", -6.5, [0,-0.7,0.7], [0,-2.3,0.7]],
	["LIB_Zis5v_w", -6.5, [0,0,-0.1], [0,-1.9,-0.1]],
	["LIB_Zis5v", -6.5, [0,0,-0.1], [0,-1.9,-0.1]],
	["CSA38_opelblitz3", -6.5, [0,-0.9,0.1], [0,-2.5,0.1]],
	["CSA38_opelblitz2", -6.5, [0,-0.9,0.1], [0,-2.5,0.1]],
	["CSA38_opelblitz", -6.5, [0,-0.9,0.1], [0,-2.5,0.1]],
	["CSA38_pragaRV6", -6.5, [0,-0.6,0.2], [0,-2.1,0.2]],
	["CSA38_pragaRV2", -6.5, [0,-0.6,0.2], [0,-2.1,0.2]],
	["CSA38_pragaRV4", -6.5, [0,-0.6,0.2], [0,-2.1,0.2]],
	["CSA38_pragaRV", -6.5, [0,-0.6,0.2], [0,-2.1,0.2]]
