### PR TITLE
0.96.7 Changed array names in presets init

### DIFF
--- a/Missionframework/functions/fn_crateFromStorage.sqf
+++ b/Missionframework/functions/fn_crateFromStorage.sqf
@@ -2,7 +2,7 @@
     File: fn_crateFromStorage.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-03-27
-    Last Update: 2020-04-23
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,7 +24,7 @@ params [
 ];
 
 // Validate parameters
-if !(_cratetype in KP_liberation_crates) exitWith {["Invalid craty type given: %1", _cratetype] call BIS_fnc_error; false};
+if !(_cratetype in KPLIB_crates) exitWith {["Invalid craty type given: %1", _cratetype] call BIS_fnc_error; false};
 if (isNull _storage) exitWith {["Null object given"] call BIS_fnc_error; false};
 
 // Get correct storage positions
@@ -34,7 +34,7 @@ if (isNull _storage) exitWith {["Null object given"] call BIS_fnc_error; false};
 private _i = 0;
 private _dir = (getDir _storage) - 180;
 private _unloadPos = _storage getPos [_unloadDist, _dir];
-while {!((nearestObjects [_unloadPos, KP_liberation_crates, 1]) isEqualTo [])} do {
+while {!((nearestObjects [_unloadPos, KPLIB_crates, 1]) isEqualTo [])} do {
     _i = _i + 1;
     _unloadPos = _storage getPos [_unloadDist + _i * 1.8, _dir];
 };

--- a/Missionframework/functions/fn_createCrate.sqf
+++ b/Missionframework/functions/fn_createCrate.sqf
@@ -2,7 +2,7 @@
     File: fn_createCrate.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-11
-    Last Update: 2020-03-30
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,7 +24,7 @@ params [
 ];
 
 // Check if resource is valid
-if !(_resource in KP_liberation_crates) exitWith {
+if !(_resource in KPLIB_crates) exitWith {
     ["Invalid resource param given: %1", _resource] call BIS_fnc_error;
     objNull
 };

--- a/Missionframework/functions/fn_getGroupType.sqf
+++ b/Missionframework/functions/fn_getGroupType.sqf
@@ -2,7 +2,7 @@
     File: fn_getGroupType.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2019-12-05
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -39,11 +39,11 @@ if (_vehType isEqualTo "") exitWith {_grpType};
 
 // Otherwise continue to get the type of the vehicle
 [] call {
-    if (_vehType in (light_vehicles apply {_x select 0})) exitWith {_grpType = "light";};
-    if (_vehType in (air_vehicles apply {_x select 0})) exitWith {_grpType = "air";};
-    if (_vehType in (heavy_vehicles apply {_x select 0})) exitWith {_grpType = "heavy";};
-    if (_vehType in (support_vehicles apply {_x select 0})) exitWith {_grpType = "support";};
-    if (_vehType in (static_vehicles apply {_x select 0})) exitWith {_grpType = "static";};
+    if (_vehType in KPLIB_b_light_classes) exitWith {_grpType = "light";};
+    if (_vehType in KPLIB_b_heavy_classes) exitWith {_grpType = "heavy";};
+    if (_vehType in KPLIB_b_air_classes) exitWith {_grpType = "air";};
+    if (_vehType in KPLIB_b_static_classes) exitWith {_grpType = "static";};
+    if (_vehType in KPLIB_b_support_classes) exitWith {_grpType = "support";};
     if ([_vehType] call KPLIB_fnc_isClassUAV) exitWith {_grpType = "uav";};
 };
 

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-29
-    Last Update: 2020-04-21
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -34,7 +34,7 @@ private _allBlueGroups = allGroups select {
 {
     private _fobPos = _x;
     private _fobObjects = (_fobPos nearobjects (GRLIB_fob_range * 1.2)) select {
-        ((typeof _x) in KP_liberation_classnamesToSave) &&          // Exclude classnames which are not in the presets
+        ((typeof _x) in KPLIB_classnamesToSave) &&                  // Exclude classnames which are not in the presets
         {alive _x} &&                                               // Exclude dead or broken objects
         {getObjectType _x >= 8} &&                                  // Exclude preplaced terrain objects
         {speed _x < 5} &&                                           // Exclude moving objects (like civilians driving through)
@@ -42,10 +42,10 @@ private _allBlueGroups = allGroups select {
         {((getpos _x) select 2) < 10} &&                            // Exclude hovering helicopters and the like
         {!(_x getVariable ["KP_liberation_edenObject", false])} &&  // Exclude all objects placed via editor in mission.sqm
         {!(_x getVariable ["KP_liberation_preplaced", false])} &&   // Exclude preplaced (e.g. little birds from carrier)
-        {!((typeOf _x) in KP_liberation_crates)}                    // Exclude storage crates (those are handled separately)
+        {!((typeOf _x) in KPLIB_crates)}                            // Exclude storage crates (those are handled separately)
     };
 
-    _allObjects = _allObjects + (_fobObjects select {!((typeOf _x) in KP_liberation_storage_buildings)});
+    _allObjects = _allObjects + (_fobObjects select {!((typeOf _x) in KPLIB_storageBuildings)});
     _allStorages = _allStorages + (_fobObjects select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0});
 
     // Process all groups near this FOB
@@ -76,7 +76,7 @@ private _allBlueGroups = allGroups select {
     private _hascrew = false;
 
     // Determine if vehicle is crewed
-    if (_class in KP_liberation_bluforClassnames) then {
+    if (_class in KPLIB_b_allVeh_classes) then {
         if (({!isPlayer _x} count (crew _x) ) > 0) then {
             _hascrew = true;
         };
@@ -85,7 +85,7 @@ private _allBlueGroups = allGroups select {
     // Only save player side, seized or captured objects
     if (
         (!(_class in civilian_vehicles) || {_x getVariable ["KPLIB_seized", false]}) &&
-        (!(_class in all_hostile_classnames) || {_x getVariable ["KPLIB_captured", false]})
+        (!(_class in KPLIB_o_allVeh_classes) || {_x getVariable ["KPLIB_captured", false]})
     ) then {
         _objectsToSave pushBack [_class, _savedpos, _savedvecdir, _savedvecup, _hascrew];
     };

--- a/Missionframework/functions/fn_getSquadComp.sqf
+++ b/Missionframework/functions/fn_getSquadComp.sqf
@@ -2,7 +2,7 @@
     File: fn_getSquadComp.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2019-11-25
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,13 +24,13 @@ private _squadcomp = [];
 if (_type == "army") then {
     private _selected = false;
     private _randomchance = 0;
-    _squadcomp = opfor_squad_8_standard;
+    _squadcomp = KPLIB_o_squadStd;
 
     if (armor_weight > 40 && !_selected) then {
         _randomchance = (armor_weight - 35) * 1.4;
         if ((random 100) < _randomchance) then {
             _selected = true;
-            _squadcomp = opfor_squad_8_tankkillers;
+            _squadcomp = KPLIB_o_squadTank;
         };
     };
 
@@ -38,7 +38,7 @@ if (_type == "army") then {
         _randomchance = (air_weight - 35) * 1.4;
         if ((random 100) < _randomchance) then {
             _selected = true;
-            _squadcomp = opfor_squad_8_airkillers;
+            _squadcomp = KPLIB_o_squadAir;
         };
     };
 
@@ -46,7 +46,7 @@ if (_type == "army") then {
         _randomchance = (infantry_weight - 35) * 1.4;
         if ((random 100) < _randomchance) then {
             _selected = true;
-            _squadcomp = opfor_squad_8_infkillers;
+            _squadcomp = KPLIB_o_squadInf;
         };
     };
 } else {

--- a/Missionframework/functions/fn_handlePlacedZeusObject.sqf
+++ b/Missionframework/functions/fn_handlePlacedZeusObject.sqf
@@ -2,7 +2,7 @@
     File: fn_handlePlacedZeusObject.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-11
-    Last Update: 2020-04-11
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,7 +21,7 @@ params [
 // Identify kind of placed object once
 private _unit = _obj in allUnits;
 private _vehicle = _obj in vehicles;
-private _crate = (typeOf _obj) in KP_liberation_crates;
+private _crate = (typeOf _obj) in KPLIB_crates;
 
 // Exit if building and no resource crate
 if !(_unit || _vehicle || _crate) exitWith {false};

--- a/Missionframework/functions/fn_setVehicleCaptured.sqf
+++ b/Missionframework/functions/fn_setVehicleCaptured.sqf
@@ -2,7 +2,7 @@
     File: fn_setVehicleCaptured.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-10
-    Last Update: 2020-04-20
+    Last Update: 2020-04-24
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,7 +24,7 @@ if (isNull _veh) exitWith {["Null object given"] call BIS_fnc_error; false};
 
 private _type = typeOf _veh:
 
-if !(_type in all_hostile_classnames) exitWith {false};
+if !(_type in KPLIB_o_allVeh_classes) exitWith {false};
 
 if !(_veh getVariable ["KPLIB_captured", false]) then {
     _veh setVariable ["KPLIB_captured", true, true];

--- a/Missionframework/kp_liberation_config.sqf
+++ b/Missionframework/kp_liberation_config.sqf
@@ -493,7 +493,7 @@ KP_liberation_allowed_items_extension = [
 
 /* - Configuration settings for crates transported by vehicles.
 Format = ["classname", distance behind vehicle to unload crate, attachTo positions for each box],    */
-box_transport_config = [
+KPLIB_transportConfigs = [
     ["B_Heli_Transport_03_F", -8, [0,2.2,-1], [0,0.5,-1], [0,-1.2,-1]],
     ["B_Heli_Transport_03_unarmed_F", -8, [0,2.2,-1], [0,0.5,-1], [0,-1.2,-1]],
     ["B_T_Truck_01_cargo_F", -6.5, [0,-0.4,0.4], [0,-2.1,0.4], [0,-3.8,0.4]],
@@ -663,7 +663,7 @@ box_transport_config = [
 
 /* Various other settings.
 Everything the AI troups should be able to resupply from. */
-ai_resupply_sources = [
+KPLIB_aiResupplySources = [
     "B_APC_Tracked_01_CRV_F",
     "B_Slingload_01_Ammo_F",
     "B_T_APC_Tracked_01_CRV_F",

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -81,13 +81,23 @@ switch (KP_liberation_preset_civilians) do {
 };
 
 // Prices for the blufor infantry squads (supplies, ammo, fuel)
-squads = [
+KPLIB_b_allSquads = [
     [blufor_squad_inf_light,200,0,0],
     [blufor_squad_inf,300,0,0],
     [blufor_squad_at,200,250,0],
     [blufor_squad_aa,200,250,0],
     [blufor_squad_recon,250,0,0],
     [blufor_squad_para,200,0,0]
+];
+
+// Squad names for build menu
+squads_names = [
+    localize "STR_LIGHT_RIFLE_SQUAD",
+    localize "STR_RIFLE_SQUAD",
+    localize "STR_AT_SQUAD",
+    localize "STR_AA_SQUAD",
+    localize "STR_RECON_SQUAD",
+    localize "STR_PARA_SQUAD"
 ];
 
 // Classnames of objects which should be ignored when building
@@ -143,92 +153,155 @@ GRLIB_ignore_colisions_when_building = [
     "ACE_friesGantry"                                                   // ACE FRIES
 ];
 
+/*
+    Checking all preset arrays for missing mods and sort out not available classnames
+*/
+// Blufor
+infantry_units                              = infantry_units                            select {[( _x select 0)] call KPLIB_fnc_checkClass};
+light_vehicles                              = light_vehicles                            select {[( _x select 0)] call KPLIB_fnc_checkClass};
+heavy_vehicles                              = heavy_vehicles                            select {[( _x select 0)] call KPLIB_fnc_checkClass};
+air_vehicles                                = air_vehicles                              select {[( _x select 0)] call KPLIB_fnc_checkClass};
+static_vehicles                             = static_vehicles                           select {[( _x select 0)] call KPLIB_fnc_checkClass};
+buildings                                   = buildings                                 select {[( _x select 0)] call KPLIB_fnc_checkClass};
+support_vehicles                            = support_vehicles                          select {[( _x select 0)] call KPLIB_fnc_checkClass};
+blufor_squad_inf_light                      = blufor_squad_inf_light                    select {[_x] call KPLIB_fnc_checkClass};
+blufor_squad_inf                            = blufor_squad_inf                          select {[_x] call KPLIB_fnc_checkClass};
+blufor_squad_at                             = blufor_squad_at                           select {[_x] call KPLIB_fnc_checkClass};
+blufor_squad_aa                             = blufor_squad_aa                           select {[_x] call KPLIB_fnc_checkClass};
+blufor_squad_recon                          = blufor_squad_recon                        select {[_x] call KPLIB_fnc_checkClass};
+blufor_squad_para                           = blufor_squad_para                         select {[_x] call KPLIB_fnc_checkClass};
+elite_vehicles                              = elite_vehicles                            select {[_x] call KPLIB_fnc_checkClass};
 
+// Opfor
+militia_squad                               = militia_squad                             select {[_x] call KPLIB_fnc_checkClass};
+militia_vehicles                            = militia_vehicles                          select {[_x] call KPLIB_fnc_checkClass};
+opfor_vehicles                              = opfor_vehicles                            select {[_x] call KPLIB_fnc_checkClass};
+opfor_vehicles_low_intensity                = opfor_vehicles_low_intensity              select {[_x] call KPLIB_fnc_checkClass};
+opfor_battlegroup_vehicles                  = opfor_battlegroup_vehicles                select {[_x] call KPLIB_fnc_checkClass};
+opfor_battlegroup_vehicles_low_intensity    = opfor_battlegroup_vehicles_low_intensity  select {[_x] call KPLIB_fnc_checkClass};
+opfor_troup_transports                      = opfor_troup_transports                    select {[_x] call KPLIB_fnc_checkClass};
+opfor_choppers                              = opfor_choppers                            select {[_x] call KPLIB_fnc_checkClass};
+opfor_air                                   = opfor_air                                 select {[_x] call KPLIB_fnc_checkClass};
 
-/* !!! DO NOT EDIT BELOW !!! */
-// Preset arrays
-infantry_units = infantry_units select {[( _x select 0)] call KPLIB_fnc_checkClass};
-light_vehicles = light_vehicles select {[( _x select 0)] call KPLIB_fnc_checkClass};
-heavy_vehicles = heavy_vehicles select {[( _x select 0)] call KPLIB_fnc_checkClass};
-air_vehicles = air_vehicles select {[( _x select 0)] call KPLIB_fnc_checkClass};
-support_vehicles = support_vehicles select {[( _x select 0)] call KPLIB_fnc_checkClass};
-static_vehicles = static_vehicles select {[( _x select 0)] call KPLIB_fnc_checkClass};
-buildings = buildings select {[( _x select 0)] call KPLIB_fnc_checkClass};
-elite_vehicles = elite_vehicles select {[_x] call KPLIB_fnc_checkClass};
+// Resistance
+KP_liberation_guerilla_units                = KP_liberation_guerilla_units              select {[_x] call KPLIB_fnc_checkClass};
+KP_liberation_guerilla_vehicles             = KP_liberation_guerilla_vehicles           select {[_x] call KPLIB_fnc_checkClass};
 
-// Preset classes arrays
-light_vehicles_classes = light_vehicles apply {toLower (_x select 0)};
-heavy_vehicles_classes = heavy_vehicles apply {toLower (_x select 0)};
-air_vehicles_classes = air_vehicles apply {toLower (_x select 0)};
+// Civilians
+civilians                                   = civilians                                 select {[_x] call KPLIB_fnc_checkClass};
+civilian_vehicles                           = civilian_vehicles                         select {[_x] call KPLIB_fnc_checkClass};
 
-// Detect type of Potato 01 and support vehicles
+// Misc
+KPLIB_transportConfigs                      = KPLIB_transportConfigs                    select {[_x select 0] call KPLIB_fnc_checkClass};
+KPLIB_aiResupplySources                     = KPLIB_aiResupplySources                   select {[_x] call KPLIB_fnc_checkClass};
+
+/*
+    Fetch arrays with only classnames from the blufor preset build arrays
+*/
+KPLIB_b_infantry_classes                    = infantry_units                            apply {toLower (_x select 0)};
+KPLIB_b_light_classes                       = light_vehicles                            apply {toLower (_x select 0)};
+KPLIB_b_heavy_classes                       = heavy_vehicles                            apply {toLower (_x select 0)};
+KPLIB_b_air_classes                         = air_vehicles                              apply {toLower (_x select 0)};
+KPLIB_b_static_classes                      = static_vehicles                           apply {toLower (_x select 0)};
+KPLIB_b_buildings_classes                   = buildings                                 apply {toLower (_x select 0)};
+KPLIB_b_support_classes                     = support_vehicles                          apply {toLower (_x select 0)};
+KPLIB_transport_classes                     = KPLIB_transportConfigs                    apply {toLower (_x select 0)};
+
+KPLIB_b_infantry_classes append (blufor_squad_inf_light + blufor_squad_inf + blufor_squad_at + blufor_squad_aa + blufor_squad_recon + blufor_squad_para);
+KPLIB_b_infantry_classes                    = KPLIB_b_infantry_classes                  arrayIntersect KPLIB_b_infantry_classes;
+
+/*
+    Opfor squad compositions
+*/
+KPLIB_o_squadStd    = [opfor_squad_leader, opfor_medic, opfor_machinegunner, opfor_heavygunner, opfor_medic, opfor_marksman, opfor_grenadier, opfor_rpg];
+KPLIB_o_squadInf    = [opfor_squad_leader, opfor_medic, opfor_machinegunner, opfor_heavygunner, opfor_heavygunner, opfor_marksman, opfor_sharpshooter, opfor_sniper];
+KPLIB_o_squadTank   = [opfor_squad_leader, opfor_medic, opfor_machinegunner, opfor_rpg, opfor_rpg, opfor_at, opfor_at, opfor_at];
+KPLIB_o_squadAir    = [opfor_squad_leader, opfor_medic, opfor_machinegunner, opfor_rpg, opfor_rpg, opfor_aa, opfor_aa, opfor_aa];
+
+/*
+    Liberation specific collections
+*/
+KPLIB_buildList         = [[], infantry_units, light_vehicles, heavy_vehicles, air_vehicles, static_vehicles, buildings, support_vehicles, KPLIB_b_allSquads];
+KPLIB_crates            = [KP_liberation_supply_crate, KP_liberation_ammo_crate, KP_liberation_fuel_crate];
+KPLIB_airSlots          = [KP_liberation_heli_slot_building, KP_liberation_plane_slot_building];
+KPLIB_storageBuildings  = [KP_liberation_small_storage_building, KP_liberation_large_storage_building];
+KPLIB_upgradeBuildings  = [KP_liberation_recycle_building, KP_liberation_air_vehicle_building, KP_liberation_heli_slot_building, KP_liberation_plane_slot_building];
+KPLIB_aiResupplySources append [Respawn_truck_typename, huron_typename, Arsenal_typename];
+
+/*
+    Classname collections
+*/
+// All land vehicle classnames
+KPLIB_allLandVeh_classes = [[], [huron_typename]] select (huron_typename isKindOf "Air");;
 {
-    _x params ["_class"];
+    KPLIB_allLandVeh_classes append _x;
+} forEach [
+    militia_vehicles,
+    opfor_vehicles,
+    opfor_vehicles_low_intensity,
+    opfor_battlegroup_vehicles,
+    opfor_battlegroup_vehicles_low_intensity,
+    opfor_troup_transports,
+    KPLIB_b_light_classes,
+    KPLIB_b_heavy_classes,
+    KPLIB_b_support_classes select {_x isKindOf "Car" || _x isKindOf "Tank"}
+];
+KPLIB_allLandVeh_classes = KPLIB_allLandVeh_classes arrayIntersect KPLIB_allLandVeh_classes;
+
+// All air vehicle classnames
+KPLIB_allAirVeh_classes = [[], [huron_typename]] select (huron_typename isKindOf "Air");
+{
+    KPLIB_allAirVeh_classes append _x;
+} forEach [opfor_choppers, opfor_air, KPLIB_b_air_classes, KPLIB_b_support_classes select {_x isKindOf "Air"}];
+
+// All blufor vehicle (land and air) classnames
+KPLIB_b_allVeh_classes = [];
+{
+    KPLIB_b_allVeh_classes append _x;
+} forEach [KPLIB_b_light_classes, KPLIB_b_heavy_classes, KPLIB_b_air_classes, KPLIB_b_static_classes, KPLIB_b_support_classes];
+
+// All opfor vehicle (land and air) classnames
+KPLIB_o_allVeh_classes  = [];
+{
+    KPLIB_o_allVeh_classes append _x;
+} forEach [
+    militia_vehicles,
+    opfor_vehicles,
+    opfor_vehicles_low_intensity,
+    opfor_battlegroup_vehicles,
+    opfor_battlegroup_vehicles_low_intensity,
+    opfor_troup_transports,
+    opfor_choppers,
+    opfor_air
+];
+KPLIB_o_allVeh_classes = KPLIB_o_allVeh_classes arrayIntersect KPLIB_o_allVeh_classes;
+
+// All regular opfor soldier classnames
+KPLIB_o_inf_classes = [opfor_sentry, opfor_rifleman, opfor_grenadier, opfor_squad_leader, opfor_team_leader, opfor_marksman, opfor_machinegunner, opfor_heavygunner, opfor_medic, opfor_rpg, opfor_at, opfor_aa, opfor_officer, opfor_sharpshooter, opfor_sniper,opfor_engineer];
+
+/*
+    Vehicle type permission arrays
+*/
+KPLIB_typeLightClasses = +KPLIB_b_light_classes;
+KPLIB_typeHeavyClasses = +KPLIB_b_heavy_classes;
+KPLIB_typeAirClasses   = +KPLIB_b_air_classes;
+{
     switch (true) do {
-        case (_class isKindOf "Tank"): {heavy_vehicles_classes pushBack toLower _class};
-        case (_class isKindOf "Air"): {air_vehicles_classes pushBack toLower _class};
-        default {light_vehicles_classes pushBack toLower _class};
+        case (_x isKindOf "Tank"):  {KPLIB_typeHeavyClasses    pushBack _x};
+        case (_x isKindOf "Air"):   {KPLIB_typeAirClasses      pushBack _x};
+        default                     {KPLIB_typeLightClasses    pushBack _x};
     };
-} forEach support_vehicles + [huron_typename];
+} forEach (KPLIB_b_support_classes + [huron_typename]);
 
-build_lists = [[], infantry_units, light_vehicles, heavy_vehicles, air_vehicles, static_vehicles, buildings, support_vehicles, squads];
-KP_liberation_storage_buildings = [KP_liberation_small_storage_building, KP_liberation_large_storage_building];
-KP_liberation_crates = [KP_liberation_supply_crate, KP_liberation_ammo_crate, KP_liberation_fuel_crate];
-KP_liberation_upgrade_buildings = [KP_liberation_recycle_building, KP_liberation_air_vehicle_building, KP_liberation_heli_slot_building, KP_liberation_plane_slot_building];
-KP_liberation_air_slots = [KP_liberation_heli_slot_building, KP_liberation_plane_slot_building];
+// Military alphabet used for FOBs and convois
+military_alphabet = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-Ray", "Yankee", "Zulu"];
 
-militia_squad = militia_squad select {[_x] call KPLIB_fnc_checkClass};
-militia_vehicles = militia_vehicles select {[_x] call KPLIB_fnc_checkClass};
-opfor_vehicles = opfor_vehicles select {[_x] call KPLIB_fnc_checkClass};
-opfor_vehicles_low_intensity = opfor_vehicles_low_intensity select {[_x] call KPLIB_fnc_checkClass};
-opfor_battlegroup_vehicles = opfor_battlegroup_vehicles select {[_x] call KPLIB_fnc_checkClass};
-opfor_battlegroup_vehicles_low_intensity = opfor_battlegroup_vehicles_low_intensity select {[_x] call KPLIB_fnc_checkClass};
-opfor_troup_transports = opfor_troup_transports select {[_x] call KPLIB_fnc_checkClass};
-opfor_choppers = opfor_choppers select {[_x] call KPLIB_fnc_checkClass};
-opfor_air = opfor_air select {[_x] call KPLIB_fnc_checkClass};
-
-civilians = civilians select {[_x] call KPLIB_fnc_checkClass};
-civilian_vehicles = civilian_vehicles select {[_x] call KPLIB_fnc_checkClass};
-
-opfor_squad_8_standard = [opfor_squad_leader,opfor_team_leader,opfor_machinegunner,opfor_heavygunner,opfor_medic,opfor_marksman,opfor_grenadier,opfor_rpg];
-opfor_squad_8_infkillers = [opfor_squad_leader,opfor_machinegunner,opfor_machinegunner,opfor_heavygunner,opfor_medic,opfor_marksman,opfor_sharpshooter,opfor_sniper];
-opfor_squad_8_tankkillers = [opfor_squad_leader,opfor_medic,opfor_machinegunner,opfor_rpg,opfor_rpg,opfor_at,opfor_at,opfor_at];
-opfor_squad_8_airkillers = [opfor_squad_leader,opfor_medic,opfor_machinegunner,opfor_rpg,opfor_rpg,opfor_aa,opfor_aa,opfor_aa];
-
-friendly_infantry_classnames = ((infantry_units apply {_x select 0}) + blufor_squad_inf_light + blufor_squad_inf + blufor_squad_at + blufor_squad_aa + blufor_squad_recon + blufor_squad_para);
-friendly_infantry_classnames = friendly_infantry_classnames arrayIntersect friendly_infantry_classnames;
-
-land_vehicles_classnames = (opfor_vehicles + opfor_vehicles_low_intensity + militia_vehicles);
-all_hostile_classnames = (land_vehicles_classnames + opfor_air + opfor_choppers + opfor_troup_transports);
-all_hostile_classnames = all_hostile_classnames arrayIntersect all_hostile_classnames;
-
-land_vehicles_classnames append (light_vehicles apply {_x select 0});
-land_vehicles_classnames append (heavy_vehicles apply {_x select 0});
-land_vehicles_classnames = land_vehicles_classnames arrayIntersect land_vehicles_classnames;
-
-air_vehicles_classnames = +opfor_choppers;
-KP_liberation_friendly_air_classnames = air_vehicles apply {_x select 0};
-air_vehicles_classnames append KP_liberation_friendly_air_classnames;
-
-KP_liberation_friendly_air_classnames = KP_liberation_friendly_air_classnames select {!(_x call KPLIB_fnc_isClassUAV)};
-
-KP_liberation_static_classnames = static_vehicles apply {_x select 0};
-
-ai_resupply_sources append [Respawn_truck_typename, huron_typename, Arsenal_typename];
-
+// Misc variables
 markers_reset = [99999,99999,0];
 zeropos = [0,0,0];
-
-box_transport_config = box_transport_config select {[_x select 0] call KPLIB_fnc_checkClass};
-ammobox_transports_typenames = box_transport_config apply {_x select 0};
-
-opfor_infantry = [opfor_sentry, opfor_rifleman, opfor_grenadier, opfor_squad_leader, opfor_team_leader, opfor_marksman, opfor_machinegunner, opfor_heavygunner, opfor_medic, opfor_rpg, opfor_at, opfor_aa, opfor_officer, opfor_sharpshooter, opfor_sniper,opfor_engineer];
-
-GRLIB_intel_file = "Land_File1_F";
-GRLIB_intel_laptop = "Land_Laptop_device_F";
-GRLIB_sar_wreck = "Land_Wreck_Heli_Attack_01_F";
-GRLIB_sar_fire = "test_EmptyObjectForFireBig";
-military_alphabet = ["Alpha","Bravo","Charlie","Delta","Echo","Foxtrot","Golf","Hotel","India","Juliet","Kilo","Lima","Mike","November","Oscar","Papa","Quebec","Romeo","Sierra","Tango","Uniform","Victor","Whiskey","X-Ray","Yankee","Zulu"];
-squads_names = [localize "STR_LIGHT_RIFLE_SQUAD", localize "STR_RIFLE_SQUAD", localize "STR_AT_SQUAD", localize "STR_AA_SQUAD", localize "STR_RECON_SQUAD", localize "STR_PARA_SQUAD"];
+KPLIB_intelFile = "Land_File1_F";
+KPLIB_intelLaptop = "Land_Laptop_device_F";
+KPLIB_sarWreck = "Land_Wreck_Heli_Attack_01_F";
+KPLIB_sarFire = "test_EmptyObjectForFireBig";
 
 if (isServer) then {[format ["----- Preset initialization finished. Time needed: %1 seconds -----", diag_ticktime - _start], "PRESETS"] call KPLIB_fnc_log;};

--- a/Missionframework/scripts/client/actions/do_recycle.sqf
+++ b/Missionframework/scripts/client/actions/do_recycle.sqf
@@ -12,9 +12,9 @@ private _ammoMulti = 0.5;
 private _fuelMulti = 0.5;
 
 if !(
-    (_type in (buildings apply {_x select 0})) ||
-    (_type in KP_liberation_storage_buildings) ||
-    (_type in KP_liberation_upgrade_buildings) ||
+    (_type in KPLIB_b_buildings_classes) ||
+    (_type in KPLIB_storageBuildings) ||
+    (_type in KPLIB_upgradeBuildings) ||
     (_type in KP_liberation_ace_crates) ||
     (_type == "B_Slingload_01_Repair_F") ||
     (_type == "B_Slingload_01_Fuel_F") ||
@@ -44,7 +44,7 @@ private _price_s = 0;
 private _price_a = 0;
 private _price_f = 0;
 
-if (_type in all_hostile_classnames) then {
+if (_type in KPLIB_o_allVeh_classes) then {
     if (_vehToRecycle isKindOf "Car") then {
         _price_s = round (60 * _suppMulti);
         _price_a = round (25 * _ammoMulti);

--- a/Missionframework/scripts/client/actions/intel_manager.sqf
+++ b/Missionframework/scripts/client/actions/intel_manager.sqf
@@ -10,7 +10,7 @@ private _actionned_intel_items = [];
 while {true} do {
     if ([5] call KPLIB_fnc_hasPermission) then {
         _near_people = (getPosATL player) nearEntities [["Man"], 5];
-        _near_intel = (getPosATL player) nearEntities [[GRLIB_intel_laptop, GRLIB_intel_file], 5];
+        _near_intel = (getPosATL player) nearEntities [[KPLIB_intelLaptop, KPLIB_intelFile], 5];
         {
             if ((captive _x) && !(_x in _actionned_captive_units) && !((side group _x) == GRLIB_side_friendly) && !(_x getVariable ["ACE_isUnconscious", false])) then {
                 _x addAction ["<t color='#FFFF00'>" + localize "STR_SECONDARY_CAPTURE" + "</t>",{[_this select 0] join (group player);},"",-850,true,true,"","(vehicle player == player) && (side group _target != GRLIB_side_friendly) && (captive _target)"];

--- a/Missionframework/scripts/client/actions/recycle_manager.sqf
+++ b/Missionframework/scripts/client/actions/recycle_manager.sqf
@@ -4,16 +4,15 @@ veh_action_detect_distance = 20;
 veh_action_distance = 10;
 
 {
-    _recycleable_classnames pushBack ( _x select 0 );
-} foreach (light_vehicles + heavy_vehicles + air_vehicles + static_vehicles + support_vehicles);
-
-_recycleable_classnames append all_hostile_classnames;
-
-private _building_classnames = [];
-{
-    _building_classnames pushBack ( _x select 0 );
-} foreach (buildings);
-_building_classnames = _building_classnames + ["B_Slingload_01_Cargo_F", "B_Slingload_01_Repair_F", "B_Slingload_01_Fuel_F", "B_Slingload_01_Ammo_F"];
+    _recycleable_classnames append _x;
+} forEach [
+    KPLIB_b_light_classes,
+    KPLIB_b_heavy_classes,
+    KPLIB_b_air_classes,
+    KPLIB_b_static_classes,
+    KPLIB_b_support_classes,
+    KPLIB_o_allVeh_classes
+];
 
 while {true} do {
     waitUntil {sleep 2; player getVariable ['KPLIB_fobDist', 99999] < GRLIB_fob_range};
@@ -21,9 +20,9 @@ while {true} do {
     if ([4] call KPLIB_fnc_hasPermission) then {
         private _detected_vehicles = (getPos player) nearObjects veh_action_detect_distance select {
             (((typeof _x in _recycleable_classnames ) && (({alive _x} count (crew _x)) == 0 || (unitIsUAV _x)) && ((locked _x == 0 || locked _x == 1))) ||
-            ((typeOf _x) in _building_classnames) ||
-            (((typeOf _x) in KP_liberation_storage_buildings) && ((_x getVariable ["KP_liberation_storage_type",-1]) == 0)) ||
-            ((typeOf _x) in KP_liberation_upgrade_buildings) ||
+            ((typeOf _x) in KPLIB_b_buildings_classes) ||
+            (((typeOf _x) in KPLIB_storageBuildings) && ((_x getVariable ["KP_liberation_storage_type",-1]) == 0)) ||
+            ((typeOf _x) in KPLIB_upgradeBuildings) ||
             ((typeOf _x) in KP_liberation_ace_crates)) &&
             (alive _x) &&
             (

--- a/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
+++ b/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
@@ -14,9 +14,9 @@ while {true} do {
 
     if ([5] call KPLIB_fnc_hasPermission) then {
 
-        _nearammoboxes = ((getpos player) nearEntities [KP_liberation_crates,10]);
-        _neartransporttrucks = ((getpos player) nearEntities [ammobox_transports_typenames,10]);
-        _nearstorageareas = nearestObjects [player,KP_liberation_storage_buildings,10];
+        _nearammoboxes = ((getpos player) nearEntities [KPLIB_crates, 10]);
+        _neartransporttrucks = ((getpos player) nearEntities [KPLIB_transport_classes, 10]);
+        _nearstorageareas = nearestObjects [player, KPLIB_storageBuildings, 10];
 
         _checked_trucks = [];
 
@@ -54,7 +54,7 @@ while {true} do {
             _next_box = _x;
             if (!(_next_box in _managed_boxes) && ( isNull  attachedTo _next_box )) then {
                 _b_action_id1 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",{[_this select 0] call do_load_box;},"",-501,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
-                _b_action_id2 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",{[(_this select 0), (nearestObjects [player,KP_liberation_storage_buildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},"",-502,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                _b_action_id2 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",{[(_this select 0), (nearestObjects [player,KPLIB_storageBuildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},"",-502,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
                 _b_action_id3 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_VALUE" + "</t>",{[_this select 0] call KPLIB_fnc_checkCrateValue;uiSleep 3; hint "";},"",-503,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
                 _b_action_id4 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_PUSH" + "</t>",{(_this select 0) setPos ((_this select 0) getPos [1, (player getDir (_this select 0))]);},"",-504,true,false,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
                 _next_box setVariable ["GRLIB_ammo_box_action", _b_action_id1, false];

--- a/Missionframework/scripts/client/ammoboxes/do_load_box.sqf
+++ b/Missionframework/scripts/client/ammoboxes/do_load_box.sqf
@@ -2,7 +2,7 @@ params [ "_ammobox", ["_max_transport_distance", 15] ];
 private [ "_neartransporttrucks", "_truck_to_load", "_truck_load", "_next_truck", "_maxload", "_i" ];
 
 _maxload = 3;
-_neartransporttrucks = ((getpos _ammobox) nearEntities [ ammobox_transports_typenames, _max_transport_distance]) select {alive _x && speed _x < 5 && ((getpos _x) select 2) < 5};
+_neartransporttrucks = ((getpos _ammobox) nearEntities [KPLIB_transport_classes, _max_transport_distance]) select {alive _x && speed _x < 5 && ((getpos _x) select 2) < 5};
 _truck_to_load = objNull;
 
 
@@ -15,7 +15,7 @@ _truck_to_load = objNull;
             _maxload = (count _x) - 2;
             for [ {_i=2}, {_i < (count _x) }, {_i=_i+1} ] do { _offsets pushback (_x select _i); };
         };
-    } foreach box_transport_config;
+    } foreach KPLIB_transportConfigs;
 
     if ( isNull _truck_to_load ) then {
         _truck_load = _next_truck getVariable ["GRLIB_ammo_truck_load", 0];

--- a/Missionframework/scripts/client/ammoboxes/do_unload_truck.sqf
+++ b/Missionframework/scripts/client/ammoboxes/do_unload_truck.sqf
@@ -5,7 +5,7 @@ _offset = 0;
 
 {
     if ( _x select 0 == typeof _truck_to_unload ) then { _offset = _x select 1; };
-} foreach box_transport_config;
+} foreach KPLIB_transportConfigs;
 
 if ( _truck_to_unload getVariable ["GRLIB_ammo_truck_load", 0] > 0 ) then {
     _truck_to_unload setVariable ["GRLIB_ammo_truck_load", 0, true];

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -34,10 +34,10 @@ while { true } do {
     if ( buildtype == 99 ) then {
         _classname = FOB_typename;
     } else {
-        _classname = ((build_lists select buildtype) select buildindex) select 0;
-        _price_s = ((build_lists select buildtype) select buildindex) select 1;
-        _price_a = ((build_lists select buildtype) select buildindex) select 2;
-        _price_f = ((build_lists select buildtype) select buildindex) select 3;
+        _classname = ((KPLIB_buildList select buildtype) select buildindex) select 0;
+        _price_s = ((KPLIB_buildList select buildtype) select buildindex) select 1;
+        _price_a = ((KPLIB_buildList select buildtype) select buildindex) select 2;
+        _price_f = ((KPLIB_buildList select buildtype) select buildindex) select 3;
 
         _nearfob = [] call KPLIB_fnc_getNearestFob;
         _storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
@@ -89,7 +89,7 @@ while { true } do {
             if (buildtype == 6 ) then {
                 _idactplacebis = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT_BIS" + "</t> <img size='2' image='res\ui_confirm.paa'/>",{build_confirmed = 2; repeatbuild = true; hint localize "STR_CONFIRM_HINT";},"",-785,false,false,"","build_invalid == 0 && build_confirmed == 1"];
             };
-            if (buildtype == 6 || buildtype == 99  || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+            if (buildtype == 6 || buildtype == 99  || _classname in KPLIB_storageBuildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
                 _idactsnap = player addAction ["<t color='#B0FF00'>" + localize "STR_GRID" + "</t>",{gridmode = gridmode + 1;},"",-735,false,false,"","build_confirmed == 1"];
                 _idactvector = player addAction ["<t color='#B0FF00'>" + localize "STR_VECACTION" + "</t>",{KP_vector = !KP_vector;},"",-800,false,false,"","build_confirmed == 1"];
             };
@@ -119,7 +119,7 @@ while { true } do {
 
             while { build_confirmed == 1 && alive player } do {
                 _truedir = 90 - (getdir player);
-                if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
+                if ((typeOf _vehicle) in KPLIB_b_static_classes) then {
                     _truepos = [((getposATL player) select 0) + (_dist * (cos _truedir)), ((getposATL player) select 1) + (_dist * (sin _truedir)),((getposATL player) select 2)];
                 } else {
                     _truepos = [((getpos player) select 0) + (_dist * (cos _truedir)), ((getpos player) select 1) + (_dist * (sin _truedir)),0];
@@ -171,7 +171,7 @@ while { true } do {
                 private _remove_objects = [];
                 {
                     private _typeOfX = typeOf _x;
-                    if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+                    if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KPLIB_b_static_classes)) then {
                         _remove_objects pushback _x;
                     };
                 } foreach _near_objects;
@@ -179,7 +179,7 @@ while { true } do {
                 private _remove_objects_25 = [];
                 {
                     private _typeOfX = typeOf _x;
-                    if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+                    if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KPLIB_b_static_classes)) then {
                         _remove_objects_25 pushback _x;
                     };
                 } foreach _near_objects_25;
@@ -208,13 +208,13 @@ while { true } do {
                     if ( ((buildtype == 6) || (buildtype == 99)) && ((gridmode % 2) == 1) ) then {
                         _vehicle setpos [round (_truepos select 0),round (_truepos select 1), _truepos select 2];
                     } else {
-                        if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
+                        if ((typeOf _vehicle) in KPLIB_b_static_classes) then {
                             _vehicle setPosATL _truepos;
                         } else {
                             _vehicle setpos _truepos;
                         };
                     };
-                    if (buildtype == 6 || buildtype == 99 || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                    if (buildtype == 6 || buildtype == 99 || _classname in KPLIB_storageBuildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
                         if (KP_vector) then {
                             _vehicle setVectorUp [0,0,1];
                         } else {
@@ -263,9 +263,9 @@ while { true } do {
 
             if ( !alive player || build_confirmed == 3 ) then {
                 private ["_price_s", "_price_a", "_price_f", "_nearfob", "_storage_areas"];
-                _price_s = ((build_lists select buildtype) select buildindex) select 1;
-                _price_a = ((build_lists select buildtype) select buildindex) select 2;
-                _price_f = ((build_lists select buildtype) select buildindex) select 3;
+                _price_s = ((KPLIB_buildList select buildtype) select buildindex) select 1;
+                _price_a = ((KPLIB_buildList select buildtype) select buildindex) select 2;
+                _price_f = ((KPLIB_buildList select buildtype) select buildindex) select 3;
 
                 _nearfob = [] call KPLIB_fnc_getNearestFob;
                 _storage_areas = (_nearfob nearobjects (GRLIB_fob_range * 2)) select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0};
@@ -303,7 +303,7 @@ while { true } do {
                 _vehicle = _classname createVehicle _truepos;
                 _vehicle allowDamage false;
                 _vehicle setdir _vehdir;
-                if ((typeOf _vehicle) in KP_liberation_static_classnames) then {
+                if ((typeOf _vehicle) in KPLIB_b_static_classes) then {
                     _vehicle setPosATL _truepos;
                 } else {
                     _vehicle setpos _truepos;
@@ -311,7 +311,7 @@ while { true } do {
 
                 [_vehicle] call KPLIB_fnc_clearCargo;
 
-                if (buildtype == 6 || buildtype == 99 || _classname in KP_liberation_storage_buildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                if (buildtype == 6 || buildtype == 99 || _classname in KPLIB_storageBuildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
                     if (KP_vector) then {
                         _vehicle setVectorUp [0,0,1];
                     } else {

--- a/Missionframework/scripts/client/build/open_build_menu.sqf
+++ b/Missionframework/scripts/client/build/open_build_menu.sqf
@@ -37,7 +37,7 @@ _nearfob = [] call KPLIB_fnc_getNearestFob;
 _actual_fob = KP_liberation_fob_resources select {((_x select 0) distance _nearfob) < GRLIB_fob_range};
 
 while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
-    _build_list = build_lists select buildtype;
+    _build_list = KPLIB_buildList select buildtype;
 
     if (_oldbuildtype != buildtype || synchro_done) then {
         synchro_done = false;
@@ -127,7 +127,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
             ((_build_item select 2 == 0 ) || ((_build_item select 2) <= ((_actual_fob select 0) select 2))) &&
             ((_build_item select 3 == 0 ) || ((_build_item select 3) <= ((_actual_fob select 0) select 3)))
         ) then {
-            if (((_build_item select 0) in KP_liberation_friendly_air_classnames) && !([_build_item select 0] call KPLIB_fnc_isClassUAV)) then {
+            if (((_build_item select 0) in KPLIB_b_air_classes) && !([_build_item select 0] call KPLIB_fnc_isClassUAV)) then {
                 if (KP_liberation_air_vehicle_building_near &&
                     ((((_build_item select 0) isKindOf "Helicopter") && (KP_liberation_heli_count < KP_liberation_heli_slots)) ||
                     (((_build_item select 0) isKindOf "Plane") && (KP_liberation_plane_count < KP_liberation_plane_slots)))
@@ -135,7 +135,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
                     _affordable = true;
                 };
             } else {
-                if (!((_build_item select 0) in KP_liberation_air_slots) || (((_build_item select 0) in KP_liberation_air_slots) && KP_liberation_air_vehicle_building_near)) then {
+                if (!((_build_item select 0) in KPLIB_airSlots) || (((_build_item select 0) in KPLIB_airSlots) && KP_liberation_air_vehicle_building_near)) then {
                     _affordable = true;
                 };
             };

--- a/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
+++ b/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
@@ -8,17 +8,14 @@ _vehtomark = [];
 _support_to_skip = [
     KP_liberation_recycle_building,
     KP_liberation_air_vehicle_building,
-    KP_liberation_supply_crate,
-    KP_liberation_ammo_crate,
-    KP_liberation_fuel_crate,
     "B_Slingload_01_Repair_F",
     "B_Slingload_01_Fuel_F",
     "B_Slingload_01_Ammo_F"
 ];
 
 {
-    _vehtomark pushback (_x select 0);
-} foreach light_vehicles + heavy_vehicles + air_vehicles + support_vehicles;
+    _vehtomark append _x;
+} forEach [KPLIB_b_light_classes, KPLIB_b_heavy_classes, KPLIB_b_air_classes, KPLIB_b_support_classes];
 
 _vehtomark = _vehtomark - _support_to_skip;
 

--- a/Missionframework/scripts/client/misc/vehicle_permissions.sqf
+++ b/Missionframework/scripts/client/misc/vehicle_permissions.sqf
@@ -6,9 +6,9 @@ private _isCargo = (_vehicle getCargoIndex player) != -1;
 if (_isCargo || _vehicle isKindOf "ParachuteBase") exitWith {};
 
 private _permissibleVehicles = [
-    [light_vehicles_classes, "STR_PERMISSION_NO_LIGHT"],
-    [heavy_vehicles_classes, "STR_PERMISSION_NO_ARMOR"],
-    [air_vehicles_classes, "STR_PERMISSION_NO_AIR"]
+    [KPLIB_typeLightClasses, "STR_PERMISSION_NO_LIGHT"],
+    [KPLIB_typeHeavyClasses, "STR_PERMISSION_NO_ARMOR"],
+    [KPLIB_typeAirClasses, "STR_PERMISSION_NO_AIR"]
 ];
 
 private _permissionIdx = _permissibleVehicles findIf {_vehicleClass in (_x select 0)};

--- a/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
+++ b/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
@@ -32,7 +32,7 @@ waitUntil { sleep 5;
     if ( !_is_near_blufor ) then {
         {
             if ((_x distance _unit) < 100) exitWith { _is_near_blufor = true };
-        } foreach (allUnits select {!(((typeof _x) in KPLIB_o_inf_classes) || ((typeof _x) in militia_squad))});
+        } forEach (allUnits select {!(((typeof _x) in KPLIB_o_inf_classes) || ((typeof _x) in militia_squad))});
     };
 
     !alive _unit || !(_is_near_blufor) || (_is_near_fob && (vehicle _unit == _unit))

--- a/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
+++ b/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
@@ -32,7 +32,7 @@ waitUntil { sleep 5;
     if ( !_is_near_blufor ) then {
         {
             if ((_x distance _unit) < 100) exitWith { _is_near_blufor = true };
-        } foreach (allUnits select {!(((typeof _x) in opfor_infantry) || ((typeof _x) in militia_squad))});
+        } foreach (allUnits select {!(((typeof _x) in KPLIB_o_inf_classes) || ((typeof _x) in militia_squad))});
     };
 
     !alive _unit || !(_is_near_blufor) || (_is_near_fob && (vehicle _unit == _unit))

--- a/Missionframework/scripts/client/ui/squad_management.sqf
+++ b/Missionframework/scripts/client/ui/squad_management.sqf
@@ -182,7 +182,7 @@ while { dialog && alive player } do {
                 _fobdistance = _selectedmember distance _nearfob;
             };
 
-            _nearsquad = ( (getpos _selectedmember) nearEntities [ ai_resupply_sources , 30 ] );
+            _nearsquad = (getPos _selectedmember) nearEntities [KPLIB_aiResupplySources, 30];
 
             if ( _fobdistance < 100 || count _nearsquad > 0 ) then {
 

--- a/Missionframework/scripts/server/base/startgame.sqf
+++ b/Missionframework/scripts/server/base/startgame.sqf
@@ -44,7 +44,7 @@ if (GRLIB_all_fobs isEqualTo []) then {
     private _crate = objNull;
     for "_i" from 1 to 6 do {
         _crate = createVehicle [
-            (KP_liberation_crates select (_i % 3)),
+            (KPLIB_crates select (_i % 3)),
             [((GRLIB_all_fobs select 0) select 0), ((GRLIB_all_fobs select 0) select 1), 150],
             [],
             80,

--- a/Missionframework/scripts/server/game/cleanup_vehicles.sqf
+++ b/Missionframework/scripts/server/game/cleanup_vehicles.sqf
@@ -2,8 +2,8 @@ private [ "_nextvehicle", "_nearestfob", "_reset_ticker" ];
 
 _cleanup_classnames = [];
 {
-    _cleanup_classnames pushback (_x select 0);
-} foreach (air_vehicles + heavy_vehicles + light_vehicles);
+    _cleanup_classnames append _x;
+} forEach [KPLIB_b_light_classes, KPLIB_b_heavy_classes, KPLIB_b_air_classes];
 
 while { GRLIB_cleanup_vehicles > 0 } do {
 

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -33,9 +33,7 @@ if (hasInterface) then {
 };
 
 // All classnames of objects which should be saved
-KP_liberation_classnamesToSave = [FOB_typename, huron_typename];
-// Classnames of blufor vehicles
-KP_liberation_bluforClassnames = [];
+KPLIB_classnamesToSave = [FOB_typename, huron_typename];
 
 /*
     --- Locals ---
@@ -97,20 +95,16 @@ resources_intel = 0;
 save_is_loaded = false;
 
 // Add all buildings for saving and kill manager ignore
-{
-    _noKillHandler pushBack (_x select 0);
-    KP_liberation_classnamesToSave pushBack (_x select 0);
-} foreach buildings;
-
-// Fetch all blufor vehicle classnames
-{
-    KP_liberation_bluforClassnames pushBack (_x select 0);
-    KP_liberation_classnamesToSave pushBack (_x select 0);
-} foreach (static_vehicles + air_vehicles + heavy_vehicles + light_vehicles + support_vehicles);
+_noKillHandler append KPLIB_b_buildings_classes;
+KPLIB_classnamesToSave append KPLIB_b_buildings_classes;
+KPLIB_classnamesToSave append KPLIB_b_allVeh_classes;
 
 // Add opfor and civilian vehicles for saving
-KP_liberation_classnamesToSave = KP_liberation_classnamesToSave + all_hostile_classnames + civilian_vehicles;
-KP_liberation_classnamesToSave  = KP_liberation_classnamesToSave  arrayIntersect KP_liberation_classnamesToSave;
+KPLIB_classnamesToSave append KPLIB_o_allVeh_classes
+KPLIB_classnamesToSave append civilian_vehicles;
+
+// Remove duplicates
+KPLIB_classnamesToSave = KPLIB_classnamesToSave arrayIntersect KPLIB_classnamesToSave;
 
 /*
     --- Statistic Variables ---
@@ -333,7 +327,7 @@ if (!isNil "_saveData") then {
         };
 
         // Only spawn, if the classname is still in the presets
-        if (_class in KP_liberation_classnamesToSave) then {
+        if (_class in KPLIB_classnamesToSave) then {
 
             // Create object without damage handling and simulation
             _object = createVehicle [_class, _pos, [], 0, "CAN_COLLIDE"];
@@ -358,7 +352,7 @@ if (!isNil "_saveData") then {
             };
 
             // Set enemy vehicle as captured
-            if (_class in all_hostile_classnames) then {
+            if (_class in KPLIB_o_allVeh_classes) then {
                 _object setVariable ["KPLIB_captured", true, true];
             };
 
@@ -405,7 +399,7 @@ if (!isNil "_saveData") then {
         _x params ["_class", "_pos", "_vecDir", "_vecUp", "_supply", "_ammo", "_fuel"];
 
         // Only spawn, if the classname is still in the presets
-        if (_class in KP_liberation_classnamesToSave) then {
+        if (_class in KPLIB_classnamesToSave) then {
 
             // Create object without damage handling and simulation
             _object = createVehicle [_class, _pos, [], 0, "CAN_COLLIDE"];

--- a/Missionframework/scripts/server/game/zeus_synchro.sqf
+++ b/Missionframework/scripts/server/game/zeus_synchro.sqf
@@ -2,9 +2,17 @@ waitUntil {!isNil "huron_typename"};
 
 // Classnames of objects which should be added as editable for Zeus
 private _vehicleClassnames = [huron_typename];
-_vehicleClassnames append KP_liberation_crates;
-_vehicleClassnames append ((light_vehicles + heavy_vehicles + air_vehicles + static_vehicles + support_vehicles) apply {_x select 0});
-if (KP_liberation_enemies_zeus) then {_vehicleClassnames append all_hostile_classnames};
+{
+    _vehicleClassnames append _x;
+} forEach [
+    KPLIB_crates,
+    KPLIB_b_light_classes,
+    KPLIB_b_heavy_classes,
+    KPLIB_b_air_classes,
+    KPLIB_b_static_classes,
+    KPLIB_b_support_classes
+];
+if (KP_liberation_enemies_zeus) then {_vehicleClassnames append KPLIB_o_allVeh_classes;};
 
 private _valids = [];
 private _toRemove = [];

--- a/Missionframework/scripts/server/resources/unit_cap.sqf
+++ b/Missionframework/scripts/server/resources/unit_cap.sqf
@@ -12,7 +12,7 @@ while {true} do {
         };
     } forEach allUnits;
     {
-        if (((typeOf _x) in KP_liberation_friendly_air_classnames) && (alive _x) && !(_x getVariable ["KP_liberation_preplaced", false])) then {
+        if ((typeOf _x) in KPLIB_b_air_classes && !([typeOf _x] call KPLIB_fnc_isClassUAV) && alive _x && !(_x getVariable ["KP_liberation_preplaced", false])) then {
             if (_x isKindOf "Helicopter") then {
                 _local_heli_count = _local_heli_count + 1;
             };

--- a/Missionframework/scripts/server/secondary/convoy_hijack.sqf
+++ b/Missionframework/scripts/server/secondary/convoy_hijack.sqf
@@ -20,7 +20,7 @@ private _transport_vehicle = [_spawnpos getPos [10, 180], opfor_ammobox_transpor
 private _boxes_amount = 0;
 {
     if ( _x select 0 == opfor_ammobox_transport ) exitWith { _boxes_amount = (count _x) - 2 };
-} foreach box_transport_config;
+} foreach KPLIB_transportConfigs;
 
 if ( _boxes_amount == 0 ) exitWith {["Opfor ammobox truck classname doesn't allow for ammobox transport, correct your preset and/or transport config", "ERROR"] call KPLIB_fnc_log;};
 

--- a/Missionframework/scripts/server/secondary/search_and_rescue.sqf
+++ b/Missionframework/scripts/server/secondary/search_and_rescue.sqf
@@ -4,14 +4,14 @@ if ( _spawn_marker == "" ) exitWith {["Could not find position for search and re
 used_positions pushbackUnique _spawn_marker;
 
 private _helopos = (markerPos _spawn_marker) getPos [random 200, random 360];
-private _helowreck = GRLIB_sar_wreck createVehicle _helopos;
+private _helowreck = KPLIB_sarWreck createVehicle _helopos;
 _helowreck allowDamage false;
 _helowreck setPos _helopos;
 _helowreck setPos _helopos;
 private _helowreckDir = (random 360);
 _helowreck setDir _helowreckDir;
 
-private _helofire = GRLIB_sar_fire createVehicle (getpos _helowreck);
+private _helofire = KPLIB_sarFire createVehicle (getpos _helowreck);
 _helofire setpos (getpos _helowreck);
 _helofire setpos (getpos _helowreck);
 

--- a/Missionframework/scripts/server/sector/manage_captureboxes.sqf
+++ b/Missionframework/scripts/server/sector/manage_captureboxes.sqf
@@ -16,9 +16,9 @@ if (!(_sector in KP_capture_sectors_already_activated)) then {
             if ( count _spawnpos == 0 ) then { _spawnpos = zeropos; };
         };
 
-        private _spawnclass = selectRandom KP_liberation_crates;
+        private _spawnclass = selectRandom KPLIB_crates;
 
-        private _newbox = [selectRandom KP_liberation_crates, 100, _spawnpos] call KPLIB_fnc_createCrate;
+        private _newbox = [selectRandom KPLIB_crates, 100, _spawnpos] call KPLIB_fnc_createCrate;
         _newbox setdir (random 360);
         _newbox setpos _spawnpos;
     };

--- a/Missionframework/scripts/server/sector/manage_intel.sqf
+++ b/Missionframework/scripts/server/sector/manage_intel.sqf
@@ -50,7 +50,7 @@ if (!(_sector in KP_military_sectors_already_activated)) then {
 
                 _used_positions pushback _buildingposition;
 
-                _intelobject = (selectRandom [GRLIB_intel_file, GRLIB_intel_laptop]) createVehicle _buildingposition;
+                _intelobject = (selectRandom [KPLIB_intelFile, KPLIB_intelLaptop]) createVehicle _buildingposition;
                 _intelobject setPosATL [_buildingposition select 0, _buildingposition select 1, (_buildingposition select 2) - 0.15];
                 _intelobject enableSimulationGlobal false;
                 _intelobject allowDamage false;

--- a/Missionframework/scripts/shared/kill_manager.sqf
+++ b/Missionframework/scripts/shared/kill_manager.sqf
@@ -42,12 +42,12 @@ if (isServer) then {
             armor_weight = armor_weight - 0.66;
             air_weight = air_weight - 0.66;
         } else {
-            if ((typeof (vehicle _killer)) in land_vehicles_classnames) then  {
+            if ((typeof (vehicle _killer)) in KPLIB_allLandVeh_classes) then  {
                 infantry_weight = infantry_weight - 0.66;
                 armor_weight = armor_weight + 1;
                 air_weight = air_weight - 0.66;
             };
-            if ((typeof (vehicle _killer)) in air_vehicles_classnames) then  {
+            if ((typeof (vehicle _killer)) in KPLIB_allAirVeh_classes) then  {
                 infantry_weight = infantry_weight - 0.66;
                 armor_weight = armor_weight - 0.66;
                 air_weight = air_weight + 1;
@@ -136,7 +136,7 @@ if (isServer) then {
         };
     } else {
         // Enemy vehicle casualty
-        if (typeof _unit in all_hostile_classnames) then {
+        if (typeof _unit in KPLIB_o_allVeh_classes) then {
             stats_opfor_vehicles_killed = stats_opfor_vehicles_killed + 1;
 
             // Destroyed by player

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ class Missions
 * Tweaked: Set factory sectors range concerning storage areas to fix 100m instead of scaling with FOB build range.
 * Tweaked: Civilians can now be treated with the elastic, basic, packing or QuickClot bandage instead of just the basic one.
 * Tweaked: Enabled HALO function by default with 5 minutes cooldown and lowered default mobile respawn cooldown from 15 to 10 minutes.
+* Tweaked: Array names for classname collections etc. from `init_presets.sqf`.
 * Fixed: Some CUP presets had free buildable arsenals. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Wrong boat in CUP USMC Woodland preset. Thanks to [Eogos](https://github.com/Eogos)
 * Fixed: Object inits will fire on units not only vehicles.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no |

### Description:
Sorted and organized `init_presets.sqf`. Also renamed many of the created arrays there with adjusting the depending scripts accordingly. Reduces the amount of "array building" in some scripts.

### Content:
- [x] Renamed arrays in `init_presets.sqf`
- [x] Changed sorting in `init_presets.sqf`
- [x] Added comments to explain purpose of arrays

### Successfully tested on:
- [ ] Local MP
- [ ] Dedicated MP