### PR TITLE
0.96.7 Save/Load of sector activation crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Added: Arma 3 support module (artillery) functionality with parameter settings and vehicle/player whitelist.
 * Added: Visual indicators of the FOB range while in build mode.
 * Added: Parameter to disable weapon sway.
+* Added: Crates which are spawned upon sector activation are now saved near their sector, if the sector is taken by blufor. (Factories/Cities)
 * Removed: `action_manager.sqf` file was removed, due to new action handling.
 * Updated: Updated CUP presets to be inline with October 2019 stable build of CUP mods. Thanks to [Eogos](https://github.com/Eogos)
 * Updated: Turkish translation. Thanks to [654wak654](https://github.com/654wak654)

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-29
-    Last Update: 2020-04-25
+    Last Update: 2020-05-03
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -22,6 +22,7 @@ private _aiGroups = [];
 private _allObjects = [];
 private _allStorages = [];
 private _allMines = [];
+private _allCrates = [];
 
 // Get all blufor groups
 private _allBlueGroups = allGroups select {
@@ -118,6 +119,15 @@ private _allBlueGroups = allGroups select {
     _resourceStorages pushBack [_class,_savedpos,_savedvecdir,_savedvecup,_supplyValue,_ammoValue,_fuelValue];
 } forEach _allStorages;
 
+// Save crates at blufor sectors which spawn crates on activation
+{
+    _allCrates append (
+        ((nearestObjects [markerPos _x, KPLIB_crates, GRLIB_capture_size]) select {isNull attachedTo _x}) apply {
+            [typeOf _x, _x getVariable ["KP_liberation_crate_value", 0], getPosATL _x]
+        }
+    );
+} forEach (blufor_sectors select {_x in sectors_factory || _x in sectors_capture});
+
 // Pack all stats in one array
 private _stats = [
     stats_ammo_produced,
@@ -189,5 +199,6 @@ private _weights = [
     KP_liberation_production,
     KP_liberation_production_markers,
     resources_intel,
-    _allMines
+    _allMines,
+    _allCrates
 ] // return

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -55,6 +55,8 @@ private _stats = [];
 private _weights = [];
 // All mines around FOBs
 private _allMines = [];
+// All unclaimed crates from crate spawning sectors
+private _allCrates = [];
 
 /*
     --- Globals ---
@@ -188,6 +190,7 @@ if (!isNil "_saveData") then {
         KP_liberation_production_markers            = _saveData select 17;
         resources_intel                             = _saveData select 18;
         _allMines                                   = _saveData param [19, []];
+        _allCrates                                  = _saveData param [20, []];
 
         stats_ammo_produced                         = _stats select  0;
         stats_ammo_spent                            = _stats select  1;
@@ -487,6 +490,12 @@ if (!isNil "_saveData") then {
         } forEach _aiGroups;
     };
     ["Saved AI units placed", "SAVE"] call KPLIB_fnc_log;
+
+    // Spawn all saved sector crates
+    {
+        _x call KPLIB_fnc_createCrate;
+    } forEach _allCrates;
+    ["Saved crates placed", "SAVE"] call KPLIB_fnc_log;
 } else {
     ["Save nil", "SAVE"] call KPLIB_fnc_log;
 };


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |

### Description:
Saves crates at blufor sectors which spawn crates on activation. (`factory_`/`capture_`).

### Content:
- [x] Save/Load of crates from sector activation

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP