### PR TITLE
Add missing semicolon to do_repackage_fob

### DIFF
--- a/Missionframework/scripts/client/actions/do_repackage_fob.sqf
+++ b/Missionframework/scripts/client/actions/do_repackage_fob.sqf
@@ -2,7 +2,7 @@ dorepackage = 0;
 
 createDialog "liberation_repackage_fob";
 waitUntil {sleep 0.1; dialog};
-waitUntil {sleep 0.1; !dialog || !alive player || dorepackage != 0}
+waitUntil {sleep 0.1; !dialog || !alive player || dorepackage != 0};
 
 if (dorepackage > 0) then {
     closeDialog 0;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? |  no |
| Needs wipe? | no |

### Description:

Adds a missing semi-colon to `do_repackage_fob`

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP