### PR TITLE
Add support for disposable launchers

### DIFF
--- a/Missionframework/scripts/client/misc/init_arsenal.sqf
+++ b/Missionframework/scripts/client/misc/init_arsenal.sqf
@@ -26,6 +26,24 @@ if (KP_liberation_arsenalUsePreset) then {
 		KP_liberation_allowed_items append GRLIB_arsenal_weapons;
 	};
 
+	// Support for CBA disposable launchers, https://github.com/CBATeam/CBA_A3/wiki/Disposable-Launchers
+	if (isClass (configFile >> "cfgPatches" >> "cba_disposable")) then {
+		private _disposableLaunchers = ["CBA_FakeLauncherMagazine"];
+		{
+			private _loadedLauncher = cba_disposable_LoadedLaunchers getVariable _x;
+			if (!isNil "_loadedLauncher") then {
+				_disposableLaunchers pushBack _loadedLauncher;
+			};
+
+			private _normalLauncher = cba_disposable_NormalLaunchers getVariable _x;
+			if (!isNil "_normalLauncher") then {
+				_normalLauncher params ["_loadedLauncher"];
+				_disposableLaunchers pushBack _loadedLauncher;
+			};
+		} forEach KP_liberation_allowed_items;
+		KP_liberation_allowed_items append _disposableLaunchers;
+	};
+
 	if ((count GRLIB_arsenal_magazines) == 0) then {
 		if ((count blacklisted_from_arsenal) == 0) then {
 			_virtualMagazines = _virtualCargo select 1;

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ class Missions
 * Fixed: Flickering/disappearing of mobile respawn.
 * Fixed: Error message when trying to build a sector storage on water didn't vanished.
 * Fixed: RHS CH53 and RHS C130J transport configs after RHS 0.5.0 update. Thanks to [FatRefrigerator](https://github.com/FatRefrigerator)
+* Fixed: Support for CBA disposable launchers. Thanks to [Dahlgren](https://github.com/Dahlgren)
 
 ### 0.96.6 (09th September 2019)
 * Added: [Swedish Forces Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=826911897) transport configs. Thanks to [Dahlgren](https://github.com/Dahlgren)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |
| Fixed issues |  |

### Description:

Automatically whitelist classes defined through CBA Disposable Launchers

### Content:
- [x] CBA Disposable Launchers

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP

### Compatibility checked with:
* CBA A3 + SFP