### PR TITLE
0.96.7 Fixed issues due to `toLower` usage in presets

### DIFF
--- a/Missionframework/functions/fn_crateFromStorage.sqf
+++ b/Missionframework/functions/fn_crateFromStorage.sqf
@@ -2,7 +2,7 @@
     File: fn_crateFromStorage.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-03-27
-    Last Update: 2020-04-24
+    Last Update: 2020-04-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,7 +24,7 @@ params [
 ];
 
 // Validate parameters
-if !(_cratetype in KPLIB_crates) exitWith {["Invalid craty type given: %1", _cratetype] call BIS_fnc_error; false};
+if !((toLower _cratetype) in KPLIB_crates) exitWith {["Invalid craty type given: %1", _cratetype] call BIS_fnc_error; false};
 if (isNull _storage) exitWith {["Null object given"] call BIS_fnc_error; false};
 
 // Get correct storage positions

--- a/Missionframework/functions/fn_createCrate.sqf
+++ b/Missionframework/functions/fn_createCrate.sqf
@@ -2,7 +2,7 @@
     File: fn_createCrate.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-11
-    Last Update: 2020-04-24
+    Last Update: 2020-04-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,7 +24,7 @@ params [
 ];
 
 // Check if resource is valid
-if !(_resource in KPLIB_crates) exitWith {
+if !((toLower _resource) in KPLIB_crates) exitWith {
     ["Invalid resource param given: %1", _resource] call BIS_fnc_error;
     objNull
 };

--- a/Missionframework/functions/fn_getGroupType.sqf
+++ b/Missionframework/functions/fn_getGroupType.sqf
@@ -2,7 +2,7 @@
     File: fn_getGroupType.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2020-04-24
+    Last Update: 2020-04-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -39,11 +39,11 @@ if (_vehType isEqualTo "") exitWith {_grpType};
 
 // Otherwise continue to get the type of the vehicle
 [] call {
-    if (_vehType in KPLIB_b_light_classes) exitWith {_grpType = "light";};
-    if (_vehType in KPLIB_b_heavy_classes) exitWith {_grpType = "heavy";};
-    if (_vehType in KPLIB_b_air_classes) exitWith {_grpType = "air";};
-    if (_vehType in KPLIB_b_static_classes) exitWith {_grpType = "static";};
-    if (_vehType in KPLIB_b_support_classes) exitWith {_grpType = "support";};
+    if ((toLower _vehType) in KPLIB_b_light_classes) exitWith {_grpType = "light";};
+    if ((toLower _vehType) in KPLIB_b_heavy_classes) exitWith {_grpType = "heavy";};
+    if ((toLower _vehType) in KPLIB_b_air_classes) exitWith {_grpType = "air";};
+    if ((toLower _vehType) in KPLIB_b_static_classes) exitWith {_grpType = "static";};
+    if ((toLower _vehType) in KPLIB_b_support_classes) exitWith {_grpType = "support";};
     if ([_vehType] call KPLIB_fnc_isClassUAV) exitWith {_grpType = "uav";};
 };
 

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-29
-    Last Update: 2020-04-24
+    Last Update: 2020-04-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -34,7 +34,7 @@ private _allBlueGroups = allGroups select {
 {
     private _fobPos = _x;
     private _fobObjects = (_fobPos nearobjects (GRLIB_fob_range * 1.2)) select {
-        ((typeof _x) in KPLIB_classnamesToSave) &&                  // Exclude classnames which are not in the presets
+        ((toLower (typeof _x)) in KPLIB_classnamesToSave) &&        // Exclude classnames which are not in the presets
         {alive _x} &&                                               // Exclude dead or broken objects
         {getObjectType _x >= 8} &&                                  // Exclude preplaced terrain objects
         {speed _x < 5} &&                                           // Exclude moving objects (like civilians driving through)
@@ -42,10 +42,10 @@ private _allBlueGroups = allGroups select {
         {((getpos _x) select 2) < 10} &&                            // Exclude hovering helicopters and the like
         {!(_x getVariable ["KP_liberation_edenObject", false])} &&  // Exclude all objects placed via editor in mission.sqm
         {!(_x getVariable ["KP_liberation_preplaced", false])} &&   // Exclude preplaced (e.g. little birds from carrier)
-        {!((typeOf _x) in KPLIB_crates)}                            // Exclude storage crates (those are handled separately)
+        {!((toLower (typeOf _x)) in KPLIB_crates)}                  // Exclude storage crates (those are handled separately)
     };
 
-    _allObjects = _allObjects + (_fobObjects select {!((typeOf _x) in KPLIB_storageBuildings)});
+    _allObjects = _allObjects + (_fobObjects select {!((toLower (typeOf _x)) in KPLIB_storageBuildings)});
     _allStorages = _allStorages + (_fobObjects select {(_x getVariable ["KP_liberation_storage_type",-1]) == 0});
 
     // Process all groups near this FOB
@@ -76,7 +76,7 @@ private _allBlueGroups = allGroups select {
     private _hascrew = false;
 
     // Determine if vehicle is crewed
-    if (_class in KPLIB_b_allVeh_classes) then {
+    if ((toLower _class) in KPLIB_b_allVeh_classes) then {
         if (({!isPlayer _x} count (crew _x) ) > 0) then {
             _hascrew = true;
         };

--- a/Missionframework/functions/fn_handlePlacedZeusObject.sqf
+++ b/Missionframework/functions/fn_handlePlacedZeusObject.sqf
@@ -2,7 +2,7 @@
     File: fn_handlePlacedZeusObject.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-11
-    Last Update: 2020-04-24
+    Last Update: 2020-04-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,7 +21,7 @@ params [
 // Identify kind of placed object once
 private _unit = _obj in allUnits;
 private _vehicle = _obj in vehicles;
-private _crate = (typeOf _obj) in KPLIB_crates;
+private _crate = (toLower (typeOf _obj)) in KPLIB_crates;
 
 // Exit if building and no resource crate
 if !(_unit || _vehicle || _crate) exitWith {false};

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -197,6 +197,7 @@ KPLIB_aiResupplySources                     = KPLIB_aiResupplySources           
 
 /*
     Fetch arrays with only classnames from the blufor preset build arrays
+    Beware that all classnames are converted to lowercase. Important for e.g. `in` checks, as it's case-sensitive.
 */
 KPLIB_b_infantry_classes                    = infantry_units                            apply {toLower (_x select 0)};
 KPLIB_b_light_classes                       = light_vehicles                            apply {toLower (_x select 0)};
@@ -208,6 +209,7 @@ KPLIB_b_support_classes                     = support_vehicles                  
 KPLIB_transport_classes                     = KPLIB_transportConfigs                    apply {toLower (_x select 0)};
 
 KPLIB_b_infantry_classes append (blufor_squad_inf_light + blufor_squad_inf + blufor_squad_at + blufor_squad_aa + blufor_squad_recon + blufor_squad_para);
+KPLIB_b_infantry_classes                    = KPLIB_b_infantry_classes                  apply {toLower _x};
 KPLIB_b_infantry_classes                    = KPLIB_b_infantry_classes                  arrayIntersect KPLIB_b_infantry_classes;
 
 /*
@@ -228,6 +230,12 @@ KPLIB_storageBuildings  = [KP_liberation_small_storage_building, KP_liberation_l
 KPLIB_upgradeBuildings  = [KP_liberation_recycle_building, KP_liberation_air_vehicle_building, KP_liberation_heli_slot_building, KP_liberation_plane_slot_building];
 KPLIB_aiResupplySources append [Respawn_truck_typename, huron_typename, Arsenal_typename];
 
+KPLIB_crates            = KPLIB_crates              apply {toLower _x};
+KPLIB_airSlots          = KPLIB_airSlots            apply {toLower _x};
+KPLIB_storageBuildings  = KPLIB_storageBuildings    apply {toLower _x};
+KPLIB_upgradeBuildings  = KPLIB_upgradeBuildings    apply {toLower _x};
+KPLIB_aiResupplySources = KPLIB_aiResupplySources   apply {toLower _x};
+
 /*
     Classname collections
 */
@@ -236,12 +244,12 @@ KPLIB_allLandVeh_classes = [[], [huron_typename]] select (huron_typename isKindO
 {
     KPLIB_allLandVeh_classes append _x;
 } forEach [
-    militia_vehicles,
-    opfor_vehicles,
-    opfor_vehicles_low_intensity,
-    opfor_battlegroup_vehicles,
-    opfor_battlegroup_vehicles_low_intensity,
-    opfor_troup_transports,
+    militia_vehicles apply {toLower _x},
+    opfor_vehicles apply {toLower _x},
+    opfor_vehicles_low_intensity apply {toLower _x},
+    opfor_battlegroup_vehicles apply {toLower _x},
+    opfor_battlegroup_vehicles_low_intensity apply {toLower _x},
+    opfor_troup_transports apply {toLower _x},
     KPLIB_b_light_classes,
     KPLIB_b_heavy_classes,
     KPLIB_b_support_classes select {_x isKindOf "Car" || _x isKindOf "Tank"}
@@ -252,7 +260,7 @@ KPLIB_allLandVeh_classes = KPLIB_allLandVeh_classes arrayIntersect KPLIB_allLand
 KPLIB_allAirVeh_classes = [[], [huron_typename]] select (huron_typename isKindOf "Air");
 {
     KPLIB_allAirVeh_classes append _x;
-} forEach [opfor_choppers, opfor_air, KPLIB_b_air_classes, KPLIB_b_support_classes select {_x isKindOf "Air"}];
+} forEach [opfor_choppers apply {toLower _x}, opfor_air apply {toLower _x}, KPLIB_b_air_classes, KPLIB_b_support_classes select {_x isKindOf "Air"}];
 
 // All blufor vehicle (land and air) classnames
 KPLIB_b_allVeh_classes = [];
@@ -274,10 +282,12 @@ KPLIB_o_allVeh_classes  = [];
     opfor_choppers,
     opfor_air
 ];
+KPLIB_o_allVeh_classes = KPLIB_o_allVeh_classes apply {toLower _x};
 KPLIB_o_allVeh_classes = KPLIB_o_allVeh_classes arrayIntersect KPLIB_o_allVeh_classes;
 
 // All regular opfor soldier classnames
 KPLIB_o_inf_classes = [opfor_sentry, opfor_rifleman, opfor_grenadier, opfor_squad_leader, opfor_team_leader, opfor_marksman, opfor_machinegunner, opfor_heavygunner, opfor_medic, opfor_rpg, opfor_at, opfor_aa, opfor_officer, opfor_sharpshooter, opfor_sniper,opfor_engineer];
+KPLIB_o_inf_classes = KPLIB_o_inf_classes apply {toLower _x};
 
 /*
     Vehicle type permission arrays
@@ -291,7 +301,7 @@ KPLIB_typeAirClasses   = +KPLIB_b_air_classes;
         case (_x isKindOf "Air"):   {KPLIB_typeAirClasses      pushBack _x};
         default                     {KPLIB_typeLightClasses    pushBack _x};
     };
-} forEach (KPLIB_b_support_classes + [huron_typename]);
+} forEach (KPLIB_b_support_classes + [toLower huron_typename]);
 
 // Military alphabet used for FOBs and convois
 military_alphabet = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-Ray", "Yankee", "Zulu"];

--- a/Missionframework/scripts/client/actions/do_recycle.sqf
+++ b/Missionframework/scripts/client/actions/do_recycle.sqf
@@ -12,9 +12,9 @@ private _ammoMulti = 0.5;
 private _fuelMulti = 0.5;
 
 if !(
-    (_type in KPLIB_b_buildings_classes) ||
-    (_type in KPLIB_storageBuildings) ||
-    (_type in KPLIB_upgradeBuildings) ||
+    ((toLower _type) in KPLIB_b_buildings_classes) ||
+    ((toLower _type) in KPLIB_storageBuildings) ||
+    ((toLower _type) in KPLIB_upgradeBuildings) ||
     (_type in KP_liberation_ace_crates) ||
     (_type == "B_Slingload_01_Repair_F") ||
     (_type == "B_Slingload_01_Fuel_F") ||

--- a/Missionframework/scripts/client/actions/recycle_manager.sqf
+++ b/Missionframework/scripts/client/actions/recycle_manager.sqf
@@ -19,21 +19,21 @@ while {true} do {
 
     if ([4] call KPLIB_fnc_hasPermission) then {
         private _detected_vehicles = (getPos player) nearObjects veh_action_detect_distance select {
-            (((typeof _x in _recycleable_classnames ) && (({alive _x} count (crew _x)) == 0 || (unitIsUAV _x)) && ((locked _x == 0 || locked _x == 1))) ||
-            ((typeOf _x) in KPLIB_b_buildings_classes) ||
-            (((typeOf _x) in KPLIB_storageBuildings) && ((_x getVariable ["KP_liberation_storage_type",-1]) == 0)) ||
-            ((typeOf _x) in KPLIB_upgradeBuildings) ||
-            ((typeOf _x) in KP_liberation_ace_crates)) &&
-            (alive _x) &&
+            (((toLower (typeof _x)) in _recycleable_classnames && (({alive _x} count (crew _x)) == 0 || unitIsUAV _x) && (locked _x == 0 || locked _x == 1)) ||
+            (toLower (typeOf _x)) in KPLIB_b_buildings_classes ||
+            (((toLower (typeOf _x)) in KPLIB_storageBuildings) && ((_x getVariable ["KP_liberation_storage_type",-1]) == 0)) ||
+            (toLower (typeOf _x)) in KPLIB_upgradeBuildings ||
+            (typeOf _x) in KP_liberation_ace_crates) &&
+            alive _x &&
             (
                 // ignore null objects left by Advanced Towing
                 // see https://github.com/sethduda/AdvancedTowing/pull/46
                 (((attachedObjects _x) select {!isNull _X}) isEqualTo [])
                 || ((typeOf _x) == "rhsusf_mkvsoc")
             ) &&
-            (_x distance startbase > 1000) &&
-            (_x distance ( [] call KPLIB_fnc_getNearestFob) < GRLIB_fob_range) &&
-            (getObjectType _x >= 8)
+            _x distance2d startbase > 1000 &&
+            (_x distance2d ([] call KPLIB_fnc_getNearestFob)) < GRLIB_fob_range &&
+            (getObjectType _x) >= 8
         };
 
         {

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -89,7 +89,7 @@ while { true } do {
             if (buildtype == 6 ) then {
                 _idactplacebis = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT_BIS" + "</t> <img size='2' image='res\ui_confirm.paa'/>",{build_confirmed = 2; repeatbuild = true; hint localize "STR_CONFIRM_HINT";},"",-785,false,false,"","build_invalid == 0 && build_confirmed == 1"];
             };
-            if (buildtype == 6 || buildtype == 99  || _classname in KPLIB_storageBuildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+            if (buildtype == 6 || buildtype == 99  || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KP_liberation_recycle_building || _classname isEqualTo KP_liberation_air_vehicle_building) then {
                 _idactsnap = player addAction ["<t color='#B0FF00'>" + localize "STR_GRID" + "</t>",{gridmode = gridmode + 1;},"",-735,false,false,"","build_confirmed == 1"];
                 _idactvector = player addAction ["<t color='#B0FF00'>" + localize "STR_VECACTION" + "</t>",{KP_vector = !KP_vector;},"",-800,false,false,"","build_confirmed == 1"];
             };
@@ -214,7 +214,7 @@ while { true } do {
                             _vehicle setpos _truepos;
                         };
                     };
-                    if (buildtype == 6 || buildtype == 99 || _classname in KPLIB_storageBuildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                    if (buildtype == 6 || buildtype == 99 || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KP_liberation_recycle_building || _classname isEqualTo KP_liberation_air_vehicle_building) then {
                         if (KP_vector) then {
                             _vehicle setVectorUp [0,0,1];
                         } else {
@@ -313,7 +313,7 @@ while { true } do {
 
                 [_vehicle] call KPLIB_fnc_clearCargo;
 
-                if (buildtype == 6 || buildtype == 99 || _classname in KPLIB_storageBuildings || _classname == KP_liberation_recycle_building || _classname == KP_liberation_air_vehicle_building) then {
+                if (buildtype == 6 || buildtype == 99 || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KP_liberation_recycle_building || _classname isEqualTo KP_liberation_air_vehicle_building) then {
                     if (KP_vector) then {
                         _vehicle setVectorUp [0,0,1];
                     } else {

--- a/Missionframework/scripts/client/build/open_build_menu.sqf
+++ b/Missionframework/scripts/client/build/open_build_menu.sqf
@@ -127,7 +127,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
             ((_build_item select 2 == 0 ) || ((_build_item select 2) <= ((_actual_fob select 0) select 2))) &&
             ((_build_item select 3 == 0 ) || ((_build_item select 3) <= ((_actual_fob select 0) select 3)))
         ) then {
-            if (((_build_item select 0) in KPLIB_b_air_classes) && !([_build_item select 0] call KPLIB_fnc_isClassUAV)) then {
+            if ((toLower (_build_item select 0)) in KPLIB_b_air_classes && !([_build_item select 0] call KPLIB_fnc_isClassUAV)) then {
                 if (KP_liberation_air_vehicle_building_near &&
                     ((((_build_item select 0) isKindOf "Helicopter") && (KP_liberation_heli_count < KP_liberation_heli_slots)) ||
                     (((_build_item select 0) isKindOf "Plane") && (KP_liberation_plane_count < KP_liberation_plane_slots)))
@@ -135,7 +135,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
                     _affordable = true;
                 };
             } else {
-                if (!((_build_item select 0) in KPLIB_airSlots) || (((_build_item select 0) in KPLIB_airSlots) && KP_liberation_air_vehicle_building_near)) then {
+                if (!((toLower (_build_item select 0)) in KPLIB_airSlots) || (((toLower (_build_item select 0)) in KPLIB_airSlots) && KP_liberation_air_vehicle_building_near)) then {
                     _affordable = true;
                 };
             };

--- a/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
+++ b/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
@@ -23,7 +23,7 @@ while { true } do {
 
     _markedveh = [];
     {
-        if ( (alive _x) && ((typeof _x) in _vehtomark) && (count (crew _x) == 0) && (_x distance startbase > 500) ) then {
+        if (alive _x && (toLower (typeof _x)) in _vehtomark && (count (crew _x)) == 0 && (_x distance2d startbase) > 500) then {
             _markedveh pushback _x;
         };
     } foreach vehicles;

--- a/Missionframework/scripts/client/misc/vehicle_permissions.sqf
+++ b/Missionframework/scripts/client/misc/vehicle_permissions.sqf
@@ -1,5 +1,5 @@
 params ["_vehicle"];
-private _vehicleClass = toLower typeOf _vehicle;
+private _vehicleClass = toLower (typeOf _vehicle);
 
 // Cargo is always allowed
 private _isCargo = (_vehicle getCargoIndex player) != -1;

--- a/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
+++ b/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
@@ -32,7 +32,7 @@ waitUntil { sleep 5;
     if ( !_is_near_blufor ) then {
         {
             if ((_x distance _unit) < 100) exitWith { _is_near_blufor = true };
-        } forEach (allUnits select {!(((typeof _x) in KPLIB_o_inf_classes) || ((typeof _x) in militia_squad))});
+        } forEach (allUnits select {!((toLower (typeof _x)) in KPLIB_o_inf_classes || (typeof _x) in militia_squad)});
     };
 
     !alive _unit || !(_is_near_blufor) || (_is_near_fob && (vehicle _unit == _unit))

--- a/Missionframework/scripts/server/game/cleanup_vehicles.sqf
+++ b/Missionframework/scripts/server/game/cleanup_vehicles.sqf
@@ -15,7 +15,7 @@ while { GRLIB_cleanup_vehicles > 0 } do {
         _nearestfob = [ getpos _nextvehicle ] call KPLIB_fnc_getNearestFob;
         if ( count _nearestfob == 3 ) then {
             if ( ( _nextvehicle distance _nearestfob > ( 1.2 * GRLIB_fob_range ) ) && ( _nextvehicle distance startbase > ( 1.2 * GRLIB_fob_range ) ) ) then {
-                if ( typeof _nextvehicle in _cleanup_classnames ) then {
+                if ((toLower (typeof _nextvehicle)) in _cleanup_classnames) then {
                     if ( count ( crew _nextvehicle ) == 0 ) then {
                         _nextvehicle setVariable [ "GRLIB_empty_vehicle_ticker", ( _nextvehicle getVariable [ "GRLIB_empty_vehicle_ticker", 0 ] ) + 1 ];
                         _reset_ticker = false;

--- a/Missionframework/scripts/server/game/zeus_synchro.sqf
+++ b/Missionframework/scripts/server/game/zeus_synchro.sqf
@@ -1,7 +1,7 @@
 waitUntil {!isNil "huron_typename"};
 
 // Classnames of objects which should be added as editable for Zeus
-private _vehicleClassnames = [huron_typename];
+private _vehicleClassnames = [toLower huron_typename];
 {
     _vehicleClassnames append _x;
 } forEach [
@@ -35,7 +35,7 @@ while {true} do {
     _valids append (vehicles select {
         (alive _x)                                                                              // Alive
         && {
-            ((typeof _x) in _vehicleClassnames)                                                 // In valid classnames
+            ((toLower (typeOf _x)) in _vehicleClassnames)                                       // In valid classnames
             || (_x getVariable ["KPLIB_captured", false])                                       // or captured
             || (_x getVariable ["KPLIB_seized", false])                                         // or seized
         }

--- a/Missionframework/scripts/server/resources/unit_cap.sqf
+++ b/Missionframework/scripts/server/resources/unit_cap.sqf
@@ -12,7 +12,7 @@ while {true} do {
         };
     } forEach allUnits;
     {
-        if ((typeOf _x) in KPLIB_b_air_classes && !([typeOf _x] call KPLIB_fnc_isClassUAV) && alive _x && !(_x getVariable ["KP_liberation_preplaced", false])) then {
+        if ((toLower (typeOf _x)) in KPLIB_b_air_classes && !([typeOf _x] call KPLIB_fnc_isClassUAV) && alive _x && !(_x getVariable ["KP_liberation_preplaced", false])) then {
             if (_x isKindOf "Helicopter") then {
                 _local_heli_count = _local_heli_count + 1;
             };


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |

### Description:
The changes in the `init_presets.sqf` made most classname collection arrays having the classnames in all lowercase. This caused issues in e.g. do_build or save_manager, as we use `in` there many times, which is case sensitive.
Hopefully I've found all occurances. Another look/search beside of the review here would be highly appreciated.

### Content:
- [ ] Fixed `toLower` issues for `in` checks