### PR TITLE
0.96.7 Range adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ Temporary Items
 .apdisk
 
 # Build directory
-build/
+/build/
 
 # KP-Steam
 steam_appid.txt

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-29
-    Last Update: 2020-04-20
+    Last Update: 2020-04-21
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -33,7 +33,7 @@ private _allBlueGroups = allGroups select {
 // Fetch all objects and AI groups near each FOB
 {
     private _fobPos = _x;
-    private _fobObjects = (_fobPos nearobjects (GRLIB_fob_range * 2)) select {
+    private _fobObjects = (_fobPos nearobjects (GRLIB_fob_range * 1.2)) select {
         ((typeof _x) in KP_liberation_classnamesToSave) &&          // Exclude classnames which are not in the presets
         {alive _x} &&                                               // Exclude dead or broken objects
         {getObjectType _x >= 8} &&                                  // Exclude preplaced terrain objects
@@ -54,10 +54,10 @@ private _allBlueGroups = allGroups select {
         private _grpUnits = (units _x) select {!(isPlayer _x) && (alive _x)};
         // Add to save array
         _aiGroups pushBack [getPosATL (leader _x), (_grpUnits apply {typeOf _x})];
-    } forEach (_allBlueGroups select {(_fobPos distance2D (leader _x)) < (GRLIB_fob_range * 2)});
+    } forEach (_allBlueGroups select {(_fobPos distance2D (leader _x)) < (GRLIB_fob_range * 1.2)});
 
     // Save all mines around FOB
-    private _fobMines = allMines inAreaArray [_fobPos, GRLIB_fob_range * 2, GRLIB_fob_range * 2];
+    private _fobMines = allMines inAreaArray [_fobPos, GRLIB_fob_range * 1.2, GRLIB_fob_range * 1.2];
     _allMines append (_fobMines apply {[
         getPosWorld _x,
         [vectorDirVisual _x, vectorUpVisual _x],

--- a/Missionframework/scripts/client/actions/do_recycle.sqf
+++ b/Missionframework/scripts/client/actions/do_recycle.sqf
@@ -88,7 +88,7 @@ if ( dorecycle == 1 && !(isnull _vehtorecycle) && alive _vehtorecycle) then {
 
 	if (!(KP_liberation_recycle_building_near) && ((_price_s + _price_a + _price_f) > 0)) exitWith {hint localize "STR_NORECBUILDING_ERROR";};
 
-	_storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
+	_storage_areas = (_nearfob nearobjects GRLIB_fob_range) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
 
 	_supplyCrates = ceil (_price_s / 100);
 	_ammoCrates = ceil (_price_a / 100);

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -1,3 +1,5 @@
+// TODO This needs absolutely a code refactoring, flamethrower or nuke
+
 private [ "_maxdist", "_truepos", "_built_object_remote", "_pos", "_grp", "_classname", "_idx", "_unitrank", "_posfob", "_ghost_spot", "_vehicle", "_dist", "_actualdir", "_near_objects", "_near_objects_25", "_debug_colisions" ];
 
 build_confirmed = 0;
@@ -6,12 +8,14 @@ _truepos = [];
 _debug_colisions = false;
 KP_vector = true;
 
-GRLIB_preview_spheres = [];
-while { count GRLIB_preview_spheres < 36 } do {
-	GRLIB_preview_spheres pushback ( "Sign_Sphere100cm_F" createVehicleLocal [ 0, 0, 0 ] );
+private _object_spheres = [];
+private _fob_spheres = [];
+for "_i" from 1 to 36 do {
+    _object_spheres pushBack ("Sign_Sphere100cm_F" createVehicleLocal [0, 0, 0]);
+    _fob_spheres pushBack ("Sign_Sphere100cm_F" createVehicleLocal [0, 0, 0]);
 };
 
-{ _x setObjectTexture [0, "#(rgb,8,8,3)color(0,1,0,1)"]; } foreach GRLIB_preview_spheres;
+{ _x setObjectTexture [0, "#(rgb,8,8,3)color(0,1,0,1)"]; } foreach _object_spheres;
 
 if (isNil "manned") then { manned = false };
 if (isNil "gridmode" ) then { gridmode = 0 };
@@ -22,345 +26,349 @@ if (isNil "build_elevation" ) then { build_elevation = 0 };
 waitUntil { sleep 0.2; !isNil "dobuild" };
 
 while { true } do {
-	waitUntil { sleep 0.2; dobuild != 0 };
+    waitUntil { sleep 0.2; dobuild != 0 };
 
-	build_confirmed = 1;
-	build_invalid = 0;
-	_classname = "";
-	if ( buildtype == 99 ) then {
-		_classname = FOB_typename;
-	} else {
-		_classname = ((build_lists select buildtype) select buildindex) select 0;
-		_price_s = ((build_lists select buildtype) select buildindex) select 1;
-		_price_a = ((build_lists select buildtype) select buildindex) select 2;
-		_price_f = ((build_lists select buildtype) select buildindex) select 3;
+    build_confirmed = 1;
+    build_invalid = 0;
+    _classname = "";
+    if ( buildtype == 99 ) then {
+        _classname = FOB_typename;
+    } else {
+        _classname = ((build_lists select buildtype) select buildindex) select 0;
+        _price_s = ((build_lists select buildtype) select buildindex) select 1;
+        _price_a = ((build_lists select buildtype) select buildindex) select 2;
+        _price_f = ((build_lists select buildtype) select buildindex) select 3;
 
-		_nearfob = [] call KPLIB_fnc_getNearestFob;
-		_storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
+        _nearfob = [] call KPLIB_fnc_getNearestFob;
+        _storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
 
-		[_price_s, _price_a, _price_f, _classname, buildtype, _storage_areas] remoteExec ["build_remote_call",2];
-	};
+        [_price_s, _price_a, _price_f, _classname, buildtype, _storage_areas] remoteExec ["build_remote_call",2];
+    };
 
-	if(buildtype == 1) then {
-		_pos = [(getpos player select 0) + 1,(getpos player select 1) + 1, 0];
-		_grp = group player;
-		if ( manned ) then {
-			_grp = createGroup GRLIB_side_friendly;
-		};
-		_classname createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
-		build_confirmed = 0;
-	} else {
-		if ( buildtype == 8 ) then {
-			_pos = [(getpos player select 0) + 1,(getpos player select 1) + 1, 0];
-			_grp = createGroup GRLIB_side_friendly;
-			_grp setGroupId [format ["%1 %2",squads_names select buildindex, groupId _grp]];
-			_idx = 0;
-			{
-				_unitrank = "private";
-				if(_idx == 0) then { _unitrank = "sergeant"; };
-				if(_idx == 1) then { _unitrank = "corporal"; };
-				if (_classname isEqualTo blufor_squad_para) then {
-					_x createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]; removeBackpackGlobal this; this addBackpackGlobal ""B_parachute""", 0.5, _unitrank];
-				} else {
-					_x createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}];", 0.5, _unitrank];
-				};
-				_idx = _idx + 1;
+    if(buildtype == 1) then {
+        _pos = [(getpos player select 0) + 1,(getpos player select 1) + 1, 0];
+        _grp = group player;
+        if ( manned ) then {
+            _grp = createGroup GRLIB_side_friendly;
+        };
+        _classname createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]", 0.5, "private"];
+        build_confirmed = 0;
+    } else {
+        if ( buildtype == 8 ) then {
+            _pos = [(getpos player select 0) + 1,(getpos player select 1) + 1, 0];
+            _grp = createGroup GRLIB_side_friendly;
+            _grp setGroupId [format ["%1 %2",squads_names select buildindex, groupId _grp]];
+            _idx = 0;
+            {
+                _unitrank = "private";
+                if(_idx == 0) then { _unitrank = "sergeant"; };
+                if(_idx == 1) then { _unitrank = "corporal"; };
+                if (_classname isEqualTo blufor_squad_para) then {
+                    _x createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]; removeBackpackGlobal this; this addBackpackGlobal ""B_parachute""", 0.5, _unitrank];
+                } else {
+                    _x createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}];", 0.5, _unitrank];
+                };
+                _idx = _idx + 1;
 
-			} foreach _classname;
-			_grp setBehaviour "SAFE";
-			build_confirmed = 0;
-		} else {
-			_posfob = getpos player;
-			if (buildtype != 99) then {
-				_posfob = [] call KPLIB_fnc_getNearestFob;
-			};
+            } foreach _classname;
+            _grp setBehaviour "SAFE";
+            build_confirmed = 0;
+        } else {
+            _posfob = getpos player;
+            if (buildtype != 99) then {
+                _posfob = [] call KPLIB_fnc_getNearestFob;
+            };
 
-			_idactcancel = -1;
-			_idactsnap = -1;
-			_idactplacebis = -1;
-			_idactvector = -1;
-			if (buildtype != 99 ) then {
-				_idactcancel = player addAction ["<t color='#B0FF00'>" + localize "STR_CANCEL" + "</t> <img size='2' image='res\ui_cancel.paa'/>","scripts\client\build\build_cancel.sqf","",-725,false,true,"","build_confirmed == 1"];
-			};
-			if (buildtype == 6 ) then {
-				_idactplacebis = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT_BIS" + "</t> <img size='2' image='res\ui_confirm.paa'/>","scripts\client\build\build_place_bis.sqf","",-785,false,false,"","build_invalid == 0 && build_confirmed == 1"];
-			};
-			if (buildtype == 6 || buildtype == 99  || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
-				_idactsnap = player addAction ["<t color='#B0FF00'>" + localize "STR_GRID" + "</t>","scripts\client\build\do_grid.sqf","",-735,false,false,"","build_confirmed == 1"];
-				_idactvector = player addAction ["<t color='#B0FF00'>" + localize "STR_VECACTION" + "</t>",{KP_vector = !KP_vector;},"",-800,false,false,"","build_confirmed == 1"];
-			};
+            _idactcancel = -1;
+            _idactsnap = -1;
+            _idactplacebis = -1;
+            _idactvector = -1;
+            if (buildtype != 99 ) then {
+                _idactcancel = player addAction ["<t color='#B0FF00'>" + localize "STR_CANCEL" + "</t> <img size='2' image='res\ui_cancel.paa'/>","scripts\client\build\build_cancel.sqf","",-725,false,true,"","build_confirmed == 1"];
+            };
+            if (buildtype == 6 ) then {
+                _idactplacebis = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT_BIS" + "</t> <img size='2' image='res\ui_confirm.paa'/>","scripts\client\build\build_place_bis.sqf","",-785,false,false,"","build_invalid == 0 && build_confirmed == 1"];
+            };
+            if (buildtype == 6 || buildtype == 99  || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                _idactsnap = player addAction ["<t color='#B0FF00'>" + localize "STR_GRID" + "</t>","scripts\client\build\do_grid.sqf","",-735,false,false,"","build_confirmed == 1"];
+                _idactvector = player addAction ["<t color='#B0FF00'>" + localize "STR_VECACTION" + "</t>",{KP_vector = !KP_vector;},"",-800,false,false,"","build_confirmed == 1"];
+            };
 
-			_idactrotate = player addAction ["<t color='#B0FF00'>" + localize "STR_ROTATION" + "</t> <img size='2' image='res\ui_rotation.paa'/>","scripts\client\build\build_rotate.sqf","",-750,false,false,"","build_confirmed == 1"];
-			_idactraise = player addAction ["<t color='#B0FF00'>" + localize "STR_RAISE" + "</t>","scripts\client\build\build_raise.sqf","",-765,false,false,"","build_confirmed == 1"];
-			_idactlower = player addAction ["<t color='#B0FF00'>" + localize "STR_LOWER" + "</t>","scripts\client\build\build_lower.sqf","",-766,false,false,"","build_confirmed == 1"];
-			_idactplace = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT" + "</t> <img size='2' image='res\ui_confirm.paa'/>","scripts\client\build\build_place.sqf","",-775,false,true,"","build_invalid == 0 && build_confirmed == 1"];
+            _idactrotate = player addAction ["<t color='#B0FF00'>" + localize "STR_ROTATION" + "</t> <img size='2' image='res\ui_rotation.paa'/>","scripts\client\build\build_rotate.sqf","",-750,false,false,"","build_confirmed == 1"];
+            _idactraise = player addAction ["<t color='#B0FF00'>" + localize "STR_RAISE" + "</t>","scripts\client\build\build_raise.sqf","",-765,false,false,"","build_confirmed == 1"];
+            _idactlower = player addAction ["<t color='#B0FF00'>" + localize "STR_LOWER" + "</t>","scripts\client\build\build_lower.sqf","",-766,false,false,"","build_confirmed == 1"];
+            _idactplace = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT" + "</t> <img size='2' image='res\ui_confirm.paa'/>","scripts\client\build\build_place.sqf","",-775,false,true,"","build_invalid == 0 && build_confirmed == 1"];
 
-			_ghost_spot = (markerPos "ghost_spot") findEmptyPosition [0,100];
+            _ghost_spot = (markerPos "ghost_spot") findEmptyPosition [0,100];
 
-			_vehicle = _classname createVehicleLocal _ghost_spot;
-			_vehicle allowdamage false;
-			_vehicle setVehicleLock "LOCKED";
-			_vehicle enableSimulationGlobal false;
-			_vehicle setVariable ["KP_liberation_preplaced", true, true];
+            _vehicle = _classname createVehicleLocal _ghost_spot;
+            _vehicle allowdamage false;
+            _vehicle setVehicleLock "LOCKED";
+            _vehicle enableSimulationGlobal false;
+            _vehicle setVariable ["KP_liberation_preplaced", true, true];
 
-			_dist = 0.6 * (sizeOf _classname);
-			if (_dist < 3.5) then { _dist = 3.5 };
-			_dist = _dist + 1;
+            _dist = 0.6 * (sizeOf _classname);
+            if (_dist < 3.5) then { _dist = 3.5 };
+            _dist = _dist + 1;
 
-			for [{_i=0}, {_i<5}, {_i=_i+1}] do {
-				_vehicle setObjectTextureGlobal [_i, '#(rgb,8,8,3)color(0,1,0,0.8)'];
-			};
+            for [{_i=0}, {_i<5}, {_i=_i+1}] do {
+                _vehicle setObjectTextureGlobal [_i, '#(rgb,8,8,3)color(0,1,0,0.8)'];
+            };
 
-			{ _x setObjectTexture [0, "#(rgb,8,8,3)color(0,1,0,1)"]; } foreach GRLIB_preview_spheres;
+            { _x setObjectTexture [0, "#(rgb,8,8,3)color(0,1,0,1)"]; } foreach _object_spheres;
 
-			while { build_confirmed == 1 && alive player } do {
-				_truedir = 90 - (getdir player);
-				if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
-					_truepos = [((getposATL player) select 0) + (_dist * (cos _truedir)), ((getposATL player) select 1) + (_dist * (sin _truedir)),((getposATL player) select 2)];
-				} else {
-					_truepos = [((getpos player) select 0) + (_dist * (cos _truedir)), ((getpos player) select 1) + (_dist * (sin _truedir)),0];
-				};
-				_actualdir = ((getdir player) + build_rotation);
-				if ( _classname == "Land_Cargo_Patrol_V1_F" || _classname == "Land_PortableLight_single_F" ) then { _actualdir = _actualdir + 180 };
-				if ( _classname == FOB_typename ) then { _actualdir = _actualdir + 270 };
+            while { build_confirmed == 1 && alive player } do {
+                _truedir = 90 - (getdir player);
+                if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
+                    _truepos = [((getposATL player) select 0) + (_dist * (cos _truedir)), ((getposATL player) select 1) + (_dist * (sin _truedir)),((getposATL player) select 2)];
+                } else {
+                    _truepos = [((getpos player) select 0) + (_dist * (cos _truedir)), ((getpos player) select 1) + (_dist * (sin _truedir)),0];
+                };
+                _actualdir = ((getdir player) + build_rotation);
+                if ( _classname == "Land_Cargo_Patrol_V1_F" || _classname == "Land_PortableLight_single_F" ) then { _actualdir = _actualdir + 180 };
+                if ( _classname == FOB_typename ) then { _actualdir = _actualdir + 270 };
 
-				while { _actualdir > 360 } do { _actualdir = _actualdir - 360 };
-				while { _actualdir < 0 } do { _actualdir = _actualdir + 360 };
-				if ( ((buildtype == 6) || (buildtype == 99)) && ((gridmode % 2) == 1) ) then {
-					if ( _actualdir >= 22.5 && _actualdir <= 67.5 ) then { _actualdir = 45 };
-					if ( _actualdir >= 67.5 && _actualdir <= 112.5 ) then { _actualdir = 90 };
-					if ( _actualdir >= 112.5 && _actualdir <= 157.5 ) then { _actualdir = 135 };
-					if ( _actualdir >= 157.5 && _actualdir <= 202.5 ) then { _actualdir = 180 };
-					if ( _actualdir >= 202.5 && _actualdir <= 247.5 ) then { _actualdir = 225 };
-					if ( _actualdir >= 247.5 && _actualdir <= 292.5 ) then { _actualdir = 270 };
-					if ( _actualdir >= 292.5 && _actualdir <= 337.5 ) then { _actualdir = 315 };
-					if ( _actualdir <= 22.5 || _actualdir >= 337.5 ) then { _actualdir = 0 };
-				};
+                while { _actualdir > 360 } do { _actualdir = _actualdir - 360 };
+                while { _actualdir < 0 } do { _actualdir = _actualdir + 360 };
+                if ( ((buildtype == 6) || (buildtype == 99)) && ((gridmode % 2) == 1) ) then {
+                    if ( _actualdir >= 22.5 && _actualdir <= 67.5 ) then { _actualdir = 45 };
+                    if ( _actualdir >= 67.5 && _actualdir <= 112.5 ) then { _actualdir = 90 };
+                    if ( _actualdir >= 112.5 && _actualdir <= 157.5 ) then { _actualdir = 135 };
+                    if ( _actualdir >= 157.5 && _actualdir <= 202.5 ) then { _actualdir = 180 };
+                    if ( _actualdir >= 202.5 && _actualdir <= 247.5 ) then { _actualdir = 225 };
+                    if ( _actualdir >= 247.5 && _actualdir <= 292.5 ) then { _actualdir = 270 };
+                    if ( _actualdir >= 292.5 && _actualdir <= 337.5 ) then { _actualdir = 315 };
+                    if ( _actualdir <= 22.5 || _actualdir >= 337.5 ) then { _actualdir = 0 };
+                };
 
-				_sphere_idx = 0;
-				{
-					_x setpos ( [ _truepos, _dist, _sphere_idx * 10 ] call BIS_fnc_relPos );
-					_sphere_idx = _sphere_idx + 1;
-				} foreach GRLIB_preview_spheres;
+                {
+                    _x setPos (_truepos getPos [_dist, 10 * _forEachIndex]);
+                } foreach _object_spheres;
 
-				_vehicle setdir _actualdir;
+                if !(buildtype isEqualTo 99) then {
+                    {
+                        _x setPos (_posfob getPos [GRLIB_fob_range, 10 * _forEachIndex])
+                    } forEach _fob_spheres;
+                };
 
-				_truepos = [_truepos select 0, _truepos select 1, (_truepos select 2) +  build_elevation];
+                _vehicle setdir _actualdir;
 
-				_near_objects = (_truepos nearobjects ["AllVehicles", _dist]) ;
-				_near_objects = _near_objects + (_truepos nearobjects [FOB_box_typename, _dist]);
-				_near_objects = _near_objects + (_truepos nearobjects [Arsenal_typename, _dist]);
+                _truepos = [_truepos select 0, _truepos select 1, (_truepos select 2) +  build_elevation];
 
-				_near_objects_25 = (_truepos nearobjects ["AllVehicles", 50]) ;
-				_near_objects_25 = _near_objects_25 + (_truepos nearobjects [FOB_box_typename, 50]);
-				_near_objects_25 = _near_objects_25 + (_truepos nearobjects [Arsenal_typename, 50]);
+                _near_objects = (_truepos nearobjects ["AllVehicles", _dist]) ;
+                _near_objects = _near_objects + (_truepos nearobjects [FOB_box_typename, _dist]);
+                _near_objects = _near_objects + (_truepos nearobjects [Arsenal_typename, _dist]);
 
-				if(	buildtype != 6 ) then {
-					_near_objects = _near_objects + (_truepos nearobjects ["Static", _dist]);
-					_near_objects_25 = _near_objects_25 + (_truepos nearobjects ["Static", 50]);
-				};
+                _near_objects_25 = (_truepos nearobjects ["AllVehicles", 50]) ;
+                _near_objects_25 = _near_objects_25 + (_truepos nearobjects [FOB_box_typename, 50]);
+                _near_objects_25 = _near_objects_25 + (_truepos nearobjects [Arsenal_typename, 50]);
 
-				private _remove_objects = [];
-				{
-					private _typeOfX = typeOf _x;
-					if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
-						_remove_objects pushback _x;
-					};
-				} foreach _near_objects;
+                if(	buildtype != 6 ) then {
+                    _near_objects = _near_objects + (_truepos nearobjects ["Static", _dist]);
+                    _near_objects_25 = _near_objects_25 + (_truepos nearobjects ["Static", 50]);
+                };
 
-				private _remove_objects_25 = [];
-				{
-					private _typeOfX = typeOf _x;
-					if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
-						_remove_objects_25 pushback _x;
-					};
-				} foreach _near_objects_25;
+                private _remove_objects = [];
+                {
+                    private _typeOfX = typeOf _x;
+                    if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+                        _remove_objects pushback _x;
+                    };
+                } foreach _near_objects;
 
-				_near_objects = _near_objects - _remove_objects;
-				_near_objects_25 = _near_objects_25 - _remove_objects_25;
+                private _remove_objects_25 = [];
+                {
+                    private _typeOfX = typeOf _x;
+                    if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+                        _remove_objects_25 pushback _x;
+                    };
+                } foreach _near_objects_25;
 
-				if ( count _near_objects == 0 ) then {
-					{
-						_dist22 = 0.6 * (sizeOf (typeof _x));
-						if ( _dist22 < 1 ) then { _dist22 = 1 };
-						if (_truepos distance _x < _dist22) then {
-							_near_objects pushback _x;
-						};
-					} foreach _near_objects_25;
-				};
+                _near_objects = _near_objects - _remove_objects;
+                _near_objects_25 = _near_objects_25 - _remove_objects_25;
 
-				if ( count _near_objects != 0 ) then {
-					GRLIB_conflicting_objects = _near_objects;
-				} else {
-					GRLIB_conflicting_objects = [];
-				};
+                if ( count _near_objects == 0 ) then {
+                    {
+                        _dist22 = 0.6 * (sizeOf (typeof _x));
+                        if ( _dist22 < 1 ) then { _dist22 = 1 };
+                        if (_truepos distance _x < _dist22) then {
+                            _near_objects pushback _x;
+                        };
+                    } foreach _near_objects_25;
+                };
 
-				if (count _near_objects == 0 && ((_truepos distance _posfob) < _maxdist) && (  ((!surfaceIsWater _truepos) && (!surfaceIsWater getpos player)) || (_classname in boats_names) ) ) then {
+                if ( count _near_objects != 0 ) then {
+                    GRLIB_conflicting_objects = _near_objects;
+                } else {
+                    GRLIB_conflicting_objects = [];
+                };
 
-					if ( ((buildtype == 6) || (buildtype == 99)) && ((gridmode % 2) == 1) ) then {
-						_vehicle setpos [round (_truepos select 0),round (_truepos select 1), _truepos select 2];
-					} else {
-						if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
-							_vehicle setPosATL _truepos;
-						} else {
-							_vehicle setpos _truepos;
-						};
-					};
-					if (buildtype == 6 || buildtype == 99 || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
-						if (KP_vector) then {
-							_vehicle setVectorUp [0,0,1];
-						} else {
-							_vehicle setVectorUp surfaceNormal position _vehicle;
-						};
-					} else {
-						_vehicle setVectorUp surfaceNormal position _vehicle;
-					};
-					if(build_invalid == 1) then {
-						GRLIB_ui_notif = "";
-						{ _x setObjectTexture [0, "#(rgb,8,8,3)color(0,1,0,1)"]; } foreach GRLIB_preview_spheres;
-					};
-					build_invalid = 0;
+                if (count _near_objects == 0 && ((_truepos distance _posfob) < _maxdist) && (  ((!surfaceIsWater _truepos) && (!surfaceIsWater getpos player)) || (_classname in boats_names) ) ) then {
 
-				} else {
-					if ( build_invalid == 0 ) then {
-						{ _x setObjectTexture [0, "#(rgb,8,8,3)color(1,0,0,1)"]; } foreach GRLIB_preview_spheres;
-					};
-					_vehicle setpos _ghost_spot;
-					build_invalid = 1;
-					if(count _near_objects > 0) then {
-						GRLIB_ui_notif = format [localize "STR_PLACEMENT_IMPOSSIBLE",count _near_objects, round _dist];
+                    if ( ((buildtype == 6) || (buildtype == 99)) && ((gridmode % 2) == 1) ) then {
+                        _vehicle setpos [round (_truepos select 0),round (_truepos select 1), _truepos select 2];
+                    } else {
+                        if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
+                            _vehicle setPosATL _truepos;
+                        } else {
+                            _vehicle setpos _truepos;
+                        };
+                    };
+                    if (buildtype == 6 || buildtype == 99 || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                        if (KP_vector) then {
+                            _vehicle setVectorUp [0,0,1];
+                        } else {
+                            _vehicle setVectorUp surfaceNormal position _vehicle;
+                        };
+                    } else {
+                        _vehicle setVectorUp surfaceNormal position _vehicle;
+                    };
+                    if(build_invalid == 1) then {
+                        GRLIB_ui_notif = "";
+                        { _x setObjectTexture [0, "#(rgb,8,8,3)color(0,1,0,1)"]; } foreach _object_spheres;
+                    };
+                    build_invalid = 0;
 
-						if (_debug_colisions) then {
-							private [ "_objs_classnames" ];
-							_objs_classnames = [];
-							{ _objs_classnames pushback (typeof _x) } foreach _near_objects;
-							hint format [ "Colisions : %1", _objs_classnames ];
-						};
-					};
-					if( ((surfaceIsWater _truepos) || (surfaceIsWater getpos player)) && !(_classname in boats_names)) then {
-						GRLIB_ui_notif = localize "STR_BUILD_ERROR_WATER";
-					};
-					if((_truepos distance _posfob) > _maxdist) then {
-						GRLIB_ui_notif = format [localize "STR_BUILD_ERROR_DISTANCE",_maxdist];
-					};
+                } else {
+                    if ( build_invalid == 0 ) then {
+                        { _x setObjectTexture [0, "#(rgb,8,8,3)color(1,0,0,1)"]; } foreach _object_spheres;
+                    };
+                    _vehicle setpos _ghost_spot;
+                    build_invalid = 1;
+                    if(count _near_objects > 0) then {
+                        GRLIB_ui_notif = format [localize "STR_PLACEMENT_IMPOSSIBLE",count _near_objects, round _dist];
 
-				};
-				sleep 0.05;
-			};
+                        if (_debug_colisions) then {
+                            private [ "_objs_classnames" ];
+                            _objs_classnames = [];
+                            { _objs_classnames pushback (typeof _x) } foreach _near_objects;
+                            hint format [ "Colisions : %1", _objs_classnames ];
+                        };
+                    };
+                    if( ((surfaceIsWater _truepos) || (surfaceIsWater getpos player)) && !(_classname in boats_names)) then {
+                        GRLIB_ui_notif = localize "STR_BUILD_ERROR_WATER";
+                    };
+                    if((_truepos distance _posfob) > _maxdist) then {
+                        GRLIB_ui_notif = format [localize "STR_BUILD_ERROR_DISTANCE",_maxdist];
+                    };
 
-			GRLIB_ui_notif = "";
+                };
+                sleep 0.05;
+            };
 
-			{ _x setpos [ 0,0,0 ] } foreach GRLIB_preview_spheres;
+            GRLIB_ui_notif = "";
 
-			if ( !alive player || build_confirmed == 3 ) then {
-				private ["_price_s", "_price_a", "_price_f", "_nearfob", "_storage_areas"];
-				_price_s = ((build_lists select buildtype) select buildindex) select 1;
-				_price_a = ((build_lists select buildtype) select buildindex) select 2;
-				_price_f = ((build_lists select buildtype) select buildindex) select 3;
+            {_x setPos [0, 0, 0];} forEach (_object_spheres + _fob_spheres);
 
-				_nearfob = [] call KPLIB_fnc_getNearestFob;
-				_storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
+            if ( !alive player || build_confirmed == 3 ) then {
+                private ["_price_s", "_price_a", "_price_f", "_nearfob", "_storage_areas"];
+                _price_s = ((build_lists select buildtype) select buildindex) select 1;
+                _price_a = ((build_lists select buildtype) select buildindex) select 2;
+                _price_f = ((build_lists select buildtype) select buildindex) select 3;
 
-				_supplyCrates = ceil (_price_s / 100);
-				_ammoCrates = ceil (_price_a / 100);
-				_fuelCrates = ceil (_price_f / 100);
-				_crateSum = _supplyCrates + _ammoCrates + _fuelCrates;
+                _nearfob = [] call KPLIB_fnc_getNearestFob;
+                _storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
 
-				_spaceSum = 0;
+                _supplyCrates = ceil (_price_s / 100);
+                _ammoCrates = ceil (_price_a / 100);
+                _fuelCrates = ceil (_price_f / 100);
+                _crateSum = _supplyCrates + _ammoCrates + _fuelCrates;
 
-				{
-					if (typeOf _x == KP_liberation_large_storage_building) then {
-						_spaceSum = _spaceSum + (count KP_liberation_large_storage_positions) - (count (attachedObjects _x));
-					};
-					if (typeOf _x == KP_liberation_small_storage_building) then {
-						_spaceSum = _spaceSum + (count KP_liberation_small_storage_positions) - (count (attachedObjects _x));
-					};
-				} forEach _storage_areas;
+                _spaceSum = 0;
 
-				deleteVehicle _vehicle;
+                {
+                    if (typeOf _x == KP_liberation_large_storage_building) then {
+                        _spaceSum = _spaceSum + (count KP_liberation_large_storage_positions) - (count (attachedObjects _x));
+                    };
+                    if (typeOf _x == KP_liberation_small_storage_building) then {
+                        _spaceSum = _spaceSum + (count KP_liberation_small_storage_positions) - (count (attachedObjects _x));
+                    };
+                } forEach _storage_areas;
 
-				if (_spaceSum < _crateSum) then {
-					hint localize "STR_CANCEL_ERROR";
-				} else {
-					[_price_s, _price_a, _price_f, _storage_areas] remoteExec ["cancel_build_remote_call",2];
-				};
-			};
+                deleteVehicle _vehicle;
 
-			if ( build_confirmed == 2 ) then {
-				_vehpos = getpos _vehicle;
-				_vehdir = getdir _vehicle;
-				deleteVehicle _vehicle;
-				sleep 0.1;
-				_vehicle = _classname createVehicle _truepos;
-				_vehicle allowDamage false;
-				_vehicle setdir _vehdir;
-				if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
-					_vehicle setPosATL _truepos;
-				} else {
-					_vehicle setpos _truepos;
-				};
+                if (_spaceSum < _crateSum) then {
+                    hint localize "STR_CANCEL_ERROR";
+                } else {
+                    [_price_s, _price_a, _price_f, _storage_areas] remoteExec ["cancel_build_remote_call",2];
+                };
+            };
+
+            if ( build_confirmed == 2 ) then {
+                _vehpos = getpos _vehicle;
+                _vehdir = getdir _vehicle;
+                deleteVehicle _vehicle;
+                sleep 0.1;
+                _vehicle = _classname createVehicle _truepos;
+                _vehicle allowDamage false;
+                _vehicle setdir _vehdir;
+                if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
+                    _vehicle setPosATL _truepos;
+                } else {
+                    _vehicle setpos _truepos;
+                };
 
                 [_vehicle] call KPLIB_fnc_clearCargo;
 
-				if (buildtype == 6 || buildtype == 99 || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
-					if (KP_vector) then {
-						_vehicle setVectorUp [0,0,1];
-					} else {
-						_vehicle setVectorUp surfaceNormal position _vehicle;
-					};
-				} else {
-					_vehicle setVectorUp surfaceNormal position _vehicle;
-				};
+                if (buildtype == 6 || buildtype == 99 || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                    if (KP_vector) then {
+                        _vehicle setVectorUp [0,0,1];
+                    } else {
+                        _vehicle setVectorUp surfaceNormal position _vehicle;
+                    };
+                } else {
+                    _vehicle setVectorUp surfaceNormal position _vehicle;
+                };
 
-				if ( (unitIsUAV _vehicle) || manned ) then {
-					[ _vehicle ] call KPLIB_fnc_forceBluforCrew;
-				};
+                if ( (unitIsUAV _vehicle) || manned ) then {
+                    [ _vehicle ] call KPLIB_fnc_forceBluforCrew;
+                };
 
                 [_vehicle] call KPLIB_fnc_addObjectInit;
 
-				sleep 0.3;
-				_vehicle allowDamage true;
-				_vehicle setDamage 0;
+                sleep 0.3;
+                _vehicle allowDamage true;
+                _vehicle setDamage 0;
 
-				if(buildtype != 6) then {
-					_vehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
-					{ _x addMPEventHandler ["MPKilled", {_this spawn kill_manager}]; } foreach (crew _vehicle);
+                if(buildtype != 6) then {
+                    _vehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];
+                    { _x addMPEventHandler ["MPKilled", {_this spawn kill_manager}]; } foreach (crew _vehicle);
 
-				};
-			};
+                };
+            };
 
-			if ( _idactcancel != -1 ) then {
-				player removeAction _idactcancel;
-			};
-			if ( _idactsnap != -1 ) then {
-				player removeAction _idactsnap;
-			};
-			if ( _idactplacebis != -1 ) then {
-				player removeAction _idactplacebis;
-			};
-			if ( _idactvector != -1 ) then {
-				player removeAction _idactvector;
-			};
-			player removeAction _idactrotate;
-			player removeAction _idactplace;
-			player removeAction _idactraise;
-			player removeAction _idactlower;
+            if ( _idactcancel != -1 ) then {
+                player removeAction _idactcancel;
+            };
+            if ( _idactsnap != -1 ) then {
+                player removeAction _idactsnap;
+            };
+            if ( _idactplacebis != -1 ) then {
+                player removeAction _idactplacebis;
+            };
+            if ( _idactvector != -1 ) then {
+                player removeAction _idactvector;
+            };
+            player removeAction _idactrotate;
+            player removeAction _idactplace;
+            player removeAction _idactraise;
+            player removeAction _idactlower;
 
-			if(buildtype == 99) then {
-				_new_fob = getpos player;
-				[_new_fob, false] remoteExec ["build_fob_remote_call",2];
-				buildtype = 1;
-			};
+            if(buildtype == 99) then {
+                _new_fob = getpos player;
+                [_new_fob, false] remoteExec ["build_fob_remote_call",2];
+                buildtype = 1;
+            };
 
-			build_confirmed = 0;
-		};
-	};
+            build_confirmed = 0;
+        };
+    };
 
-	if ( repeatbuild ) then {
-		dobuild = 1;
-		repeatbuild = false;
-	} else {
-		dobuild = 0;
-	};
-	manned = false;
+    if ( repeatbuild ) then {
+        dobuild = 1;
+        repeatbuild = false;
+    } else {
+        dobuild = 0;
+    };
+    manned = false;
 };

--- a/Missionframework/scripts/client/build/do_sector_build.sqf
+++ b/Missionframework/scripts/client/build/do_sector_build.sqf
@@ -8,7 +8,7 @@ if (((_this select 3) select 0) == KP_liberation_small_storage_building) then {
 	build_invalid = 0;
 	KP_vector = true;
 
-	_sectorpos = markerPos ([GRLIB_fob_range] call KPLIB_fnc_getNearestSector);
+	_sectorpos = markerPos ([100] call KPLIB_fnc_getNearestSector);
 
 	_idactcancel = player addAction ["<t color='#B0FF00'>" + localize "STR_CANCEL" + "</t> <img size='2' image='res\ui_cancel.paa'/>",{build_confirmed = 3;},"",-725,false,true,"","build_confirmed == 1"];
 	_idactplace = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT" + "</t> <img size='2' image='res\ui_confirm.paa'/>",{build_confirmed = 2;},"",-775,false,true,"","build_invalid == 0 && build_confirmed == 1"];
@@ -33,7 +33,7 @@ if (((_this select 3) select 0) == KP_liberation_small_storage_building) then {
 		_truedir = 90 - (getdir player);
 		_truepos = [((getpos player) select 0) + (_dist * (cos _truedir)), ((getpos player) select 1) + (_dist * (sin _truedir)),0];
 
-		if ((surfaceIsWater _truepos) || (surfaceIsWater getpos player) || ((_truepos distance _sectorpos) > GRLIB_fob_range)) then {
+		if ((surfaceIsWater _truepos) || (surfaceIsWater getpos player) || ((_truepos distance _sectorpos) > 100)) then {
 			_building setpos _ghost_spot;
 			build_invalid = 1;
 
@@ -41,8 +41,8 @@ if (((_this select 3) select 0) == KP_liberation_small_storage_building) then {
 				GRLIB_ui_notif = localize "STR_BUILD_ERROR_WATER";
 			};
 
-			if((_truepos distance _sectorpos) > GRLIB_fob_range) then {
-				GRLIB_ui_notif = format [localize "STR_BUILD_ERROR_DISTANCE",GRLIB_fob_range];
+			if((_truepos distance _sectorpos) > 100) then {
+				GRLIB_ui_notif = format [localize "STR_BUILD_ERROR_DISTANCE", 100];
 			};
 		} else {
 			_building setdir (getDir player);

--- a/Missionframework/scripts/client/misc/playerNamespace.sqf
+++ b/Missionframework/scripts/client/misc/playerNamespace.sqf
@@ -2,7 +2,7 @@
     File: playerNamespace.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-12
-    Last Update: 2020-04-18
+    Last Update: 2020-04-21
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -19,7 +19,6 @@ waitUntil {one_eco_done};
 private _fobPos = [0, 0, 0];
 private _fobDist = 99999;
 private _fobName = "";
-private _nearSector = "";
 
 while {true} do {
     // FOB distance, name and position
@@ -56,9 +55,8 @@ while {true} do {
     player setVariable ["KPLIB_isNearStart", (player distance2d startbase) < 200];
 
     // Nearest activated sector and possible production data
-    _nearSector = [GRLIB_sector_size] call KPLIB_fnc_getNearestSector;
-    player setVariable ["KPLIB_nearProd", KP_liberation_production param [KP_liberation_production findIf {(_x select 1) isEqualTo _nearSector}, []]];
-    player setVariable ["KPLIB_nearSector", _nearSector];
+    player setVariable ["KPLIB_nearProd", KP_liberation_production param [KP_liberation_production findIf {(_x select 1) isEqualTo ([100] call KPLIB_fnc_getNearestSector)}, []]];
+    player setVariable ["KPLIB_nearSector", [GRLIB_sector_size] call KPLIB_fnc_getNearestSector];
 
     // Zeus module synced to player
     player setVariable ["KPLIB_ownedZeusModule", getAssignedCuratorLogic player];

--- a/Missionframework/scripts/server/game/cleanup_vehicles.sqf
+++ b/Missionframework/scripts/server/game/cleanup_vehicles.sqf
@@ -14,7 +14,7 @@ while { GRLIB_cleanup_vehicles > 0 } do {
         _nextvehicle = _x;
         _nearestfob = [ getpos _nextvehicle ] call KPLIB_fnc_getNearestFob;
         if ( count _nearestfob == 3 ) then {
-            if ( ( _nextvehicle distance _nearestfob > ( 4 * GRLIB_fob_range ) ) && ( _nextvehicle distance startbase > ( 4 * GRLIB_fob_range ) ) ) then {
+            if ( ( _nextvehicle distance _nearestfob > ( 1.2 * GRLIB_fob_range ) ) && ( _nextvehicle distance startbase > ( 1.2 * GRLIB_fob_range ) ) ) then {
                 if ( typeof _nextvehicle in _cleanup_classnames ) then {
                     if ( count ( crew _nextvehicle ) == 0 ) then {
                         _nextvehicle setVariable [ "GRLIB_empty_vehicle_ticker", ( _nextvehicle getVariable [ "GRLIB_empty_vehicle_ticker", 0 ] ) + 1 ];

--- a/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
@@ -4,7 +4,7 @@ params ["_index", "_nearfob", "_clientID", "_supplies", "_ammo", "_fuel"];
 
 logiError = 0;
 
-private _storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
+private _storage_areas = (_nearfob nearobjects GRLIB_fob_range) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
 
 if ((count _storage_areas) == 0) exitWith {(localize "STR_LOGISTIC_CANTAFFORD") remoteExec ["hint",_clientID]; logiError = 1; _clientID publicVariableClient "logiError";};
 

--- a/Missionframework/scripts/server/remotecall/build_fac_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/build_fac_remote_call.sqf
@@ -22,7 +22,7 @@ switch (_fac) do {
             stats_ammo_spent = stats_ammo_spent + _price_a;
             stats_fuel_spent = stats_fuel_spent + _price_f;
 
-            private _storage = nearestObjects [(markerPos (_x select 1)), [KP_liberation_small_storage_building], GRLIB_fob_range];
+            private _storage = nearestObjects [(markerPos (_x select 1)), [KP_liberation_small_storage_building], 100];
             _storage = _storage select {(_x getVariable ["KP_liberation_storage_type",-1]) == 1};
             if ((count _storage) == 0) exitWith {};
             _storage = (_storage select 0);

--- a/Missionframework/scripts/server/remotecall/del_logiTruck_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/del_logiTruck_remote_call.sqf
@@ -6,7 +6,7 @@ logiError = 0;
 
 if (((KP_liberation_logistics select _index) select 1) <= 0) exitWith {logiError = 1; _clientID publicVariableClient "logiError";};
 
-private _storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
+private _storage_areas = (_nearfob nearobjects GRLIB_fob_range) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
 
 if ((count _storage_areas) == 0) exitWith {(localize "STR_LOGISTIC_NOSPACE") remoteExec ["hint",_clientID]; logiError = 1; _clientID publicVariableClient "logiError";};
 

--- a/Missionframework/scripts/server/resources/manage_logistics.sqf
+++ b/Missionframework/scripts/server/resources/manage_logistics.sqf
@@ -25,7 +25,7 @@ while {GRLIB_endgame == 0} do {
                     if ((_x select 8) > 1) then {
                         switch (_x select 7) do {case 1: {_locPos = 2; _locRes = 4;}; case 3: {_locPos = 3; _locRes = 5;};};
                         switch (_x select 9) do {case 2: {_x set [9,0];}; case 3: {_x set [9,1];};};
-                        private _storage_areas = nearestObjects [(_x select _locPos), [KP_liberation_small_storage_building, KP_liberation_large_storage_building], GRLIB_fob_range];
+                        private _storage_areas = nearestObjects [(_x select _locPos), [KP_liberation_small_storage_building, KP_liberation_large_storage_building], 150];
 
                         if (((_x select 9) == 0) && !((_x select 6) isEqualTo [0,0,0])) then {
 
@@ -351,7 +351,7 @@ while {GRLIB_endgame == 0} do {
                     if ((_x select 8) > 1) then {
                         _locPos = switch (_x select 7) do {case 5: {2}; case 6: {3};};
                         _x set [9,0];
-                        private _storage_areas = nearestObjects [(_x select _locPos), [KP_liberation_small_storage_building, KP_liberation_large_storage_building], GRLIB_fob_range];
+                        private _storage_areas = nearestObjects [(_x select _locPos), [KP_liberation_small_storage_building, KP_liberation_large_storage_building], 150];
 
                         if ((count (_storage_areas)) == 0) exitWith {_x set [9,2];};
 

--- a/Missionframework/scripts/server/resources/manage_resources.sqf
+++ b/Missionframework/scripts/server/resources/manage_resources.sqf
@@ -29,7 +29,7 @@ while {GRLIB_endgame == 0} do {
             private _fuelValue = 0;
             private _time = _x select 8;
 
-            private _storage = nearestObjects [(markerPos (_x select 1)), [KP_liberation_small_storage_building], GRLIB_fob_range];
+            private _storage = nearestObjects [(markerPos (_x select 1)), [KP_liberation_small_storage_building], 100];
             _storage = _storage select {(_x getVariable ["KP_liberation_storage_type",-1]) == 1};
             if ((count _storage) > 0) then {
                 _storage = (_storage select 0);

--- a/Missionframework/scripts/server/resources/recalculate_resources.sqf
+++ b/Missionframework/scripts/server/resources/recalculate_resources.sqf
@@ -26,7 +26,7 @@ while {true} do {
     private _local_infantry_cap = 50 * GRLIB_resources_multiplier;
 
     {
-        private _fob_buildings = _x nearobjects (GRLIB_fob_range * 2);
+        private _fob_buildings = _x nearobjects GRLIB_fob_range;
         private _storage_areas = _fob_buildings select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
         private _heliSlots = {(typeOf _x) == KP_liberation_heli_slot_building;} count _fob_buildings;
         private _planeSlots = {(typeOf _x) == KP_liberation_plane_slot_building;} count _fob_buildings;

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ class Missions
 * Added: A kind of playerNamespace which sets some widely used variables to the player instead of running same checks in several scripts.
 * Added: `KPLIB_fnc_log` function to replace the usage of `diag_log` and apply prefix etc. at one place.
 * Added: Arma 3 High Command for commander, toggleable via parameters.
+* Added: Visual indicators of the FOB range while in build mode.
 * Removed: `action_manager.sqf` file was removed, due to new action handling.
 * Updated: Updated CUP presets to be inline with October 2019 stable build of CUP mods. Thanks to [Eogos](https://github.com/Eogos)
 * Updated: Turkish translation. Thanks to [654wak654](https://github.com/654wak654)
@@ -231,6 +232,7 @@ class Missions
 * Tweaked: Arsenal initialization on mission start improved.
 * Tweaked: `sector_manager.sqf` reworked as FSM.
 * Tweaked: Improved handling of captured/seized vehicles. Should also fix the rare issue with vanishing of captured enemy vehicles.
+* Tweaked: Set factory sectors range concerning storage areas to fix 100m instead of scaling with FOB build range.
 * Fixed: Some CUP presets had free buildable arsenals. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Wrong boat in CUP USMC Woodland preset. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Object inits will fire on units not only vehicles.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |

### Description:
Lowered the positive margin for the FOB ranges in saving, cleanup, recycle, etc.
Also set a fixed value for the range checks concerning production sectors for e.g. find the storage area of the sector.
Aims to lower the possiblity of unwanted behavior, if the FOB range is highly increased via config.
Furthermore I've added a simple visual aid for the FOB range while build mode is enabled. Maybe this also shows how large the default radius of 125m really is.

### Content:
- [x] Range adjustments for FOBs and factories
- [x] FOB build range indicators for build mode

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP