### PR TITLE
Lower the chance for unarmed BRDM in GM East enemy preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Tweaked: Arsenal presets are now in the presets folder.
 * Tweaked: Blacklist and arsenal extension are now own files in presets/arsenal.
 * Tweaked: Renamed blufor/opfor to players/enemies, to possibly avoid further confusion with using an opfor faction for a player preset.
+* Tweaked: GM East enemy preset, lower the chance for unarmed BRDM.
 * Fixed: Description.ext stated 34 players while there are also 3 additional HC slots, so 37 in total.
 * Fixed: Sector monitor got stuck after sector cap was reached until restarting the server.
 * Fixed: FOB truck got mass set, but should've just apply to FOB boxes.

--- a/Missionframework/presets/enemies/gm_east.sqf
+++ b/Missionframework/presets/enemies/gm_east.sqf
@@ -2,7 +2,7 @@
     File: gm_east.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-06
-    Last Update: 2020-05-15
+    Last Update: 2020-05-23
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -65,7 +65,9 @@ KPLIB_o_militiaInfantry = [
 
 // Militia vehicles. Lightweight vehicle classnames the game will pick from randomly as sector defenders. Can also be empty for only infantry milita.
 KPLIB_o_militiaVehicles = [
-    "gm_gc_army_brdm2um"                                                // SPW40-P2UM
+    "gm_gc_army_brdm2um",                                               // SPW40-P2UM
+    "gm_gc_army_brdm2",                                                 // SPW-40P2
+    "gm_gc_army_brdm2"                                                  // SPW-40P2
 ];
 
 // All enemy vehicles that can spawn as sector defenders and patrols at high enemy combat readiness (aggression levels).
@@ -85,14 +87,16 @@ KPLIB_o_armyVehicles = [
 KPLIB_o_armyVehiclesLight = [
     "gm_gc_army_brdm2um",                                               // SPW40-P2UM
     "gm_gc_army_brdm2",                                                 // SPW-40P2
+    "gm_gc_army_brdm2",                                                 // SPW-40P2
     "gm_gc_army_btr60pa",                                               // SPW-60PA
+    "gm_gc_army_btr60pa",                                               // SPW-60PA
+    "gm_gc_army_btr60pb"                                                // SPW-60PB
     "gm_gc_army_btr60pb"                                                // SPW-60PB
 ];
 
 // All enemy vehicles that can spawn as battlegroups, either assaulting or as reinforcements, at high enemy combat readiness (aggression levels).
 KPLIB_o_battleGrpVehicles = [
     "gm_gc_army_ural4320_cargo",                                        // Truck gel. 5 Transport
-    "gm_gc_army_brdm2um",                                               // SPW40-P2UM
     "gm_gc_army_brdm2",                                                 // SPW-40P2
     "gm_gc_army_btr60pa",                                               // SPW-60PA
     "gm_gc_army_btr60pb",                                               // SPW-60PB


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no  |
| Needs wipe? | no  |

### Description:

Just started a session in GM version and that damn harmless thing was driving around everywhere.

### Content:
- [x] Updated GM East enemy preset

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP
