### PR TITLE
0.96.7 Locality change of slingloaded cargo

### DIFF
--- a/Missionframework/CfgFunctions.hpp
+++ b/Missionframework/CfgFunctions.hpp
@@ -4,6 +4,7 @@ class KPLIB
     {
         file = "functions";
         class addObjectInit             {};
+        class addRopeAttachEh           {};
         class allowCrewInImmobile       {};
         class checkClass                {};
         class checkCrateValue           {};

--- a/Missionframework/functions/fn_addRopeAttachEh.sqf
+++ b/Missionframework/functions/fn_addRopeAttachEh.sqf
@@ -1,0 +1,35 @@
+/*
+    File: fn_addRopeAttachEh.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2020-04-09
+    Last Update: 2020-04-10
+    License: MIT License - http://www.opensource.org/licenses/MIT
+
+    Description:
+        Adds a ropeAttach EH if given vehicle is able to slingload objects.
+        The EH will make sure that the slingloaded cargo is local to the
+        helicopter pilot to avoid a rope breaking due to desyncs.
+
+    Parameter(s):
+        _obj - Object to apply the EH to [OBJECT, defaults to objNull]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_obj", objNull, [objNull]]
+];
+
+if (isNull _obj) exitWith {["Null object given"] call BIS_fnc_error; false};
+
+if (getNumber (configfile >> "CfgVehicles" >> (typeOf _obj) >> "slingLoadMaxCargoMass") > 0) then {
+    _obj addEventHandler ["RopeAttach", {
+        params ["_heli", "_rope", "_cargo"];
+        if !((owner _heli) isEqualTo (owner _cargo)) then {
+            _cargo setOwner (owner _heli);
+        };
+    }];
+};
+
+true

--- a/Missionframework/functions/fn_getOpforSpawnPoint.sqf
+++ b/Missionframework/functions/fn_getOpforSpawnPoint.sqf
@@ -2,7 +2,7 @@
     File: fn_getOpforSpawnPoint.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2019-12-03
+    Last Update: 2020-04-09
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -96,7 +96,7 @@ if (_possibleSpawns isEqualTo []) exitWith {diag_log "[KP LIBERATION] [WARNING] 
 // Return nearest spawn point to a blufor sector/FOB, if selected via parameter
 if (_nearest) exitWith {
     _possibleSpawns sort true;
-    (_possibeSpawns select 0) select 1
+    (_possibleSpawns select 0) select 1
 };
 
 // Return nearest spawn point to given position, if provided

--- a/Missionframework/kp_objectInits.sqf
+++ b/Missionframework/kp_objectInits.sqf
@@ -67,5 +67,12 @@ KPLIB_objectInits = [
     [
         ["gm_ge_army_kat1_454_cargo", "gm_ge_army_kat1_454_cargo_win"],
         {_this animateSource ["cover_unhide", 0, true];}
+    ],
+
+    // Make sure a slingloaded object is local to the helicopter pilot (avoid desync and rope break)
+    [
+        ["Helicopter"],
+        {if (isServer) then {[_this] call KPLIB_fnc_addRopeAttachEh;} else {[_this] remoteExecCall ["KPLIB_fnc_addRopeAttachEh", 2];};},
+        true
     ]
 ];

--- a/Missionframework/scripts/server/base/huron_manager.sqf
+++ b/Missionframework/scripts/server/base/huron_manager.sqf
@@ -22,6 +22,7 @@ while {true} do {
         huron enableSimulationGlobal true;
         huron setDamage 0;
         huron allowdamage true;
+        [huron] call KPLIB_fnc_addObjectInit;
     };
     [huron] call KPLIB_fnc_clearCargo;
     huron setVariable ["ace_medical_isMedicalVehicle", true, true];

--- a/Missionframework/scripts/server/base/startvehicle_spawn.sqf
+++ b/Missionframework/scripts/server/base/startvehicle_spawn.sqf
@@ -43,6 +43,7 @@ private _veh = objNull;
         _veh setDamage 0;
         _veh allowDamage true;
         _veh setVariable ["KP_liberation_preplaced", true, true];
+        [_veh] call KPLIB_fnc_addObjectInit;
     };
 } forEach [
     ["littlebird_", KP_liberation_little_bird_classname],

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ class Missions
 * Added: [Chernarus 2020](https://steamcommunity.com/sharedfiles/filedetails/?id=1913961235) basefile. Thanks to [Eogos](https://github.com/Eogos)
 * Added: [Chernarus 2020](https://steamcommunity.com/sharedfiles/filedetails/?id=1913961235) building ignore list. Thanks to [Eogos](https://github.com/Eogos)
 * Added: Steam Workshop upload to build tools
+* Added: Locality change of slingloaded cargo to heli pilot to avoid breaking ropes while e.g. slingloading the FOB box.
 * Updated: Updated CUP presets to be inline with October 2019 stable build of CUP mods. Thanks to [Eogos](https://github.com/Eogos)
 * Updated: Turkish translation. Thanks to [654wak654](https://github.com/654wak654)
 * Updated: Russian localization. Thanks to [Dj_Haski](https://github.com/DjHaski)
@@ -208,6 +209,7 @@ class Missions
 * Tweaked: Start vehicle/Potato 01/start resources spawn at mission start optimized.
 * Tweaked: Explanation and formatting of `kp_objectInits.sqf`.
 * Tweaked: Integer to bool conversion in fetch param macro.
+* Tweaked: ObjectInit is now also called on spawned start vehicles.
 * Fixed: Some CUP presets had free buildable arsenals. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Wrong boat in CUP USMC Woodland preset. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Object inits will fire on units not only vehicles.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | - |

### Description:
As it was sometimes reported, that people loose e.g. the FOB box due to breaking ropes on dedicated servers while transporting it with the Potato 01 helicopter, I've added a locality change for slingloaded cargo. It'll add a `ropeAttach` EH to every helicopter which is able to slingload cargo. The EH will change the locality of the cargo to the helicopter pilot, which will fix the desyncs and resulting rope breaks while flying.
Also the start vehicles are now also checked for possible objectInit entries.

### Content:
- [x] ropeAttach EH for helicopters to change cargo locality
- [x] objectInit applied for start vehicles

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP