### PR TITLE
0.96.7 Use structured text for diag_log

### DIFF
--- a/Missionframework/functions/fn_checkClass.sqf
+++ b/Missionframework/functions/fn_checkClass.sqf
@@ -2,7 +2,7 @@
     File: fn_checkClass.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2019-12-03
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,6 +24,6 @@ if (_classname isEqualTo "") exitWith {["Empty string given"] call BIS_fnc_error
 if (isClass (configFile >> "CfgVehicles" >> _classname)) then {
     true
 } else {
-    if (isServer) then {diag_log format ["[KP LIBERATION] [PRESETS] %1 not found in CfgVehicles", _classname];};
+    if (isServer) then {diag_log text format ["[KP LIBERATION] [PRESETS] %1 not found in CfgVehicles", _classname];};
     false
 };

--- a/Missionframework/functions/fn_checkGear.sqf
+++ b/Missionframework/functions/fn_checkGear.sqf
@@ -2,7 +2,7 @@
     File: fn_checkGear.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-11-22
-    Last Update: 2020-04-05
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -115,7 +115,7 @@ _removedItems = (_removedItems arrayIntersect _removedItems) - [""];
 if !(_removedItems isEqualTo []) exitWith {
     [_removedItems] spawn {
         params ["_removedItems"];
-        private _text = format ["[KP LIBERATION] [BLACKLIST] Found %1 at Player %2", _removedItems, name player];
+        private _text = text format ["[KP LIBERATION] [BLACKLIST] Found %1 at Player %2", _removedItems, name player];
         _text remoteExec ["diag_log", 2];
         hint format [localize "STR_BLACKLISTED_ITEM_FOUND", _removedItems joinString "\n"];
         sleep 6;

--- a/Missionframework/functions/fn_crAddAceAction.sqf
+++ b/Missionframework/functions/fn_crAddAceAction.sqf
@@ -2,7 +2,7 @@
     File: fn_crAddAceAction.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-12-03
-    Last Update: 2019-12-04
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,7 +21,7 @@ params [
 
 if (isNull _civ) exitWith {["Null object given"] call BIS_fnc_error; false};
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] ace_action called on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] ace_action called on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 _civ addAction [
     "<t color='#FF0000'>" + localize "STR_CR_ACE_ACTION" + "</t>",

--- a/Missionframework/functions/fn_crGlobalMsg.sqf
+++ b/Missionframework/functions/fn_crGlobalMsg.sqf
@@ -2,7 +2,7 @@
     File: fn_crGlobalMsg.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-12-03
-    Last Update: 2019-12-04
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,7 +21,7 @@ params [
     ["_data", [], []]
 ];
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] globalMsg called on: %1 - Parameters: [%2, %3]", debug_source, _msgType, _data];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] globalMsg called on: %1 - Parameters: [%2, %3]", debug_source, _msgType, _data];_text remoteExec ["diag_log",2];};
 
 switch (_msgType) do {
     case 0: {systemChat localize "STR_CR_VEHICLEMSG";};
@@ -30,7 +30,7 @@ switch (_msgType) do {
     case 3: {systemChat (format [localize "STR_CR_RESISTANCE_KILLMSG", (_data select 0)]);};
     case 4: {systemChat (format [localize "STR_CR_HEALMSG", (_data select 0)]);};
     case 5: {["lib_asymm_guerilla_incoming", _data] call BIS_fnc_showNotification;};
-    default {[format ["[KP LIBERATION] [ERROR] [CIVREP] globalMsg without valid msgType - %1", _msgType]] remoteExec ["diag_log", 2];};
+    default {[text format ["[KP LIBERATION] [ERROR] [CIVREP] globalMsg without valid msgType - %1", _msgType]] remoteExec ["diag_log", 2];};
 };
 
 true

--- a/Missionframework/functions/fn_getOpforSpawnPoint.sqf
+++ b/Missionframework/functions/fn_getOpforSpawnPoint.sqf
@@ -2,7 +2,7 @@
     File: fn_getOpforSpawnPoint.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2020-04-09
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -91,7 +91,7 @@ private ["_valid", "_current", "_distances"];
 } forEach _spawnsToCheck;
 
 // Return empty string, if no possible spawn point was found
-if (_possibleSpawns isEqualTo []) exitWith {diag_log "[KP LIBERATION] [WARNING] No opfor spawn point found"; ""};
+if (_possibleSpawns isEqualTo []) exitWith {diag_log text "[KP LIBERATION] [WARNING] No opfor spawn point found"; ""};
 
 // Return nearest spawn point to a blufor sector/FOB, if selected via parameter
 if (_nearest) exitWith {

--- a/Missionframework/functions/fn_getSaveableParam.sqf
+++ b/Missionframework/functions/fn_getSaveableParam.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveableParam.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2018-01-27
-    Last Update: 2019-12-06
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -41,18 +41,18 @@ switch (_action) do {
         private _savedParams = profileNamespace getVariable _saveKey;
 
         if(isNil "_savedParams") then {
-            if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [PARAM] Param save data is corrupted, creating new.";};
+            if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [PARAM] Param save data is corrupted, creating new.";};
             // Create new "associative" array
             _savedParams = [[_paramName, _value]];
 
         } else {
             private _singleParam = (_savedParams select {(_x select 0) == _paramName}) select 0;
             if(isNil "_singleParam") then {
-                if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [PARAM] Saving value: %1 for param: %2,", _value, _paramName];};
+                if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [PARAM] Saving value: %1 for param: %2,", _value, _paramName];};
                 _savedParams pushBack [_paramName, _value];
 
             } else {
-                if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [PARAM] Overwriting value: %1 with: %2 for param: %3,", (_singleParam select 1), _value, _paramName];};
+                if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [PARAM] Overwriting value: %1 with: %2 for param: %3,", (_singleParam select 1), _value, _paramName];};
                 // _singleparam is an reference to array in _savedParams, we can use "set"
                 _singleParam set [1, _value];
             };
@@ -66,25 +66,25 @@ switch (_action) do {
     case 1: {
         private _savedParams = profileNamespace getVariable _saveKey;
         if(isNil "_savedParams") then {
-            if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [PARAM] Param save data is corrupted, can't load!";};
+            if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [PARAM] Param save data is corrupted, can't load!";};
             // Fix param save data
             profileNamespace setVariable [_saveKey, []];
-            if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [PARAM] No saved value for param: %1, fetching value.", _paramName];};
+            if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [PARAM] No saved value for param: %1, fetching value.", _paramName];};
             _value = [_paramName, _defaultValue] call bis_fnc_getParamValue;
         } else {
             private _singleParam = (_savedParams select {(_x select 0) == _paramName}) select 0;
             if(isNil "_singleParam") then {
-                if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [PARAM] No saved value for param: %1, fetching value.", _paramName];};
+                if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [PARAM] No saved value for param: %1, fetching value.", _paramName];};
                 _value = [_paramName, _defaultValue] call bis_fnc_getParamValue;
             } else {
-                if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [PARAM] Found value: %1 for param: %2,", (_singleParam select 1), _paramName];};
+                if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [PARAM] Found value: %1 for param: %2,", (_singleParam select 1), _paramName];};
                 _value = _singleParam select 1;
             };
         };
     };
     // Get param
     default {
-        if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [PARAM] Fetch selected value for param";};
+        if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [PARAM] Fetch selected value for param";};
         _value = [_paramName, _defaultValue] call bis_fnc_getParamValue;
     };
 };

--- a/Missionframework/functions/fn_sortStorage.sqf
+++ b/Missionframework/functions/fn_sortStorage.sqf
@@ -2,7 +2,7 @@
     File: fn_sortStorage.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-06-09
-    Last Update: 2020-04-03
+    Last Update: 2020-04-10
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -30,7 +30,7 @@ private _fuel = 0;
         case KP_liberation_supply_crate: {_supply = _supply + (_x getVariable ["KP_liberation_crate_value",0]);};
         case KP_liberation_ammo_crate: {_ammo = _ammo + (_x getVariable ["KP_liberation_crate_value",0]);};
         case KP_liberation_fuel_crate: {_fuel = _fuel + (_x getVariable ["KP_liberation_crate_value",0]);};
-        default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+        default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
     };
     detach _x;
     deleteVehicle _x;

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -1,7 +1,7 @@
 if (isServer) then {
-    diag_log format ["[KP LIBERATION] [PRESETS] ----- Server starts preset initialization - time: %1", diag_ticktime];
-    diag_log "[KP LIBERATION] [PRESETS] Not found vehicles listed below are not an issue in general. It just sorts out vehicles from not loaded mods.";
-    diag_log "[KP LIBERATION] [PRESETS] Only if you e.g. use a CUP preset and you get messages about missing CUP classes, then check your loaded mods.";
+    diag_log text format ["[KP LIBERATION] [PRESETS] ----- Server starts preset initialization - time: %1", diag_ticktime];
+    diag_log text "[KP LIBERATION] [PRESETS] Not found vehicles listed below are not an issue in general. It just sorts out vehicles from not loaded mods.";
+    diag_log text "[KP LIBERATION] [PRESETS] Only if you e.g. use a CUP preset and you get messages about missing CUP classes, then check your loaded mods.";
 };
 
 switch (KP_liberation_preset_blufor) do {
@@ -214,4 +214,4 @@ GRLIB_intel_laptop = "Land_Laptop_device_F";
 GRLIB_sar_wreck = "Land_Wreck_Heli_Attack_01_F";
 GRLIB_sar_fire = "test_EmptyObjectForFireBig";
 
-if (isServer) then {diag_log format ["[KP LIBERATION] [PRESETS] ----- Server finished preset initialization - time: %1", diag_ticktime];};
+if (isServer) then {diag_log text format ["[KP LIBERATION] [PRESETS] ----- Server finished preset initialization - time: %1", diag_ticktime];};

--- a/Missionframework/scripts/client/asymmetric/asymm_notifications.sqf
+++ b/Missionframework/scripts/client/asymmetric/asymm_notifications.sqf
@@ -2,7 +2,7 @@ if (isDedicated) exitWith {};
 
 params ["_notif_id", ["_pos", getpos player]];
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] asymm_notifications called on: %1 - Parameters: [%2, %3] ", debug_source, _notif_id, _pos];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] asymm_notifications called on: %1 - Parameters: [%2, %3] ", debug_source, _notif_id, _pos];_text remoteExec ["diag_log",2];};
 
 switch (_notif_id) do {
 	case 0: {
@@ -20,5 +20,5 @@ switch (_notif_id) do {
 		["lib_asymm_convoy_ambush_fail"] call BIS_fnc_showNotification;
 		deleteMarkerLocal "asymm_ambushmarker";
 	};
-	default {private _text = format ["[KP LIBERATION] [ERROR] asymm_notifications.sqf -> no valid value for _notif_id: %1", _notif_id];_text remoteExec ["diag_log",2];};
+	default {private _text = text format ["[KP LIBERATION] [ERROR] asymm_notifications.sqf -> no valid value for _notif_id: %1", _notif_id];_text remoteExec ["diag_log",2];};
 };

--- a/Missionframework/scripts/client/civinformant/civinfo_escort.sqf
+++ b/Missionframework/scripts/client/civinformant/civinfo_escort.sqf
@@ -2,11 +2,11 @@ params ["_informant"];
 
 if (isDedicated) exitWith {};
 
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_escort called on: %1 - Parameters: [%2]", debug_source, _informant];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_escort called on: %1 - Parameters: [%2]", debug_source, _informant];_text remoteExec ["diag_log",2];};
 
 waitUntil {sleep 0.5; local _informant || !alive _informant};
 
-if !(alive _informant) exitWith {if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_escort exited by: %1 - Informant isn't alive", debug_source];_text remoteExec ["diag_log",2];};};
+if !(alive _informant) exitWith {if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_escort exited by: %1 - Informant isn't alive", debug_source];_text remoteExec ["diag_log",2];};};
 
 private _is_near_fob = false;
 
@@ -39,9 +39,9 @@ if (alive _informant) then {
 		sleep 5;
 		[_informant, "AidlPsitMstpSnonWnonDnon_ground00"] remoteExec ["remote_call_switchmove"];
 		[_informant] remoteExec ["civinfo_delivered",2];
-		if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] civinfo_escort -> Informant at FOB";_text remoteExec ["diag_log",2];};
+		if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] civinfo_escort -> Informant at FOB";_text remoteExec ["diag_log",2];};
 		sleep 600;
 		deleteVehicle _informant;
-		if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_escort finished by: %1", debug_source];_text remoteExec ["diag_log",2];};
+		if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_escort finished by: %1", debug_source];_text remoteExec ["diag_log",2];};
 	};
 };

--- a/Missionframework/scripts/client/civinformant/civinfo_notifications.sqf
+++ b/Missionframework/scripts/client/civinformant/civinfo_notifications.sqf
@@ -2,7 +2,7 @@ if (isDedicated) exitWith {};
 
 params ["_notif_id", ["_pos", getpos player]];
 
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_notifications called on: %1 - Parameters: [%2, %3] ", debug_source, _notif_id, _pos];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_notifications called on: %1 - Parameters: [%2, %3] ", debug_source, _notif_id, _pos];_text remoteExec ["diag_log",2];};
 
 switch (_notif_id) do {
 	case 0: {
@@ -47,5 +47,5 @@ switch (_notif_id) do {
 		deleteMarkerLocal "HVT_marker";
 		deleteMarkerLocal "HVT_zone";
 	};
-	default {private _text = format ["[KP LIBERATION] [ERROR] civinfo_notifications.sqf -> no valid value for _notif_id: %1", _notif_id];_text remoteExec ["diag_log",2];};
+	default {private _text = text format ["[KP LIBERATION] [ERROR] civinfo_notifications.sqf -> no valid value for _notif_id: %1", _notif_id];_text remoteExec ["diag_log",2];};
 };

--- a/Missionframework/scripts/client/civrep/kp_cr_checkVehicle.sqf
+++ b/Missionframework/scripts/client/civrep/kp_cr_checkVehicle.sqf
@@ -1,6 +1,6 @@
 params ["_vehicle"];
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] checkVehicle called on: %1 - Vehicle: %2", debug_source, _vehicle];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] checkVehicle called on: %1 - Vehicle: %2", debug_source, _vehicle];_text remoteExec ["diag_log",2];};
 
 if (isNil "KP_liberation_cr_vehicles") then {
     KP_liberation_cr_vehicles = [];
@@ -18,4 +18,4 @@ if (((typeOf _vehicle) in civilian_vehicles) && !(_vehicle in KP_liberation_cr_v
     publicVariable "stats_civilian_vehicles_seized";
 };
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] checkVehicle finished on: %1 - Stolen vehicle list: %2", debug_source, KP_liberation_cr_vehicles];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] checkVehicle finished on: %1 - Stolen vehicle list: %2", debug_source, KP_liberation_cr_vehicles];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/client/remotecall/remote_call_intel.sqf
+++ b/Missionframework/scripts/client/remotecall/remote_call_intel.sqf
@@ -55,5 +55,5 @@ switch (_notiftype) do {
 		deleteMarkerLocal "secondarymarkerzone";
 		secondary_objective_position_marker = [];
 	};
-	default {private _text = format ["[KP LIBERATION] [ERROR] remote_call_intel.sqf -> no valid value for _notiftype: %1", _notiftype];_text remoteExec ["diag_log",2];};
+	default {private _text = text format ["[KP LIBERATION] [ERROR] remote_call_intel.sqf -> no valid value for _notiftype: %1", _notiftype];_text remoteExec ["diag_log",2];};
 };

--- a/Missionframework/scripts/server/asymmetric/asymmetric_loop.sqf
+++ b/Missionframework/scripts/server/asymmetric/asymmetric_loop.sqf
@@ -2,7 +2,7 @@ waitUntil {!isNil "save_is_loaded"};
 waitUntil {!isNil "KP_liberation_civ_rep"};
 waitUntil {save_is_loaded};
 
-if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Loop spawned on: %1", debug_source];};
+if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Loop spawned on: %1", debug_source];};
 
 KP_liberation_asymmetric_sectors = [];
 
@@ -27,10 +27,10 @@ while {GRLIB_endgame == 0} do {
 				if ((_x select 0) == _sector) exitWith {
 					if ((((_x select 1) + 1800) < time) && (_units_at_sector == 0)) then {
 						asymm_blocked_sectors = asymm_blocked_sectors - [_x];
-						if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 removed from blocked sectors", markerText (_x select 0)];};
+						if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 removed from blocked sectors", markerText (_x select 0)];};
 					} else {
 						_blocked = true;
-						if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 still blocked for ambush", markerText (_x select 0)];};
+						if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 still blocked for ambush", markerText (_x select 0)];};
 					};
 				};
 			} forEach asymm_blocked_sectors;

--- a/Missionframework/scripts/server/asymmetric/convoy/logistic_convoy_ambush.sqf
+++ b/Missionframework/scripts/server/asymmetric/convoy/logistic_convoy_ambush.sqf
@@ -1,20 +1,20 @@
 params ["_convoy"];
 
-if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1: spawning ambush", (_convoy select 0)];};
+if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1: spawning ambush", (_convoy select 0)];};
 
 private _pos = [0,0,0];
 
 switch ((_convoy select 7)) do {
 	case 2: {_pos = (_convoy select 3) getPos [(_convoy select 8) * 400, (_convoy select 3) getDir (_convoy select 2)]};
 	case 4: {_pos = (_convoy select 2) getPos [(_convoy select 8) * 400, (_convoy select 2) getDir (_convoy select 3)]};
-	default {diag_log format ["[KP LIBERATION] [ERROR] Logistic convoy %1 ambush: convoy is not travelling", (_convoy select 0)];};
+	default {diag_log text format ["[KP LIBERATION] [ERROR] Logistic convoy %1 ambush: convoy is not travelling", (_convoy select 0)];};
 };
 
-if (_pos isEqualTo [0,0,0]) exitWith {diag_log format ["[KP LIBERATION] [ERROR] Logistic convoy %1 ambush: no position", (_convoy select 0)];};
+if (_pos isEqualTo [0,0,0]) exitWith {diag_log text format ["[KP LIBERATION] [ERROR] Logistic convoy %1 ambush: no position", (_convoy select 0)];};
 
 private _roadObj = [_pos, 400, []] call BIS_fnc_nearestRoad;
 if (isNull _roadObj) exitWith {
-	if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: no road near current convoy position", (_convoy select 0)];};
+	if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: no road near current convoy position", (_convoy select 0)];};
 	KP_liberation_convoy_ambush_check = 1;
 };
 
@@ -41,7 +41,7 @@ for "_i" from 1 to (_convoy select 1) do {
 	private _driver = createVehicle [crewman_classname, getPos _veh, [], 12, "NONE"];
 	_driver setDamage 1;
 };
-if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: truck spawning done", (_convoy select 0)];};
+if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: truck spawning done", (_convoy select 0)];};
 
 private _supplies = (_convoy select 6) select 0;
 private _ammo = (_convoy select 6) select 1;
@@ -80,7 +80,7 @@ while {_fuel > 0} do {
 	_crate setPos (_crate getPos [random 60, random 360]);
 	_crateArray pushBack [_crate];
 };
-if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: resource spawning done", (_convoy select 0)];};
+if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: resource spawning done", (_convoy select 0)];};
 
 private _grp = [getPos _roadObj] call KPLIB_fnc_spawnGuerillaGroup;
 
@@ -96,7 +96,7 @@ _waypoint setWaypointCompletionRadius 10;
 _waypoint = _grp addWaypoint [getPos _roadObj, 150];
 _waypoint setWaypointType "CYCLE";
 _waypoint setWaypointCompletionRadius 10;
-if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: guerillas spawning done", (_convoy select 0)];};
+if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: guerillas spawning done", (_convoy select 0)];};
 
 private _waitingTime = KP_liberation_convoy_ambush_duration;
 
@@ -111,7 +111,7 @@ while {(({alive _x} count (units _grp)) > 0) && (_waitingTime > 0)} do {
 		_waitingTime = _waitingTime - 1;
 	};
 };
-if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: ambush finished", (_convoy select 0)];};
+if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: ambush finished", (_convoy select 0)];};
 
 KP_liberation_convoy_ambush_inProgress = false;
 
@@ -133,8 +133,8 @@ if ((_waitingTime <= 0) && (({alive _x} count (units _grp)) > 0)) then {
 		deleteVehicle (_x select 0);
 	} forEach _crateArray;
 	KP_liberation_guerilla_strength = KP_liberation_guerilla_strength + _gain;
-	if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: guerillas escaped", (_convoy select 0)];};
+	if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: guerillas escaped", (_convoy select 0)];};
 } else {
 	[1] remoteExec ["asymm_notifications"];
-	if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: guerillas defeated", (_convoy select 0)];};
+	if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1 ambush: guerillas defeated", (_convoy select 0)];};
 };

--- a/Missionframework/scripts/server/asymmetric/ied/manage_asymIED.sqf
+++ b/Missionframework/scripts/server/asymmetric/ied/manage_asymIED.sqf
@@ -2,11 +2,11 @@ params ["_sector", "_count"];
 
 if (_count <= 0) exitWith {};
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf for %1 spawned on: %2", markerText _sector, debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf for %1 spawned on: %2", markerText _sector, debug_source];_text remoteExec ["diag_log",2];};
 
 waitUntil {sleep 1; _sector in KP_liberation_asymmetric_sectors};
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> spawning IED %1 at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> spawning IED %1 at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
 
 private _activation_radius_infantry = 6.66;
 private _activation_radius_vehicles = 10;
@@ -28,7 +28,7 @@ if (!(isnull _roadobj)) then {
 	_ied_obj = createMine [_ied_type, _roadpos getPos [_spread, random (360)], [], 0];
 	_ied_obj setdir (random 360);
 
-	if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> IED %1 spawned at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> IED %1 spawned at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
 
 	while {(_sector in KP_liberation_asymmetric_sectors) && (mineActive _ied_obj) && !_goes_boom} do {
 		_nearinfantry = ((getpos _ied_obj) nearEntities ["Man", _activation_radius_infantry]) select {side _x == GRLIB_side_friendly};
@@ -41,10 +41,10 @@ if (!(isnull _roadobj)) then {
 		sleep 1;
 	};
 } else {
-	if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> _roadobj is Null for IED %1 at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> _roadobj is Null for IED %1 at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
 };
 
-if ((KP_liberation_asymmetric_debug > 0) && !(isNull _roadobj)) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> exit IED %1 loop at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
+if ((KP_liberation_asymmetric_debug > 0) && !(isNull _roadobj)) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] manage_asymIED.sqf -> exit IED %1 loop at %2", _count, markerText _sector];_text remoteExec ["diag_log",2];};
 
 sleep 60;
 

--- a/Missionframework/scripts/server/asymmetric/init_module.sqf
+++ b/Missionframework/scripts/server/asymmetric/init_module.sqf
@@ -1,4 +1,4 @@
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] Module initialising on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] Module initialising on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 // Scripts
 // Logistic convoy ambush
@@ -18,4 +18,4 @@ publicVariable "asymm_blocked_sectors";
 // Start module loop
 execVM "scripts\server\asymmetric\asymmetric_loop.sqf";
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] Module initialised on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] Module initialised on: %1", debug_source];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/server/asymmetric/random/asym_sector_ambush.sqf
+++ b/Missionframework/scripts/server/asymmetric/random/asym_sector_ambush.sqf
@@ -1,6 +1,6 @@
 params ["_sector"];
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf for %1 spawned on: %2 - Time: %3", markerText _sector, debug_source, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf for %1 spawned on: %2 - Time: %3", markerText _sector, debug_source, time];_text remoteExec ["diag_log",2];};
 
 waitUntil {sleep 1; _sector in KP_liberation_asymmetric_sectors};
 
@@ -10,7 +10,7 @@ private _positions = [];
 	_positions = _positions + ([_x] call BIS_fnc_buildingPositions);
 } forEach _buildings;
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Found %1 suitable buildings in %2 - Time: %3", count _buildings, markerText _sector, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Found %1 suitable buildings in %2 - Time: %3", count _buildings, markerText _sector, time];_text remoteExec ["diag_log",2];};
 
 private _position_indexes = [];
 private _position_count = count _positions;
@@ -32,7 +32,7 @@ private _idxposit = 0;
 	_idxposit = _idxposit + 1;
 } forEach (units _grp);
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Units spawned in %1 - Time: %2", markerText _sector, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Units spawned in %1 - Time: %2", markerText _sector, time];_text remoteExec ["diag_log",2];};
 
 private _attack = false;
 
@@ -59,7 +59,7 @@ while {(_sector in KP_liberation_asymmetric_sectors) && (!isNull _grp)} do {
 	sleep 1;
 };
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Exit Loop in %1 - Time: %2", markerText _sector, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Exit Loop in %1 - Time: %2", markerText _sector, time];_text remoteExec ["diag_log",2];};
 
 sleep 60;
 
@@ -71,4 +71,4 @@ if (!isNull _grp) then {
 	} forEach (units _grp);
 };
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Ambush dropped in %1 - Time: %2", markerText _sector, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] asym_sector_ambush.sqf -> Ambush dropped in %1 - Time: %2", markerText _sector, time];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/server/asymmetric/random/sector_guerilla.sqf
+++ b/Missionframework/scripts/server/asymmetric/random/sector_guerilla.sqf
@@ -1,6 +1,6 @@
 params ["_sector"];
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 (%2) - sector_guerilla spawned on: %3", (markerText _sector), _sector, debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 (%2) - sector_guerilla spawned on: %3", (markerText _sector), _sector, debug_source];_text remoteExec ["diag_log",2];};
 
 private _startpos = (markerPos _sector) getPos [(1200 + (round (random 400))), (random 360)];
 
@@ -128,4 +128,4 @@ if (!isServer && _strengthChanged) then {
 	publicVariableServer "KP_liberation_guerilla_strength";
 };
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 (%2) - sector_guerilla dropped on: %3", (markerText _sector), _sector, debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 (%2) - sector_guerilla dropped on: %3", (markerText _sector), _sector, debug_source];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -1,11 +1,11 @@
 waitUntil {sleep 10; ({_x in sectors_capture || _x in sectors_bigtown} count blufor_sectors) > 0};
 
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] Loop spawned on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] Loop spawned on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 while {true} do {
 	uiSleep (KP_liberation_civinfo_min + round (random (KP_liberation_civinfo_max - KP_liberation_civinfo_min)));
 
-	if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] Informant sleep passed";_text remoteExec ["diag_log",2];};
+	if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] Informant sleep passed";_text remoteExec ["diag_log",2];};
 
 	waitUntil {
 		sleep 10;
@@ -13,7 +13,7 @@ while {true} do {
 		KP_liberation_civ_rep >= 25
 	};
 
-	if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] Informant waitUntil passed";_text remoteExec ["diag_log",2];};
+	if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] Informant waitUntil passed";_text remoteExec ["diag_log",2];};
 
 	if ((KP_liberation_civinfo_chance >= (random 100)) && GRLIB_endgame == 0) then {
 		private _sector = selectRandom (blufor_sectors select {_x in sectors_capture || _x in sectors_bigtown});
@@ -36,7 +36,7 @@ while {true} do {
 			_informant setCaptive true;
 		};
 
-		if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] Informant %1 spawned on: %2 - Position: %3", name _informant, debug_source, getPos _informant];_text remoteExec ["diag_log",2];};
+		if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] Informant %1 spawned on: %2 - Position: %3", name _informant, debug_source, getPos _informant];_text remoteExec ["diag_log",2];};
 
 		[0, [((((getPos _informant) select 0) + 200) - random 400),((((getPos _informant) select 1) + 200) - random 400),0]] remoteExec ["civinfo_notifications"];
 
@@ -51,7 +51,7 @@ while {true} do {
 				_waiting_time = _waiting_time - 1;
 			};
 
-			if ((KP_liberation_civinfo_debug > 0) && ((_waiting_time % 60) == 0)) then {private _text = format ["[KP LIBERATION] [CIVINFO] Informant will despawn in %1 minutes", round (_waiting_time / 60)];_text remoteExec ["diag_log",2];};
+			if ((KP_liberation_civinfo_debug > 0) && ((_waiting_time % 60) == 0)) then {private _text = text format ["[KP LIBERATION] [CIVINFO] Informant will despawn in %1 minutes", round (_waiting_time / 60)];_text remoteExec ["diag_log",2];};
 		};
 
 		if (_waiting_time > 0) then {
@@ -65,15 +65,15 @@ while {true} do {
 				sleep 1;
 				[_informant] remoteExec ["civinfo_escort"];
 			} else {
-				if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] Informant is dead";_text remoteExec ["diag_log",2];};
+				if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] Informant is dead";_text remoteExec ["diag_log",2];};
 				[3] remoteExec ["civinfo_notifications"];
 			};
 		} else {
 			deleteVehicle _informant;
-			if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] Informant despawned";_text remoteExec ["diag_log",2];};
+			if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] Informant despawned";_text remoteExec ["diag_log",2];};
 			[2] remoteExec ["civinfo_notifications"];
 		};
 	} else {
-		if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] Informant spawn chance missed";_text remoteExec ["diag_log",2];};
+		if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] Informant spawn chance missed";_text remoteExec ["diag_log",2];};
 	};
 };

--- a/Missionframework/scripts/server/civinformant/init_module.sqf
+++ b/Missionframework/scripts/server/civinformant/init_module.sqf
@@ -1,4 +1,4 @@
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] Module initialising on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] Module initialising on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 // Scripts
 // Task selection and spawning
@@ -7,4 +7,4 @@ civinfo_task = compileFinal preprocessFileLineNumbers "scripts\server\civinforma
 // Start spawn loop
 execVM "scripts\server\civinformant\civinfo_loop.sqf";
 
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] Module initialised on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] Module initialised on: %1", debug_source];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/server/civinformant/tasks/civinfo_task.sqf
+++ b/Missionframework/scripts/server/civinformant/tasks/civinfo_task.sqf
@@ -1,9 +1,9 @@
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf spawned on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf spawned on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 private _spawn_marker = [2000,999999,false] call KPLIB_fnc_getOpforSpawnPoint;
 private _roadObj = [markerPos _spawn_marker, 400, []] call BIS_fnc_nearestRoad;
 
-if (isNull _roadObj) exitWith {if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> no road found";_text remoteExec ["diag_log",2];};};
+if (isNull _roadObj) exitWith {if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> no road found";_text remoteExec ["diag_log",2];};};
 
 private _veh = createVehicle [opfor_mrap, getPos _roadObj, [], 0, "NONE"];
 _veh setDir (getDir _roadObj);
@@ -38,7 +38,7 @@ _waypoint setWaypointType "MOVE";
 _waypoint = _grp addWaypoint [getPos _roadObj, 100];
 _waypoint setWaypointType "CYCLE";
 
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> vehicle and group created on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> vehicle and group created on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 private _marker_pos = [((((getPos _roadObj) select 0) + 200) - random 400),((((getPos _roadObj) select 1) + 200) - random 400),0];
 
@@ -56,21 +56,21 @@ while {(alive _hvt) && _time_remaining > 0} do {
 	if !(_player_near) then {
 		_time_remaining = _time_remaining - 1;
 	};
-	if ((KP_liberation_civinfo_debug > 0) && ((_time_remaining % 60) == 0)) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> Task will despawn in %1 minutes", round (_time_remaining / 60)];_text remoteExec ["diag_log",2];};
+	if ((KP_liberation_civinfo_debug > 0) && ((_time_remaining % 60) == 0)) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> Task will despawn in %1 minutes", round (_time_remaining / 60)];_text remoteExec ["diag_log",2];};
 };
 
-if (KP_liberation_civinfo_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> loop exited on: %1", debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civinfo_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> loop exited on: %1", debug_source];_text remoteExec ["diag_log",2];};
 
 if (alive _hvt) then {
 	deleteVehicle _veh;
 	{deleteVehicle _x} forEach (units _grp);
 	[6] remoteExec ["civinfo_notifications"];
-	if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> Task despawned";_text remoteExec ["diag_log",2];};
+	if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> Task despawned";_text remoteExec ["diag_log",2];};
 } else {
 	combat_readiness = round (combat_readiness * 0.8);
 	if (!isServer) then {
 		publicVariableServer "combat_readiness";
 	};
 	[5] remoteExec ["civinfo_notifications"];
-	if (KP_liberation_civinfo_debug > 0) then {private _text = "[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> Task ended with success";_text remoteExec ["diag_log",2];};
+	if (KP_liberation_civinfo_debug > 0) then {private _text = text "[KP LIBERATION] [CIVINFO] civinfo_task.sqf -> Task ended with success";_text remoteExec ["diag_log",2];};
 };

--- a/Missionframework/scripts/server/civrep/fnc/f_kp_cr_changeCR.sqf
+++ b/Missionframework/scripts/server/civrep/fnc/f_kp_cr_changeCR.sqf
@@ -1,6 +1,6 @@
 params ["_amount", ["_negative", false]];
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] changeCR called on: %1 - Parameters [%2, %3]", debug_source, _amount, _negative];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] changeCR called on: %1 - Parameters [%2, %3]", debug_source, _amount, _negative];_text remoteExec ["diag_log",2];};
 
 if (_negative) then {
 	KP_liberation_civ_rep = KP_liberation_civ_rep - _amount;
@@ -19,5 +19,5 @@ GRLIB_side_enemy setFriend [GRLIB_side_resistance, _resistanceEnemy];
 GRLIB_side_resistance setFriend [GRLIB_side_friendly, _resistanceFriendly];
 GRLIB_side_friendly setFriend [GRLIB_side_resistance, _resistanceFriendly];
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] changeCR finished on: %1 - New value: %2", debug_source, KP_liberation_civ_rep];_text remoteExec ["diag_log",2];};
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] %1 getFriend %2: %3 - %1 getFriend %4: %5", GRLIB_side_resistance, GRLIB_side_enemy, (GRLIB_side_resistance getFriend GRLIB_side_enemy), GRLIB_side_friendly, (GRLIB_side_resistance getFriend GRLIB_side_friendly)];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] changeCR finished on: %1 - New value: %2", debug_source, KP_liberation_civ_rep];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] %1 getFriend %2: %3 - %1 getFriend %4: %5", GRLIB_side_resistance, GRLIB_side_enemy, (GRLIB_side_resistance getFriend GRLIB_side_enemy), GRLIB_side_friendly, (GRLIB_side_resistance getFriend GRLIB_side_friendly)];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/server/civrep/fnc/f_kp_cr_getBuildings.sqf
+++ b/Missionframework/scripts/server/civrep/fnc/f_kp_cr_getBuildings.sqf
@@ -1,6 +1,6 @@
 params ["_sector"];
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] getBuildings called on: %1 - Sector: %2", debug_source, markerText _sector];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] getBuildings called on: %1 - Sector: %2", debug_source, markerText _sector];_text remoteExec ["diag_log",2];};
 
 private _return = 0;
 
@@ -10,6 +10,6 @@ if (KP_liberation_cr_param_buildings) then {
 	_return = count (nearestObjects [markerPos _sector, ["House"], 1.5 * GRLIB_capture_size] select {(alive _x) && !((typeOf _x) in KP_liberation_cr_ign_buildings)});
 };
 
-if (KP_liberation_civrep_debug > 0) then {private _text = format ["[KP LIBERATION] [CIVREP] getBuildings finished on: %1 - Return: %2", debug_source, _return];_text remoteExec ["diag_log",2];};
+if (KP_liberation_civrep_debug > 0) then {private _text = text format ["[KP LIBERATION] [CIVREP] getBuildings finished on: %1 - Return: %2", debug_source, _return];_text remoteExec ["diag_log",2];};
 
 _return

--- a/Missionframework/scripts/server/civrep/fnc/f_kp_cr_liberatedSector.sqf
+++ b/Missionframework/scripts/server/civrep/fnc/f_kp_cr_liberatedSector.sqf
@@ -1,7 +1,7 @@
 params ["_sector"];
 
 if (_sector in sectors_bigtown || _sector in sectors_capture) then {
-	if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] liberatedSector called at: %1 - Sector: %2", time, markerText _sector];};
+	if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] liberatedSector called at: %1 - Sector: %2", time, markerText _sector];};
 
 	private _penalty = 0;
 
@@ -23,5 +23,5 @@ if (_sector in sectors_bigtown || _sector in sectors_capture) then {
 		[(KP_liberation_cr_sector_gain - _penalty), false] spawn F_cr_changeCR;
 	};
 
-	if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] liberatedSector finished at: %1 - Penalty: %2", time, _penalty];};
+	if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] liberatedSector finished at: %1 - Penalty: %2", time, _penalty];};
 };

--- a/Missionframework/scripts/server/civrep/init_buildings.sqf
+++ b/Missionframework/scripts/server/civrep/init_buildings.sqf
@@ -1,4 +1,4 @@
-if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] init_buildings.sqf initialising on: %1", debug_source];};
+if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] init_buildings.sqf initialising on: %1", debug_source];};
 
 switch (worldName) do {
     case "Chernarus": {call compile preprocessFileLineNumbers "scripts\server\civrep\ignored\chernarus.sqf"};
@@ -32,8 +32,8 @@ KP_liberation_cr_sectorbuildings = [];
 sleep 1;
 
 if (KP_liberation_civrep_debug > 0) then {
-    diag_log format ["[KP LIBERATION] [CIVREP] init_buildings.sqf finished on: %1 - Listing sectors with buildings amount...", debug_source];
+    diag_log text format ["[KP LIBERATION] [CIVREP] init_buildings.sqf finished on: %1 - Listing sectors with buildings amount...", debug_source];
     {
-        diag_log format ["[KP LIBERATION] [CIVREP] %1: %2", markerText (_x select 0), (_x select 1)];
+        diag_log text format ["[KP LIBERATION] [CIVREP] %1: %2", markerText (_x select 0), (_x select 1)];
     } forEach KP_liberation_cr_sectorbuildings;
 };

--- a/Missionframework/scripts/server/civrep/init_module.sqf
+++ b/Missionframework/scripts/server/civrep/init_module.sqf
@@ -1,4 +1,4 @@
-if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] Module initialising on: %1", debug_source];};
+if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] Module initialising on: %1", debug_source];};
 
 // Functions
 // Get buildings count for sector
@@ -17,4 +17,4 @@ civrep_wounded_civs = compileFinal preprocessFileLineNumbers "scripts\server\civ
 execVM "scripts\server\civrep\init_buildings.sqf";
 
 
-if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] Module initialised on: %1", debug_source];};
+if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] Module initialised on: %1", debug_source];};

--- a/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
+++ b/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
@@ -2,7 +2,7 @@ params ["_sector"];
 
 if (!(_sector in sectors_bigtown) && !(_sector in sectors_capture)) exitWith {};
 
-if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] civrep_wounded_civs.sqf -> Spawned for %1 on: %2 - Time: %3", markerText _sector, debug_source, time];};
+if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] civrep_wounded_civs.sqf -> Spawned for %1 on: %2 - Time: %3", markerText _sector, debug_source, time];};
 
 private _count = 2 + (ceil (random 2));
 private _grp = creategroup [GRLIB_side_civilian, true];
@@ -30,7 +30,7 @@ for "_i" from 1 to _count do {
 	_markers pushBack _marker;
 };
 
-if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] civrep_wounded_civs.sqf -> Spawned %1 wounded civilians at %2 - Time: %3", _count, markerText _sector, time];};
+if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] civrep_wounded_civs.sqf -> Spawned %1 wounded civilians at %2 - Time: %3", _count, markerText _sector, time];};
 
 private _units_near = [markerPos _sector, 300, GRLIB_side_friendly] call KPLIB_fnc_getUnitsCount;
 private _healed_civs = [];
@@ -63,4 +63,4 @@ sleep 60;
 	deleteMarker _x;
 } forEach _markers;
 
-if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] civrep_wounded_civs.sqf -> dropped at %1 - Time: %3", markerText _sector, time];};
+if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] civrep_wounded_civs.sqf -> dropped at %1 - Time: %3", markerText _sector, time];};

--- a/Missionframework/scripts/server/game/manage_weather.sqf
+++ b/Missionframework/scripts/server/game/manage_weather.sqf
@@ -8,11 +8,11 @@ private _newWeather = selectRandom _weathers;
 0 setOvercast _newWeather;
 forceWeatherChange;
 
-diag_log format ["[KP LIBERATION] [WEATHER] Set initial weather to: %1 - Param Value: %2 - Time: %3", _newWeather, GRLIB_weather_param, diag_tickTime];
+diag_log text format ["[KP LIBERATION] [WEATHER] Set initial weather to: %1 - Param Value: %2 - Time: %3", _newWeather, GRLIB_weather_param, diag_tickTime];
 
 while {GRLIB_endgame == 0} do {
     _newWeather = selectRandom _weathers;
     (3600 * timeMultiplier) setOvercast _newWeather;
-    diag_log format ["[KP LIBERATION] [WEATHER] Set next weather transition to: %1 - Time: %2", _newWeather, diag_tickTime];
+    diag_log text format ["[KP LIBERATION] [WEATHER] Set next weather transition to: %1 - Time: %2", _newWeather, diag_tickTime];
     sleep 3000; // Slighty less than weather transition time, as sleep duration is depending on FPS
 };

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -1,12 +1,12 @@
-diag_log format ["[KP LIBERATION] [SAVE] ----- save_manager.sqf started - time: %1", diag_tickTime];
+diag_log text format ["[KP LIBERATION] [SAVE] ----- save_manager.sqf started - time: %1", diag_tickTime];
 
 // Handle possible enabled "wipe save" mission parameters
 if (GRLIB_param_wipe_savegame_1 == 1 && GRLIB_param_wipe_savegame_2 == 1) then {
     profileNamespace setVariable [GRLIB_save_key,nil];
     saveProfileNamespace;
-    diag_log "[KP LIBERATION] [SAVE] Save wiped via mission parameters";
+    diag_log text "[KP LIBERATION] [SAVE] Save wiped via mission parameters";
 } else {
-    diag_log "[KP LIBERATION] [SAVE] No save wipe";
+    diag_log text "[KP LIBERATION] [SAVE] No save wipe";
 };
 
 /*
@@ -150,7 +150,7 @@ greuh_liberation_savegame = profileNamespace getVariable GRLIB_save_key;
 // Load save data, when retrieved
 if (!isNil "greuh_liberation_savegame") then {
     if (((greuh_liberation_savegame select 0) select 0) isEqualType 0) then {
-        diag_log format ["[KP LIBERATION] [SAVE] Save data from version: %1", (greuh_liberation_savegame select 0) joinstring "."];
+        diag_log text format ["[KP LIBERATION] [SAVE] Save data from version: %1", (greuh_liberation_savegame select 0) joinstring "."];
 
         _dateTime                                   = greuh_liberation_savegame select  1;
         _objectsToSave                              = greuh_liberation_savegame select  2;
@@ -216,7 +216,7 @@ if (!isNil "greuh_liberation_savegame") then {
             --- Compatibility for older save data ---
             This will be removed if we reach a 0.96.7 due to more released Arma 3 DLCs until we finish 0.97.0
         */
-        diag_log "[KP LIBERATION] [SAVE] Save data from version: pre 0.96.5";
+        diag_log text "[KP LIBERATION] [SAVE] Save data from version: pre 0.96.5";
 
         blufor_sectors                              = greuh_liberation_savegame select  0;
         GRLIB_all_fobs                              = greuh_liberation_savegame select  1;
@@ -278,7 +278,7 @@ if (!isNil "greuh_liberation_savegame") then {
     GRLIB_side_resistance setFriend [GRLIB_side_friendly, _resistanceFriendly];
     GRLIB_side_friendly setFriend [GRLIB_side_resistance, _resistanceFriendly];
 
-    if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] %1 getFriend %2: %3 - %1 getFriend %4: %5", GRLIB_side_resistance, GRLIB_side_enemy, (GRLIB_side_resistance getFriend GRLIB_side_enemy), GRLIB_side_friendly, (GRLIB_side_resistance getFriend GRLIB_side_friendly)];};
+    if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] %1 getFriend %2: %3 - %1 getFriend %4: %5", GRLIB_side_resistance, GRLIB_side_enemy, (GRLIB_side_resistance getFriend GRLIB_side_enemy), GRLIB_side_friendly, (GRLIB_side_resistance getFriend GRLIB_side_friendly)];};
 
     // Apply current date and time
     if (_dateTime isEqualType []) then {
@@ -368,7 +368,7 @@ if (!isNil "greuh_liberation_savegame") then {
         _x allowdamage true;
     } forEach _spawnedObjects;
 
-    if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved buildings placed";};
+    if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [SAVE] Saved buildings placed";};
 
     {
         _x params ["_minePos", "_dirAndUp", "_class", "_known"];
@@ -384,7 +384,7 @@ if (!isNil "greuh_liberation_savegame") then {
 
     } forEach _allMines;
 
-    if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved mines placed";};
+    if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [SAVE] Saved mines placed";};
 
     // Spawn saved resource storages and their content
     {
@@ -415,7 +415,7 @@ if (!isNil "greuh_liberation_savegame") then {
         };
     } forEach _resourceStorages;
 
-    if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved storages placed"};
+    if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [SAVE] Saved storages placed"};
 
     // Spawn saved sector storages and their content
     {
@@ -448,7 +448,7 @@ if (!isNil "greuh_liberation_savegame") then {
         };
     } forEach KP_liberation_production;
 
-    if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved sector storages placed";};
+    if (KP_liberation_savegame_debug > 0) then {diag_log text "[KP LIBERATION] [SAVE] Saved sector storages placed";};
 
     // Spawn BLUFOR AI groups
     // This will be removed if we reach a 0.96.7 due to more released Arma 3 DLCs until we finish 0.97.0
@@ -476,9 +476,9 @@ if (!isNil "greuh_liberation_savegame") then {
             } forEach _savedGroup;
         } forEach _aiGroups;
     };
-    diag_log "[KP LIBERATION] [SAVE] Save loading finished";
+    diag_log text "[KP LIBERATION] [SAVE] Save loading finished";
 } else {
-    diag_log "[KP LIBERATION] [SAVE] Save nil";
+    diag_log text "[KP LIBERATION] [SAVE] Save nil";
 };
 
 publicVariable "stats_civilian_vehicles_seized";
@@ -496,7 +496,7 @@ GRLIB_vehicle_to_military_base_links = GRLIB_vehicle_to_military_base_links sele
 // Check for additions in the locked vehicles array
 private _lockedVehCount = count GRLIB_vehicle_to_military_base_links;
 if ((_lockedVehCount < (count sectors_military)) && (_lockedVehCount < (count elite_vehicles))) then {
-    diag_log "[KP LIBERATION] [SAVE] Additional military sectors or unlockable vehicles detected and assigned";
+    diag_log text "[KP LIBERATION] [SAVE] Additional military sectors or unlockable vehicles detected and assigned";
     private _assignedVehicles = [];
     private _assignedBases = [];
     private _nextVehicle = "";
@@ -522,7 +522,7 @@ publicVariable "GRLIB_permissions";
 publicVariable "KP_liberation_cr_vehicles";
 save_is_loaded = true; publicVariable "save_is_loaded";
 
-diag_log format ["[KP LIBERATION] [SAVE] ----- save_manager.sqf done - time: %1", diag_tickTime];
+diag_log text format ["[KP LIBERATION] [SAVE] ----- save_manager.sqf done - time: %1", diag_tickTime];
 
 // Start the save loop
 while {true} do {
@@ -531,7 +531,7 @@ while {true} do {
         doSaveTrigger || GRLIB_endgame == 1;
     };
 
-    if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [SAVE] Save interval started - time: %1", time];};
+    if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [SAVE] Save interval started - time: %1", time];};
 
     // Exit the while and wipe save, if campaign ended
     if (GRLIB_endgame == 1) exitWith {
@@ -632,7 +632,7 @@ while {true} do {
                 case KP_liberation_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KP_liberation_crate_value",0]);};
                 case KP_liberation_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KP_liberation_crate_value",0]);};
                 case KP_liberation_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KP_liberation_crate_value",0]);};
-                default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+                default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
             };
         } forEach (attachedObjects _x);
 
@@ -718,9 +718,9 @@ while {true} do {
     profileNamespace setVariable [GRLIB_save_key, greuh_liberation_savegame];
     saveProfileNamespace;
 
-    if (KP_liberation_savegame_debug > 0) then {diag_log format ["[KP LIBERATION] [SAVE] Save interval finished - time: %1", time];};
+    if (KP_liberation_savegame_debug > 0) then {diag_log text format ["[KP LIBERATION] [SAVE] Save interval finished - time: %1", time];};
 };
 
-diag_log "[KP LIBERATION] [SAVE] Left saving loop in save_manager.sqf";
+diag_log text "[KP LIBERATION] [SAVE] Left saving loop in save_manager.sqf";
 
 true

--- a/Missionframework/scripts/server/game/server_restart.sqf
+++ b/Missionframework/scripts/server/game/server_restart.sqf
@@ -2,7 +2,7 @@ if (!isDedicated) exitWith {};
 
 _serverDuration = (KP_liberation_restart * 60 * 60);
 
-diag_log format ["[KP LIBERATION] [RESTART] Restart Timer Set To %1", _serverDuration];
+diag_log text format ["[KP LIBERATION] [RESTART] Restart Timer Set To %1", _serverDuration];
 
 private _30minspassed = false;
 private _15minspassed = false;
@@ -22,7 +22,7 @@ while{true} do
 		case ((_timeUntilRestart < (1 * 60)) && !_60secondspassed) :
 		{
 			["lib_restart_60_s"] remoteExecCall ["BIS_fnc_showNotification"];
-			diag_log "[KP LIBERATION] [RESTART] 60 seconds until server restart.";
+			diag_log text "[KP LIBERATION] [RESTART] 60 seconds until server restart.";
 			_60secondspassed = true;
 			_5minspassed = true;
 			_15minspassed = true;
@@ -31,7 +31,7 @@ while{true} do
 		case ((_timeUntilRestart < (5 * 60)) && !_5minspassed) :
 		{
 			["lib_restart_5_min"] remoteExecCall ["BIS_fnc_showNotification"];
-			diag_log "[KP LIBERATION] [RESTART] 5 minutes until server restart.";
+			diag_log text "[KP LIBERATION] [RESTART] 5 minutes until server restart.";
 			_5minspassed = true;
 			_15minspassed = true;
 			_30minspassed = true;
@@ -39,21 +39,21 @@ while{true} do
 		case ((_timeUntilRestart < (15 * 60)) && !_15minspassed) :
 		{
 			["lib_restart_15_min"] remoteExecCall ["BIS_fnc_showNotification"];
-			diag_log "[KP LIBERATION] [RESTART] 15 minutes until server restart.";
+			diag_log text "[KP LIBERATION] [RESTART] 15 minutes until server restart.";
 			_15minspassed = true;
 			_30minspassed = true;
 		};
 		case ((_timeUntilRestart < (30 * 60)) && !_30minspassed) :
 		{
 			["lib_restart_30_min"] remoteExecCall ["BIS_fnc_showNotification"];
-			diag_log "[KP LIBERATION] [RESTART] 30 minutes until server restart.";
+			diag_log text "[KP LIBERATION] [RESTART] 30 minutes until server restart.";
 			_30minspassed = true;
 		};
 	};
 
 	if(_timeSinceStart > _serverDuration) then
 	{
-		diag_log "[KP LIBERATION] [RESTART] Restart timeout elapsed, attempting server shutdown.";
+		diag_log text "[KP LIBERATION] [RESTART] Restart timeout elapsed, attempting server shutdown.";
 		sleep 5;
 
 		private _myPass = call compile preprocessFileLineNumbers "\userconfig\restart\myPass.hpp";
@@ -61,11 +61,11 @@ while{true} do
 
 		if(_shutdownSuccess) then
 		{
-			diag_log "[KP LIBERATION] [RESTART] Shutting down server!";
+			diag_log text "[KP LIBERATION] [RESTART] Shutting down server!";
 		}
 		else
 		{
-			diag_log "[KP LIBERATION] [RESTART] Shutdown failed!";
+			diag_log text "[KP LIBERATION] [RESTART] Shutdown failed!";
 		};
 	};
 	sleep 15;

--- a/Missionframework/scripts/server/offloading/group_diag.sqf
+++ b/Missionframework/scripts/server/offloading/group_diag.sqf
@@ -3,8 +3,8 @@ waitUntil {sleep 1; !isNil "active_sectors"};
 while {true} do {
     uiSleep 600;
 
-    diag_log format ["[KP LIBERATION] [GROUPCHECK] ----- Groupcheck for %1 groups started at %2 -----", count allGroups, time];
-    diag_log "[KP LIBERATION] [GROUPCHECK] Groups which aren't marked for deletion when empty:";
+    diag_log text format ["[KP LIBERATION] [GROUPCHECK] ----- Groupcheck for %1 groups started at %2 -----", count allGroups, time];
+    diag_log text "[KP LIBERATION] [GROUPCHECK] Groups which aren't marked for deletion when empty:";
 
     private _markedgroups = 0;
 
@@ -25,7 +25,7 @@ while {true} do {
                 };
                 _markedgroups = _markedgroups + 1;
 
-                diag_log format [
+                diag_log text format [
                     "[KP LIBERATION] [GROUPCHECK] %1 - Owner: %2 - Units: %3 - Marked now: %4 - Side: %5",
                     groupId _x,
                     _owner,
@@ -38,8 +38,8 @@ while {true} do {
     } forEach allGroups;
 
     if (_markedgroups == 0) then {
-        diag_log "[KP LIBERATION] [GROUPCHECK] No groups found.";
+        diag_log text "[KP LIBERATION] [GROUPCHECK] No groups found.";
     };
 
-    diag_log format ["[KP LIBERATION] [GROUPCHECK] ----- Groupcheck finished at %1 - Groups marked: %2 -----", time, _markedgroups];
+    diag_log text format ["[KP LIBERATION] [GROUPCHECK] ----- Groupcheck finished at %1 - Groups marked: %2 -----", time, _markedgroups];
 };

--- a/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
@@ -64,7 +64,7 @@ if ((_price_s > _supplies) || (_price_a > _ammo) || (_price_f > _fuel)) exitWith
 					};
 				};
 			};
-			default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+			default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
 		};
 	} forEach _storedCrates;
 

--- a/Missionframework/scripts/server/remotecall/build_fac_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/build_fac_remote_call.sqf
@@ -72,7 +72,7 @@ switch (_fac) do {
                             };
                         };
                     };
-                    default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+                    default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
                 };
             } forEach _storedCrates;
 

--- a/Missionframework/scripts/server/remotecall/build_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/build_remote_call.sqf
@@ -56,7 +56,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                         };
                     };
                 };
-                default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+                default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
             };
         } forEach _storedCrates;
 

--- a/Missionframework/scripts/server/remotecall/start_secondary_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/start_secondary_remote_call.sqf
@@ -7,7 +7,7 @@ params [
 if (_mission_index < 0) exitWith {false};
 
 if (isNil "GRLIB_secondary_starting") then { GRLIB_secondary_starting = false;};
-if (GRLIB_secondary_starting) exitWith {diag_log "[KP LIBERATION] [ERROR] Multiple calls to start secondary mission : shouldn't be possible, isn't allowed";};
+if (GRLIB_secondary_starting) exitWith {diag_log text "[KP LIBERATION] [ERROR] Multiple calls to start secondary mission : shouldn't be possible, isn't allowed";};
 if (isNil "used_positions") then {used_positions = [];};
 
 GRLIB_secondary_starting = true; publicVariable "GRLIB_secondary_starting";

--- a/Missionframework/scripts/server/resources/manage_logistics.sqf
+++ b/Missionframework/scripts/server/resources/manage_logistics.sqf
@@ -2,7 +2,7 @@ waitUntil {!isNil "save_is_loaded"};
 waitUntil {!isNil "KP_liberation_logistics"};
 waitUntil {save_is_loaded};
 
-if (KP_liberation_logistic_debug > 0) then {diag_log "[KP LIBERATION] [LOGISTIC] Logistic management started";};
+if (KP_liberation_logistic_debug > 0) then {diag_log text "[KP LIBERATION] [LOGISTIC] Logistic management started";};
 
 KP_liberation_convoy_ambush_inProgress = false;
 KP_liberation_convoy_ambush_check = 0;
@@ -10,7 +10,7 @@ KP_liberation_convoy_ambush_check = 0;
 while {GRLIB_endgame == 0} do {
 
 	if (((count (allPlayers - entities "HeadlessClient_F")) > 0) && ((count KP_liberation_logistics) > 0)) then {
-		if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic interval started: %1", time];};
+		if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic interval started: %1", time];};
 
 		private _tempLogistics = +KP_liberation_logistics;
 
@@ -110,7 +110,7 @@ while {GRLIB_endgame == 0} do {
 								} forEach _storage_areas;
 							};
 							please_recalculate = true;
-							if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+							if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 						} else {
 							_x set [9,1];
 						};
@@ -129,7 +129,7 @@ while {GRLIB_endgame == 0} do {
 										case KP_liberation_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KP_liberation_crate_value",0]);};
 										case KP_liberation_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KP_liberation_crate_value",0]);};
 										case KP_liberation_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KP_liberation_crate_value",0]);};
-										default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+										default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
 									};
 								} forEach (attachedObjects _x);
 							} forEach _storage_areas;
@@ -247,7 +247,7 @@ while {GRLIB_endgame == 0} do {
 												};
 											};
 										};
-										default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+										default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
 									};
 								} forEach _storedCrates;
 
@@ -266,7 +266,7 @@ while {GRLIB_endgame == 0} do {
 
 							} forEach _storage_areas;
 
-							if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+							if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 						};
 					} else {
 						private _nextState = 0;
@@ -283,7 +283,7 @@ while {GRLIB_endgame == 0} do {
 						_x set [8,_time];
 						_x set [9,0];
 
-						if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+						if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 					};
 				};
 				case 2;
@@ -293,7 +293,7 @@ while {GRLIB_endgame == 0} do {
 						if (((_x select 8) <= ((ceil (((_x select 2) distance2D (_x select 3)) / 400)) - 3)) && ((_x select 8) >= 3) && !((_x select 6) isEqualTo [0,0,0]) && !KP_liberation_convoy_ambush_inProgress && (KP_liberation_civ_rep <= -25) && (((_x select 8) % 2) == 0)) then {
 							private _dice = round (random 100);
 							private _chance = KP_liberation_convoy_ambush_chance + ([] call KPLIB_fnc_crGetMulti);
-							if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1: ambush possible - current ETA: %2 - Dice: %3 - Chance: %4", (_x select 0), (_x select 8), _dice, _chance];_text remoteExec ["diag_log",2];};
+							if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] Logistic convoy %1: ambush possible - current ETA: %2 - Dice: %3 - Chance: %4", (_x select 0), (_x select 8), _dice, _chance];_text remoteExec ["diag_log",2];};
 							if (_dice <= _chance) then {
 								private _convoy = +_x;
 								sleep 0.1;
@@ -319,7 +319,7 @@ while {GRLIB_endgame == 0} do {
 							_x set [8,((_x select 8) - 1)];
 						};
 
-						if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+						if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 
 					} else {
 						private _nextState = -1;
@@ -342,7 +342,7 @@ while {GRLIB_endgame == 0} do {
 						_x set [7,_nextState];
 						_x set [8,_time];
 
-						if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+						if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 					};
 				};
 				case 5;
@@ -435,7 +435,7 @@ while {GRLIB_endgame == 0} do {
 						};
 						please_recalculate = true;
 
-						if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+						if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 					} else {
 						_x set [2,[0,0,0]];
 						_x set [3,[0,0,0]];
@@ -445,7 +445,7 @@ while {GRLIB_endgame == 0} do {
 						_x set [7,0];
 						_x set [8,-1];
 
-						if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
+						if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic Group Update: %1", _x];};
 					};
 				};
 				default {};
@@ -454,7 +454,7 @@ while {GRLIB_endgame == 0} do {
 
 		KP_liberation_logistics = +_tempLogistics;
 
-		if (KP_liberation_logistic_debug > 0) then {diag_log format ["[KP LIBERATION] [LOGISTIC] Logistic interval finished: %1", time];};
+		if (KP_liberation_logistic_debug > 0) then {diag_log text format ["[KP LIBERATION] [LOGISTIC] Logistic interval finished: %1", time];};
 	};
 	uiSleep 60;
 };

--- a/Missionframework/scripts/server/resources/manage_resources.sqf
+++ b/Missionframework/scripts/server/resources/manage_resources.sqf
@@ -5,7 +5,7 @@ waitUntil {save_is_loaded};
 sectors_recalculating = false;
 sectors_timer = false;
 
-if (KP_liberation_production_debug > 0) then {diag_log "[KP LIBERATION] [PRODUCTION] Production management started";};
+if (KP_liberation_production_debug > 0) then {diag_log text "[KP LIBERATION] [PRODUCTION] Production management started";};
 
 while {GRLIB_endgame == 0} do {
 
@@ -18,7 +18,7 @@ while {GRLIB_endgame == 0} do {
 		private _time_update = false;
 		if (sectors_timer) then {_time_update = true; sectors_timer = false;};
 
-		if (KP_liberation_production_debug > 0) then {diag_log format ["[KP LIBERATION] [PRODUCTION] Production interval started: %1 - _time_update: %2", time, _time_update];};
+		if (KP_liberation_production_debug > 0) then {diag_log text format ["[KP LIBERATION] [PRODUCTION] Production interval started: %1 - _time_update: %2", time, _time_update];};
 
 		private _tempProduction = [];
 		{
@@ -60,7 +60,7 @@ while {GRLIB_endgame == 0} do {
 						case KP_liberation_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KP_liberation_crate_value",0]);};
 						case KP_liberation_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KP_liberation_crate_value",0]);};
 						case KP_liberation_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KP_liberation_crate_value",0]);};
-						default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+						default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
 					};
 				} forEach (attachedObjects _storage);
 			};
@@ -79,7 +79,7 @@ while {GRLIB_endgame == 0} do {
 				_ammoValue,
 				_fuelValue
 			];
-			if (KP_liberation_production_debug > 0) then {diag_log format ["[KP LIBERATION] [PRODUCTION] Production Update: %1", _tempProduction select _forEachIndex];};
+			if (KP_liberation_production_debug > 0) then {diag_log text format ["[KP LIBERATION] [PRODUCTION] Production Update: %1", _tempProduction select _forEachIndex];};
 		} forEach KP_liberation_production;
 
 		_tempProduction sort true;
@@ -87,6 +87,6 @@ while {GRLIB_endgame == 0} do {
 		KP_liberation_production = +_tempProduction;
 		sectors_recalculating = false;
 	};
-	if (KP_liberation_production_debug > 0) then {diag_log format ["[KP LIBERATION] [PRODUCTION] Production interval finished: %1", time];};
+	if (KP_liberation_production_debug > 0) then {diag_log text format ["[KP LIBERATION] [PRODUCTION] Production interval finished: %1", time];};
 	waitUntil {sleep 1; recalculate_sectors};
 };

--- a/Missionframework/scripts/server/resources/recalculate_resources.sqf
+++ b/Missionframework/scripts/server/resources/recalculate_resources.sqf
@@ -45,7 +45,7 @@ while {true} do {
 					case KP_liberation_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KP_liberation_crate_value",0]);};
 					case KP_liberation_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KP_liberation_crate_value",0]);};
 					case KP_liberation_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KP_liberation_crate_value",0]);};
-					default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
+					default {diag_log text format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
 				};
 			} forEach (attachedObjects _x);
 		} forEach _storage_areas;

--- a/Missionframework/scripts/server/secondary/convoy_hijack.sqf
+++ b/Missionframework/scripts/server/secondary/convoy_hijack.sqf
@@ -5,7 +5,7 @@ while { count _convoy_destinations_markers < 3 } do { _convoy_destinations_marke
 
 private _couldnt_spawn = false;
 { if ( _x == "" ) exitWith { _couldnt_spawn = true; }; } foreach _convoy_destinations_markers;
-if ( _couldnt_spawn ) exitWith { diag_log "[KP LIBERATION] [ERROR] Could not find enough map positions for convoy hijack mission"; };
+if ( _couldnt_spawn ) exitWith { diag_log text "[KP LIBERATION] [ERROR] Could not find enough map positions for convoy hijack mission"; };
 
 private _convoy_destinations = [];
 { _convoy_destinations pushback (markerPos _x); } foreach _convoy_destinations_markers;
@@ -22,7 +22,7 @@ private _boxes_amount = 0;
 	if ( _x select 0 == opfor_ammobox_transport ) exitWith { _boxes_amount = (count _x) - 2 };
 } foreach box_transport_config;
 
-if ( _boxes_amount == 0 ) exitWith { diag_log "[KP LIBERATION] [ERROR] Opfor ammobox truck classname doesn't allow for ammobox transport, correct your classnames.sqf"; };
+if ( _boxes_amount == 0 ) exitWith { diag_log text "[KP LIBERATION] [ERROR] Opfor ammobox truck classname doesn't allow for ammobox transport, correct your classnames.sqf"; };
 
 GRLIB_secondary_in_progress = 1; publicVariable "GRLIB_secondary_in_progress";
 

--- a/Missionframework/scripts/server/secondary/fob_hunting.sqf
+++ b/Missionframework/scripts/server/secondary/fob_hunting.sqf
@@ -2,7 +2,7 @@
 _defenders_amount = (15 * (sqrt (GRLIB_unitcap))) min 15;
 
 _spawn_marker = [2000,999999,false] call KPLIB_fnc_getOpforSpawnPoint;
-if (_spawn_marker == "") exitWith {diag_log "[KP LIBERATION] [ERROR] Could not find position for fob hunting mission";};
+if (_spawn_marker == "") exitWith {diag_log text "[KP LIBERATION] [ERROR] Could not find position for fob hunting mission";};
 
 used_positions pushBack _spawn_marker;
 _base_position = markerpos _spawn_marker;

--- a/Missionframework/scripts/server/secondary/search_and_rescue.sqf
+++ b/Missionframework/scripts/server/secondary/search_and_rescue.sqf
@@ -1,6 +1,6 @@
 
 private _spawn_marker = [ 2000, 999999, false ] call KPLIB_fnc_getOpforSpawnPoint;
-if ( _spawn_marker == "" ) exitWith { diag_log "[KP LIBERATION] [ERROR] Could not find position for search and rescue mission"; };
+if ( _spawn_marker == "" ) exitWith { diag_log text "[KP LIBERATION] [ERROR] Could not find position for search and rescue mission"; };
 used_positions pushbackUnique _spawn_marker;
 
 private _helopos = (markerPos _spawn_marker) getPos [random 200, random 360];

--- a/Missionframework/scripts/server/sector/ied_manager.sqf
+++ b/Missionframework/scripts/server/sector/ied_manager.sqf
@@ -2,7 +2,7 @@ params ["_sector", "_radius", "_number"];
 
 if (_number <= 0) exitWith {};
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf for %1 spawned on: %2", markerText _sector, debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf for %1 spawned on: %2", markerText _sector, debug_source];_text remoteExec ["diag_log",2];};
 
 _number = round _number;
 
@@ -22,7 +22,7 @@ private _roadobj = [(markerPos _sector) getPos [random _radius, random 360], _ra
 private _goes_boom = false;
 private _ied_marker = "";
 
-if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> spawning IED %1 at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
+if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> spawning IED %1 at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
 
 if (_number > 0) then {
 	[_sector, _radius, _number - 1] spawn ied_manager;
@@ -34,7 +34,7 @@ if (!(isnull _roadobj)) then {
 	_ied_obj = createMine [_ied_type, _roadpos getPos [_spread, random 360], [], 0];
 	_ied_obj setdir (random 360);
 
-	if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> IED %1 spawned at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> IED %1 spawned at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
 
 	while {_sector in active_sectors && mineActive _ied_obj && !_goes_boom} do {
 		_nearinfantry = ((getpos _ied_obj) nearEntities ["Man", _activation_radius_infantry]) select {side _x == GRLIB_side_friendly};
@@ -52,10 +52,10 @@ if (!(isnull _roadobj)) then {
 		sleep 1;
 	};
 } else {
-	if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> _roadobj is Null for IED %1 at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> _roadobj is Null for IED %1 at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
 };
 
-if ((KP_liberation_asymmetric_debug > 0) && !(isNull _roadobj)) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> exited IED %1 loop at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
+if ((KP_liberation_asymmetric_debug > 0) && !(isNull _roadobj)) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] ied_manager.sqf -> exited IED %1 loop at %2", _number, markerText _sector];_text remoteExec ["diag_log",2];};
 
 sleep 1800;
 

--- a/Missionframework/scripts/server/sector/manage_one_sector.sqf
+++ b/Missionframework/scripts/server/sector/manage_one_sector.sqf
@@ -10,7 +10,7 @@ params ["_sector"];
 
 waitUntil {!isNil "combat_readiness"};
 
-if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector spawned on: %3 - time: %4", (markerText _sector), _sector, debug_source, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector spawned on: %3 - time: %4", (markerText _sector), _sector, debug_source, time];_text remoteExec ["diag_log",2];};
 
 private _sectorpos = markerPos _sector;
 private _stopit = false;
@@ -169,7 +169,7 @@ if ((!(_sector in blufor_sectors)) && (([markerPos _sector, [_opforcount] call K
 
 	_vehtospawn = _vehtospawn select {!(isNil "_x")};
 
-	if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector calculated -> _infsquad: %3 - _squad1: %4 - _squad2: %5 - _squad3: %6 - _squad4: %7 - _vehtospawn: %8 - _building_ai_max: %9", (markerText _sector), _sector, _infsquad, (count _squad1), (count _squad2), (count _squad3), (count _squad4), (count _vehtospawn), _building_ai_max];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector calculated -> _infsquad: %3 - _squad1: %4 - _squad2: %5 - _squad3: %6 - _squad4: %7 - _vehtospawn: %8 - _building_ai_max: %9", (markerText _sector), _sector, _infsquad, (count _squad1), (count _squad2), (count _squad3), (count _squad4), (count _vehtospawn), _building_ai_max];_text remoteExec ["diag_log",2];};
 
 	if (_building_ai_max > 0 && GRLIB_adaptive_opfor) then {
 		_building_ai_max = round (_building_ai_max * ([] call KPLIB_fnc_getOpforFactor));
@@ -189,7 +189,7 @@ if ((!(_sector in blufor_sectors)) && (([markerPos _sector, [_opforcount] call K
 		{
 			_buildingpositions = _buildingpositions + ([_x] call BIS_fnc_buildingPositions);
 		} forEach _allbuildings;
-		if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector found %3 building positions", (markerText _sector), _sector, (count _buildingpositions)];_text remoteExec ["diag_log",2];};
+		if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector found %3 building positions", (markerText _sector), _sector, (count _buildingpositions)];_text remoteExec ["diag_log",2];};
 		if (count _buildingpositions > _minimum_building_positions) then {
 			_managed_units = _managed_units + ([_infsquad, _building_ai_max, _buildingpositions, _sector] call KPLIB_fnc_spawnBuildingSquad);
 		};
@@ -225,7 +225,7 @@ if ((!(_sector in blufor_sectors)) && (([markerPos _sector, [_opforcount] call K
 		_managed_units = _managed_units + ([_sector] call KPLIB_fnc_spawnCivilians);
 	};
 
-	if (KP_liberation_asymmetric_debug > 0) then {private _text = format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 (%2) - Range: %3 - Count: %4", (markerText _sector), _sector, _building_range, _iedcount];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_asymmetric_debug > 0) then {private _text = text format ["[KP LIBERATION] [ASYMMETRIC] Sector %1 (%2) - Range: %3 - Count: %4", (markerText _sector), _sector, _building_range, _iedcount];_text remoteExec ["diag_log",2];};
 	[_sector, _building_range, _iedcount] spawn ied_manager;
 
 	if (_guerilla) then {
@@ -238,7 +238,7 @@ if ((!(_sector in blufor_sectors)) && (([markerPos _sector, [_opforcount] call K
 		[_sector] remoteExec ["reinforcements_remote_call",2];
 	};
 
-	if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - populating done at %3", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};
+	if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - populating done at %3", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};
 
 	private _activationTime = time;
 	// sector lifetime loop
@@ -304,4 +304,4 @@ if ((!(_sector in blufor_sectors)) && (([markerPos _sector, [_opforcount] call K
 	active_sectors = active_sectors - [_sector]; publicVariable "active_sectors";
 };
 
-if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector dropped on: %3", (markerText _sector), _sector, debug_source];_text remoteExec ["diag_log",2];};
+if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - manage_one_sector dropped on: %3", (markerText _sector), _sector, debug_source];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/server/sector/manage_sectors.sqf
+++ b/Missionframework/scripts/server/sector/manage_sectors.sqf
@@ -3,7 +3,7 @@ active_sectors = [];
 waitUntil {!isNil "blufor_sectors"};
 waitUntil {!isNil "sectors_allSectors"};
 
-if (KP_liberation_sectorspawn_debug > 0) then {diag_log format ["[KP LIBERATION] [SECTORSPAWN] Sector Manager started at %1", time];};
+if (KP_liberation_sectorspawn_debug > 0) then {diag_log text format ["[KP LIBERATION] [SECTORSPAWN] Sector Manager started at %1", time];};
 
 private _timer = 0;
 
@@ -43,7 +43,7 @@ while {GRLIB_endgame == 0} do {
 			{
 				_current_sectors pushBack (markerText _x);
 			} forEach active_sectors;
-			diag_log format ["[KP LIBERATION] [SECTORSPAWN] Overview at %1 - active sectors: %2", time, _current_sectors];
+			diag_log text format ["[KP LIBERATION] [SECTORSPAWN] Overview at %1 - active sectors: %2", time, _current_sectors];
 		};
 	};
 	sleep 1;

--- a/Missionframework/scripts/server/sector/wait_to_spawn_sector.sqf
+++ b/Missionframework/scripts/server/sector/wait_to_spawn_sector.sqf
@@ -1,6 +1,6 @@
 params ["_sector", "_opforcount"];
 
-if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - Time: %3 - waiting to spawn sector...", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - Time: %3 - waiting to spawn sector...", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};
 
 private _corrected_size = [_opforcount] call KPLIB_fnc_getSectorRange;
 sleep 0.1;
@@ -40,4 +40,4 @@ if (_unitscount == 1) then {
 	sleep 5;
 };
 
-if (KP_liberation_sectorspawn_debug > 0) then {private _text = format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - Time: %3 - waiting done", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};
+if (KP_liberation_sectorspawn_debug > 0) then {private _text = text format ["[KP LIBERATION] [SECTORSPAWN] Sector %1 (%2) - Time: %3 - waiting done", (markerText _sector), _sector, time];_text remoteExec ["diag_log",2];};

--- a/Missionframework/scripts/shared/defines.hpp
+++ b/Missionframework/scripts/shared/defines.hpp
@@ -1,9 +1,9 @@
 // Get parameter
 #define GET_PARAM(outVar, paramName, paramDefault)          outVar = [paramName,paramDefault] call KPLIB_fnc_getSaveableParam;\
                                                             publicVariable #outVar;\
-                                                            diag_log format ["[KP LIBERATION] [PARAM] %1: %2", paramName, outVar]
+                                                            diag_log text format ["[KP LIBERATION] [PARAM] %1: %2", paramName, outVar]
 
 // Get parameter and convert to bool
 #define GET_PARAM_BOOL(outVar, paramName, paramDefault)     outVar = ([paramName,paramDefault] call KPLIB_fnc_getSaveableParam) isEqualTo 1;\
                                                             publicVariable #outVar;\
-                                                            diag_log format ["[KP LIBERATION] [PARAM] %1: %2", paramName, outVar]
+                                                            diag_log text format ["[KP LIBERATION] [PARAM] %1: %2", paramName, outVar]

--- a/Missionframework/scripts/shared/diagnostics.sqf
+++ b/Missionframework/scripts/shared/diagnostics.sqf
@@ -23,7 +23,7 @@ while {true} do {
 	};
 
 	if (isServer) then {
-		diag_log format ["[KP LIBERATION] [STATS] Source: %1 - FPS: %2 - Local groups: %3 - Local units: %4 - Total units: %5 - Vehicles: %6 - Active Sectors: %7 - Active Scripts: %8",
+		diag_log text format ["[KP LIBERATION] [STATS] Source: %1 - FPS: %2 - Local groups: %3 - Local units: %4 - Total units: %5 - Vehicles: %6 - Active Sectors: %7 - Active Scripts: %8",
 		_source,
 		((round (diag_fps * 100.0)) / 100.0),
 		{local _x} count allGroups,
@@ -33,7 +33,7 @@ while {true} do {
 		count active_sectors,
 		diag_activeScripts];
 	} else {
-		private _text = format ["[KP LIBERATION] [STATS] Source: %1 - FPS: %2 - Local groups: %3 - Local units: %4 - Active Scripts: %5",
+		private _text = text format ["[KP LIBERATION] [STATS] Source: %1 - FPS: %2 - Local groups: %3 - Local units: %4 - Active Scripts: %5",
 		_source,
 		((round (diag_fps * 100.0)) / 100.0),
 		{local _x} count allGroups,

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -1,7 +1,7 @@
 #include "defines.hpp"
 
 // Check if ACE is running
-if (isClass (configfile >> "CfgPatches" >> "ace_common")) then {KP_liberation_ace = true; diag_log "[KP LIBERATION] ACE detected. Deactivating resupply script from Liberation."} else {KP_liberation_ace = false};
+if (isClass (configfile >> "CfgPatches" >> "ace_common")) then {KP_liberation_ace = true; diag_log text "[KP LIBERATION] ACE detected. Deactivating resupply script from Liberation."} else {KP_liberation_ace = false};
 
 /* Not saveable params */
 GRLIB_param_wipe_savegame_1 = ["WipeSave1",0] call bis_fnc_getParamValue;
@@ -19,25 +19,25 @@ KP_load_params = ["LoadSaveParams", 1] call BIS_fnc_getParamValue;
 
 if(isServer) then {
     /* Saveable params */
-    diag_log format ["[KP LIBERATION] [PARAM] ----- Server starts parameter initialization - time: %1", diag_ticktime];
+    diag_log text format ["[KP LIBERATION] [PARAM] ----- Server starts parameter initialization - time: %1", diag_ticktime];
     switch (KP_load_params) do {
         case 0: {
-            diag_log "[KP LIBERATION] [PARAM] Save/Load is set to SAVE";
+            diag_log text "[KP LIBERATION] [PARAM] Save/Load is set to SAVE";
         };
         case 1: {
-            diag_log "[KP LIBERATION] [PARAM] Save/Load is set to LOAD";
+            diag_log text "[KP LIBERATION] [PARAM] Save/Load is set to LOAD";
         };
         case 2: {
-            diag_log "[KP LIBERATION] [PARAM] Save/Load is set to USE SELECTED";
+            diag_log text "[KP LIBERATION] [PARAM] Save/Load is set to USE SELECTED";
         };
         default {
-            diag_log "[KP LIBERATION] [PARAM] Save/Load has no valid value";
+            diag_log text "[KP LIBERATION] [PARAM] Save/Load has no valid value";
         };
     };
-    diag_log "[KP LIBERATION] [PARAM]";
+    diag_log text "[KP LIBERATION] [PARAM]";
 
     // Mission Options
-    diag_log "[KP LIBERATION] [PARAM] --- Mission Options ---";
+    diag_log text "[KP LIBERATION] [PARAM] --- Mission Options ---";
     GET_PARAM(GRLIB_unitcap, "Unitcap", 2);
     GET_PARAM(GRLIB_difficulty_modifier, "Difficulty", 2);
     GET_PARAM(GRLIB_csat_aggressivity, "Aggressivity", 2);
@@ -56,15 +56,15 @@ if(isServer) then {
     GET_PARAM(GRLIB_resources_multiplier, "ResourcesMultiplier", 3);
     GET_PARAM_BOOL(KP_liberation_arsenal_type, "ArsenalType", 0);
     GET_PARAM(KP_liberation_victoryCondition, "VictoryCondition", 0);
-    diag_log "[KP LIBERATION] [PARAM]";
+    diag_log text "[KP LIBERATION] [PARAM]";
 
     // Deactivate BI Revive when ACE Medical is running
     if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then {
         bis_reviveParam_mode = 0; publicVariable "bis_reviveParam_mode";
-        diag_log "[KP LIBERATION] [PARAM] ACE Medical detected. Deactivating BI Revive System."
+        diag_log text "[KP LIBERATION] [PARAM] ACE Medical detected. Deactivating BI Revive System."
     } else {
         // Revive Options
-        diag_log "[KP LIBERATION] [PARAM] --- Revive Options ---";
+        diag_log text "[KP LIBERATION] [PARAM] --- Revive Options ---";
         GET_PARAM(bis_reviveParam_mode, "ReviveMode", 1);
         GET_PARAM(bis_reviveParam_duration, "ReviveDuration", 6);
         GET_PARAM(bis_reviveParam_requiredTrait, "ReviveRequiredTrait", 1);
@@ -74,10 +74,10 @@ if(isServer) then {
         GET_PARAM(bis_reviveParam_bleedOutDuration, "ReviveBleedOutDuration", 180);
         GET_PARAM(bis_reviveParam_forceRespawnDuration, "ReviveForceRespawnDuration", 10);
     };
-    diag_log "[KP LIBERATION] [PARAM]";
+    diag_log text "[KP LIBERATION] [PARAM]";
 
     // Gameplay Options
-    diag_log "[KP LIBERATION] [PARAM] --- Gameplay Options ---";
+    diag_log text "[KP LIBERATION] [PARAM] --- Gameplay Options ---";
     GET_PARAM_BOOL(GRLIB_fatigue, "Fatigue", 1);
     GET_PARAM_BOOL(KP_liberation_arsenalUsePreset, "ArsenalUsePreset", 1);
     GET_PARAM_BOOL(KP_liberation_mapmarkers, "MapMarkers", 1);
@@ -92,10 +92,10 @@ if(isServer) then {
     GET_PARAM(KP_liberation_allowEnemiesInImmobile, "AllowEnemiesInImmobile", 50);
     GET_PARAM(KP_liberation_delayDespawnMax, "DelayDespawnMax", 5);
     GET_PARAM_BOOL(KP_liberation_limited_zeus, "LimitedZeus", 1);
-    diag_log "[KP LIBERATION] [PARAM]";
+    diag_log text "[KP LIBERATION] [PARAM]";
 
     // Technical Options
-    diag_log "[KP LIBERATION] [PARAM] --- Technical Options ---";
+    diag_log text "[KP LIBERATION] [PARAM] --- Technical Options ---";
     GET_PARAM_BOOL(GRLIB_permissions_param, "Permissions", 1);
     GET_PARAM(GRLIB_cleanup_vehicles, "CleanupVehicles", 2);
     GET_PARAM_BOOL(GRLIB_introduction, "Introduction", 1);
@@ -109,7 +109,7 @@ if(isServer) then {
     KP_serverParamsFetched = true;
     publicVariable "KP_serverParamsFetched";
 
-    diag_log format ["[KP LIBERATION] [PARAM] ----- Server finished parameter initialization - time: %1", diag_ticktime];
+    diag_log text format ["[KP LIBERATION] [PARAM] ----- Server finished parameter initialization - time: %1", diag_ticktime];
 };
 
 // Fix for not working float values in mission params

--- a/Missionframework/scripts/shared/kill_manager.sqf
+++ b/Missionframework/scripts/shared/kill_manager.sqf
@@ -2,18 +2,18 @@ params ["_unit", "_killer"];
 
 if (isServer) then {
 
-    if (KP_liberation_kill_debug > 0) then {diag_log format ["[KP LIBERATION] [KILL] Kill Manager executed - _unit: %1 (%2) - _killer: %3 (%4)", typeOf _unit, _unit, typeOf _killer, _killer];};
+    if (KP_liberation_kill_debug > 0) then {diag_log text format ["[KP LIBERATION] [KILL] Kill Manager executed - _unit: %1 (%2) - _killer: %3 (%4)", typeOf _unit, _unit, typeOf _killer, _killer];};
 
     // Get Killer, when ACE enabled, via lastDamageSource
     if (KP_liberation_ace) then {
         if (local _unit) then {
             _killer = _unit getVariable ["ace_medical_lastDamageSource", _killer];
-            if (KP_liberation_kill_debug > 0) then {diag_log format ["[KP LIBERATION] [KILL] _unit is local to %1", debug_source];};
+            if (KP_liberation_kill_debug > 0) then {diag_log text format ["[KP LIBERATION] [KILL] _unit is local to %1", debug_source];};
         } else {
-            if (KP_liberation_kill_debug > 0) then {diag_log format ["[KP LIBERATION] [KILL] _unit is not local to %1", debug_source];};
+            if (KP_liberation_kill_debug > 0) then {diag_log text format ["[KP LIBERATION] [KILL] _unit is not local to %1", debug_source];};
             if (isNil "KP_liberation_ace_killer") then {KP_liberation_ace_killer = objNull;};
             waitUntil {sleep 0.5; !(isNull KP_liberation_ace_killer)};
-            if (KP_liberation_kill_debug > 0) then {diag_log format ["[KP LIBERATION] [KILL] KP_liberation_ace_killer received on %1", debug_source];};
+            if (KP_liberation_kill_debug > 0) then {diag_log text format ["[KP LIBERATION] [KILL] KP_liberation_ace_killer received on %1", debug_source];};
             _killer = KP_liberation_ace_killer;
             KP_liberation_ace_killer = objNull;
             publicVariable "KP_liberation_ace_killer";
@@ -105,7 +105,7 @@ if (isServer) then {
 
                 // Killed by BLUFOR
                 if (side _killer == GRLIB_side_friendly) then {
-                    if (KP_liberation_asymmetric_debug > 0) then {diag_log format ["[KP LIBERATION] [ASYMMETRIC] Guerilla unit killed by: %1", name _killer];};
+                    if (KP_liberation_asymmetric_debug > 0) then {diag_log text format ["[KP LIBERATION] [ASYMMETRIC] Guerilla unit killed by: %1", name _killer];};
                     [3, [(name _unit)]] remoteExec ["KPLIB_fnc_crGlobalMsg"];
                     stats_resistance_teamkills = stats_resistance_teamkills + 1;
                     [KP_liberation_cr_resistance_penalty, true] spawn F_cr_changeCR;
@@ -124,7 +124,7 @@ if (isServer) then {
 
             // Killed by BLUFOR
             if (side _killer == GRLIB_side_friendly) then {
-                if (KP_liberation_civrep_debug > 0) then {diag_log format ["[KP LIBERATION] [CIVREP] Civilian killed by: %1", name _killer];};
+                if (KP_liberation_civrep_debug > 0) then {diag_log text format ["[KP LIBERATION] [CIVREP] Civilian killed by: %1", name _killer];};
                 [2, [(name _unit)]] remoteExec ["KPLIB_fnc_crGlobalMsg"];
                 [KP_liberation_cr_kill_penalty, true] spawn F_cr_changeCR;
             };
@@ -161,7 +161,7 @@ if (isServer) then {
 } else {
     // Get Killer and send it to server, when ACE enabled, via lastDamageSource
     if (KP_liberation_ace && local _unit) then {
-        if (KP_liberation_kill_debug > 0) then {private _text = format ["[KP LIBERATION] [KILL] _unit is local to: %1", debug_source];_text remoteExec ["diag_log",2];};
+        if (KP_liberation_kill_debug > 0) then {private _text = text format ["[KP LIBERATION] [KILL] _unit is local to: %1", debug_source];_text remoteExec ["diag_log",2];};
         KP_liberation_ace_killer = _unit getVariable ["ace_medical_lastDamageSource", _killer];
         publicVariable "KP_liberation_ace_killer";
     };

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ class Missions
 * Tweaked: Explanation and formatting of `kp_objectInits.sqf`.
 * Tweaked: Integer to bool conversion in fetch param macro.
 * Tweaked: ObjectInit is now also called on spawned start vehicles.
+* Tweaked: Usage of structured text for `diag_log`, so there are no quotes around the messages in the rpt.
 * Fixed: Some CUP presets had free buildable arsenals. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Wrong boat in CUP USMC Woodland preset. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Object inits will fire on units not only vehicles.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | - |

### Description:
Converts all strings given to diag_log command to structured text. This will get rid of the quotes in the rpt.

### Content:
- [x] Structured text conversion of diag_log texts