### PR TITLE
0.96.7 Exit while on spawnpos search

### DIFF
--- a/Missionframework/functions/fn_spawnRegularSquad.sqf
+++ b/Missionframework/functions/fn_spawnRegularSquad.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnRegularSquad.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-12-03
-    Last Update: 2020-04-05
+    Last Update: 2020-05-06
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,12 +25,18 @@ if (_sector isEqualTo "") exitWith {["Empty string given"] call BIS_fnc_error; g
 
 // Get spawn position for squad
 private _sectorPos = (markerPos _sector) getPos [random 100, random 360];
-private _spawnPos = zeropos;
+private _spawnPos = [];
 private _i = 0;
-while {_spawnPos distance2d zeropos < 100} do {
+while {_spawnPos isEqualTo []} do {
+    _i = _i + 1;
     _spawnPos = (_sectorPos getPos [random 50, random 360]) findEmptyPosition [5, 100, "B_Heli_Light_01_F"];
-    if (count _spawnPos == 0) then {_spawnPos = zeropos; _i = _i + 1;};
-    if (_i == 10) exitWith {["No suitable spawn position found."] call BIS_fnc_error; grpNull};
+    if (_i isEqualTo 10) exitWith {};
+};
+
+if (_spawnPos isEqualTo zeroPos) exitWith {
+    ["No suitable spawn position found."] call BIS_fnc_error;
+    [format ["Couldn't find infantry spawn position for sector %1", _sector], "WARNING"] call KPLIB_fnc_log;
+    grpNull
 };
 
 // Spawn units of squad

--- a/Missionframework/functions/fn_spawnVehicle.sqf
+++ b/Missionframework/functions/fn_spawnVehicle.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnVehicle.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-12-03
-    Last Update: 2020-04-26
+    Last Update: 2020-05-06
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -30,7 +30,7 @@ if (_classname isEqualTo "") exitWith {["Empty string given"] call BIS_fnc_error
 if (!canSuspend) exitWith {_this spawn KPLIB_fnc_spawnVehicle};
 
 private _newvehicle = objNull;
-private _spawnpos = zeropos;
+private _spawnpos = [];
 
 if (_precise) then {
     // Directly use given pos, if precise placement is true
@@ -38,11 +38,17 @@ if (_precise) then {
 } else {
     // Otherwise find a suitable position for vehicle spawning near given pos
     private _i = 0;
-    while {_spawnpos distance2d zeropos < 100} do {
+    while {_spawnPos isEqualTo []} do {
+        _i = _i + 1;
         _spawnpos = (_pos getPos [random 150, random 360]) findEmptyPosition [10, 100, 'B_Heli_Transport_01_F'];
-        if (_spawnpos isEqualTo []) then {_spawnpos = zeropos; _i = _i + 1;};
-        if (_i == 10) exitWith {["No suitable spawn position found near given position."] call BIS_fnc_error; objNull};
+        if (_i isEqualTo 10) exitWith {};
     };
+};
+
+if (_spawnPos isEqualTo zeroPos) exitWith {
+    ["No suitable spawn position found."] call BIS_fnc_error;
+    [format ["Couldn't find spawn position for %1 around position %2", _classname, _pos], "WARNING"] call KPLIB_fnc_log;
+    objNull
 };
 
 // If it's a chopper, spawn it flying

--- a/Missionframework/functions/fn_spawnVehicle.sqf
+++ b/Missionframework/functions/fn_spawnVehicle.sqf
@@ -40,7 +40,7 @@ if (_precise) then {
     private _i = 0;
     while {_spawnPos isEqualTo []} do {
         _i = _i + 1;
-        _spawnpos = (_pos getPos [random 150, random 360]) findEmptyPosition [10, 100, 'B_Heli_Transport_01_F'];
+        _spawnpos = (_pos getPos [random 150, random 360]) findEmptyPosition [10, 100, _classname];
         if (_i isEqualTo 10) exitWith {};
     };
 };

--- a/Missionframework/kp_liberation_config.sqf
+++ b/Missionframework/kp_liberation_config.sqf
@@ -1003,8 +1003,8 @@ KP_liberation_suppMod_artyVeh = [
 
 // Objects which are spawned as intel objects for pickup
 KPLIB_intelObjectClasses = [
-    "Land_File1_F",
-    "Land_Laptop_device_F"
+    "Land_File_research_F",
+    "Land_Document_01_F"
 ];
 
 // Classnames of buildings inside military sectors, which are valid to hold intel items

--- a/Missionframework/scripts/server/sector/fn_spawnSectorCrates.sqf
+++ b/Missionframework/scripts/server/sector/fn_spawnSectorCrates.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnSectorCrates.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-28
-    Last Update: 2020-05-03
+    Last Update: 2020-05-06
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -29,13 +29,21 @@ if !(_sector in KPLIB_sectorCratesSpawned) then {
 
     private _amount = (ceil (random 3)) * GRLIB_resources_multiplier;
     private _spawnPos = [];
+    private _j = 0;
 
     for "_i" from 1 to _amount do {
         while {_spawnPos isEqualTo []} do {
+            _j = _j + 1;
             _spawnPos = ((markerPos _sector) getPos [random 50, random 360]) findEmptyPosition [10, 40, "B_Heli_Transport_01_F"];
+            if (_j isEqualTo 10) exitWith {};
         };
-        [selectRandom KPLIB_crates, 100, _spawnpos] call KPLIB_fnc_createCrate;
-        _spawnPos = [];
+        if !(_spawnPos isEqualTo []) then {
+            [selectRandom KPLIB_crates, 100, _spawnpos] call KPLIB_fnc_createCrate;
+            _spawnPos = [];
+        } else {
+            ["No suitable spawn position found."] call BIS_fnc_error;
+            [format ["Couldn't find spawn position for resource crate for sector %1", _sector], "WARNING"] call KPLIB_fnc_log;
+        };
     };
 };
 

--- a/Missionframework/scripts/server/sector/fn_spawnSectorCrates.sqf
+++ b/Missionframework/scripts/server/sector/fn_spawnSectorCrates.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnSectorCrates.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-28
-    Last Update: 2020-05-06
+    Last Update: 2020-05-07
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -34,7 +34,7 @@ if !(_sector in KPLIB_sectorCratesSpawned) then {
     for "_i" from 1 to _amount do {
         while {_spawnPos isEqualTo []} do {
             _j = _j + 1;
-            _spawnPos = ((markerPos _sector) getPos [random 50, random 360]) findEmptyPosition [10, 40, "B_Heli_Transport_01_F"];
+            _spawnPos = ((markerPos _sector) getPos [random 50, random 360]) findEmptyPosition [10, 40, KP_liberation_ammo_crate];
             if (_j isEqualTo 10) exitWith {};
         };
         if !(_spawnPos isEqualTo []) then {

--- a/Missionframework/scripts/server/sector/fn_spawnSectorIntel.sqf
+++ b/Missionframework/scripts/server/sector/fn_spawnSectorIntel.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnSectorIntel.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-05-01
-    Last Update: 2020-05-01
+    Last Update: 2020-05-06
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -31,7 +31,8 @@ if !(_sector in KPLIB_sectorIntelSpawned) then {
     private _buildings = (nearestObjects [markerPos _sector, KPLIB_intelBuildingClasses, _range]) select {alive _x};
 
     if !(_buildings isEqualTo []) then {
-        private _positions = (_buildings apply {[_x] call BIS_fnc_buildingPositions}) select {(_x select 2) < 2};
+        private _positions = [];
+        {_positions append _x;} forEach (_buildings apply {[_x] call BIS_fnc_buildingPositions});
 
         if ((count _positions) >= (_amount * 4)) then {
             private _spawnPos = [];
@@ -41,8 +42,7 @@ if !(_sector in KPLIB_sectorIntelSpawned) then {
                 _spawnPos = _positions deleteAt (floor random (count _positions));
                 _obj = (selectRandom KPLIB_intelObjectClasses) createVehicle _spawnPos;
                 _obj setdir (random 360);
-                _obj setPosATL [_spawnPos select 0, _spawnPos select 1, (_spawnPos select 2) - 0.15];
-                _obj enableSimulationGlobal false;
+                _obj setPosATL _spawnPos;
                 _obj allowDamage false;
             };
         };


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |

### Description:
Possible fix for creating possible endless loops while searching for a suitable spawn position. At least it'll give more insight in possible issues due to added logging.
Furthermore a fix for an error in intel spawning.

### Content:
- [x] Added exit conditions to while loops of regular squad, vehicle and capture boxes spawn
- [x] Fixed error in intel spawning function