### PR TITLE
0.96.7 Basic Discord Rich Presence

### DIFF
--- a/Missionframework/CfgFunctions.hpp
+++ b/Missionframework/CfgFunctions.hpp
@@ -61,6 +61,7 @@ class KPLIB
         class potatoScan                {};
         class protectObject             {};
         class secondsToTimer            {};
+        class setDiscordState           {};
         class setFobMass                {};
         class setLoadableViV            {};
         class setLoadout                {};

--- a/Missionframework/description.ext
+++ b/Missionframework/description.ext
@@ -46,3 +46,14 @@ class CfgDebriefing
         pictureBackground = "";
     };
 };
+
+class CfgDiscordRichPresence {
+    applicationID="698133766975258664";
+    defaultDetails="";
+    defaultState="Preparing...";
+    defaultLargeImageKey="liberation_logo";
+    defaultLargeImageText="KP Liberation";
+    defaultSmallImageKey="arma3_logo";
+    defaultSmallImageText="Arma 3";
+    useTimeElapsed=1;
+};

--- a/Missionframework/functions/fn_setDiscordState.sqf
+++ b/Missionframework/functions/fn_setDiscordState.sqf
@@ -21,6 +21,6 @@ params [
 
 [
     ["UpdateState", _state]
-] call (missionNameSpace getVariable ["DiscordRichPresence_fnc_update",{}]);
+] call (missionNamespace getVariable ["DiscordRichPresence_fnc_update", {}]);
 
 true

--- a/Missionframework/functions/fn_setDiscordState.sqf
+++ b/Missionframework/functions/fn_setDiscordState.sqf
@@ -1,0 +1,26 @@
+/*
+    File: fn_setDiscordState.sqf
+    Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
+    Date: 2020-04-10
+    Last Update: 2020-04-10
+    License: MIT License - http://www.opensource.org/licenses/MIT
+
+    Description:
+        Updated the Discord rich presence state with given string.
+
+    Parameter(s):
+        _state - New state which should be applied to rich presence [STRING, defaults to ""]
+
+    Returns:
+        Function reached the end [BOOL]
+*/
+
+params [
+    ["_state", "", [""]]
+];
+
+[
+    ["UpdateState", _state]
+] call (missionNameSpace getVariable ["DiscordRichPresence_fnc_update",{}]);
+
+true

--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -23,6 +23,11 @@ if (!isDedicated && !hasInterface && isMultiplayer) then {
 };
 
 if (!isDedicated && hasInterface) then {
+    // Get mission version and readable world name for Discord rich presence
+    [
+        ["UpdateDetails", [localize "STR_MISSION_VERSION", "on", getText (configfile >> "CfgWorlds" >> worldName >> "description")] joinString " "]
+    ] call (missionNameSpace getVariable ["DiscordRichPresence_fnc_update",{}]);
+
     waitUntil {alive player};
     if (debug_source != name player) then {debug_source = name player};
     [] call compileFinal preprocessFileLineNumbers "scripts\client\init_client.sqf";

--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -26,7 +26,7 @@ if (!isDedicated && hasInterface) then {
     // Get mission version and readable world name for Discord rich presence
     [
         ["UpdateDetails", [localize "STR_MISSION_VERSION", "on", getText (configfile >> "CfgWorlds" >> worldName >> "description")] joinString " "]
-    ] call (missionNameSpace getVariable ["DiscordRichPresence_fnc_update",{}]);
+    ] call (missionNamespace getVariable ["DiscordRichPresence_fnc_update", {}]);
 
     waitUntil {alive player};
     if (debug_source != name player) then {debug_source = name player};

--- a/Missionframework/scripts/client/ui/ui_manager.sqf
+++ b/Missionframework/scripts/client/ui/ui_manager.sqf
@@ -239,6 +239,17 @@ while { true } do {
 				{ ((uiNamespace getVariable 'GUI_OVERLAY') displayCtrl (_x)) ctrlShow false; } foreach  _sectorcontrols;
 				"zone_capture" setmarkerposlocal markers_reset;
 			};
+
+            // Update state in Discord rich presence in accordance to current location
+            if (_fobdistance < _distfob) then {
+                [["FOB", [_nearfob] call KPLIB_fnc_getFobName] joinString " "] call KPLIB_fnc_setDiscordState;
+            } else {
+                if !(_nearest_active_sector isEqualTo "") then {
+                    [markerText _nearest_active_sector] call KPLIB_fnc_setDiscordState;
+                } else {
+                    ["In the field"] call KPLIB_fnc_setDiscordState;
+                };
+            };
 		};
 
 	};

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ class Missions
 * Added: [Chernarus 2020](https://steamcommunity.com/sharedfiles/filedetails/?id=1913961235) building ignore list. Thanks to [Eogos](https://github.com/Eogos)
 * Added: Steam Workshop upload to build tools
 * Added: Locality change of slingloaded cargo to heli pilot to avoid breaking ropes while e.g. slingloading the FOB box.
+* Added: Support and utilization of the [Discord Rich Presence Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=1493485159) from [ConnorAU](https://github.com/ConnorAU).
 * Updated: Updated CUP presets to be inline with October 2019 stable build of CUP mods. Thanks to [Eogos](https://github.com/Eogos)
 * Updated: Turkish translation. Thanks to [654wak654](https://github.com/654wak654)
 * Updated: Russian localization. Thanks to [Dj_Haski](https://github.com/DjHaski)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | - |

### Description:
Adds basic Discord rich presence functionality by adding support and utilization of the [Discord Rich Presence Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=1493485159) from @ConnorAU.
It simply just shows if you're at a FOB, at a sector or in the field. This can and might be enhanced later, of course.

![unknown](https://user-images.githubusercontent.com/3811977/78991461-489fb580-7b39-11ea-8572-a07bab08ef0c.png)

### Content:
- [x] Discord Rich Presence support and setter function

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP