### PR TITLE
[0.96.8] Preset variables rename

### DIFF
--- a/Missionframework/functions/fn_addActionsFob.sqf
+++ b/Missionframework/functions/fn_addActionsFob.sqf
@@ -2,7 +2,7 @@
     File: fn_addActionsFob.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-13
-    Last Update: 2020-04-13
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,7 +23,7 @@ if (isNull _object) exitWith {["Null object given"] call BIS_fnc_error; false};
 
 if (isNil "FOB_build_in_progress") then {FOB_build_in_progress = false;};
 
-if ((typeOf _obj) isEqualTo FOB_typename) exitWith {
+if ((typeOf _obj) isEqualTo KPLIB_b_fobBuilding) exitWith {
     _obj addAction [
         ["<t color='#FFFF00'>", localize "STR_FOB_REPACKAGE", "</t> <img size='2' image='res\ui_deployfob.paa'/>"] joinString "",
         "scripts\client\actions\do_repackage_fob.sqf",
@@ -38,7 +38,7 @@ if ((typeOf _obj) isEqualTo FOB_typename) exitWith {
     true
 };
 
-if ((typeOf _obj) in [FOB_box_typename, FOB_truck_typename]) exitWith {
+if ((typeOf _obj) in [KPLIB_b_fobBox, KPLIB_b_fobTruck]) exitWith {
     _obj addAction [
         ["<t color='#FFFF00'>", localize "STR_FOB_ACTION", "</t> <img size='2' image='res\ui_deployfob.paa'/>"] joinString "",
         "scripts\client\build\do_build_fob.sqf",

--- a/Missionframework/functions/fn_addActionsPlayer.sqf
+++ b/Missionframework/functions/fn_addActionsPlayer.sqf
@@ -2,7 +2,7 @@
     File: fn_addActionsPlayer.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-13
-    Last Update: 2020-05-17
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -169,7 +169,7 @@ _player addAction [
 _player addAction [
     ["<t color='#FFFF00'>", localize "STR_SECSTORAGEBUILD_ACTION", "</t>"] joinString "",
     "scripts\client\build\do_sector_build.sqf",
-    [KPLIB_small_storage_building],
+    [KPLIB_b_smallStorage],
     -770,
     false,
     true,

--- a/Missionframework/functions/fn_createCrate.sqf
+++ b/Missionframework/functions/fn_createCrate.sqf
@@ -2,14 +2,14 @@
     File: fn_createCrate.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-11
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
         Spawns a resource crate of given type and with given amount at given position.
 
     Parameter(s):
-        _resource   - Type of resource                  [STRING, defaults to KPLIB_supply_crate]
+        _resource   - Type of resource                  [STRING, defaults to KPLIB_b_crateSupply]
         _amount     - Resource amount                   [NUMBER, defaults to 100]
         _pos        - Position where to spawn the crate [POSITION, defaults to getPos player]
 
@@ -18,7 +18,7 @@
 */
 
 params [
-    ["_resource", KPLIB_supply_crate, [""]],
+    ["_resource", KPLIB_b_crateSupply, [""]],
     ["_amount", 100, [0]],
     ["_pos", getPos player, [[]], [2, 3]]
 ];

--- a/Missionframework/functions/fn_forceBluforCrew.sqf
+++ b/Missionframework/functions/fn_forceBluforCrew.sqf
@@ -2,7 +2,7 @@
     File: fn_forceBluforCrew.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -31,7 +31,7 @@ if ((side _grp) != KPLIB_side_friendly) then {
 
     _grp = createGroup [KPLIB_side_friendly, true];
     while {count units _grp < 3} do {
-        [crewman_classname, getPos _veh, _grp] call KPLIB_fnc_createManagedUnit;
+        [KPLIB_b_crewUnit, getPos _veh, _grp] call KPLIB_fnc_createManagedUnit;
     };
     ((units _grp) select 0) moveInDriver _veh;
     ((units _grp) select 1) moveInGunner _veh;

--- a/Missionframework/functions/fn_getCrateHeight.sqf
+++ b/Missionframework/functions/fn_getCrateHeight.sqf
@@ -2,7 +2,7 @@
     File: fn_getCrateHeight.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-26
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,9 +24,9 @@ if (_crateClass isEqualTo "") exitWith {["Empty string given"] call BIS_fnc_erro
 private _height = 0;
 
 switch (_crateClass) do {
-    case KPLIB_supply_crate: {_height = 0.4;};
-    case KPLIB_ammo_crate: {_height = 0.6;};
-    case KPLIB_fuel_crate: {_height = 0.3;};
+    case KPLIB_b_crateSupply: {_height = 0.4;};
+    case KPLIB_b_crateAmmo: {_height = 0.6;};
+    case KPLIB_b_crateFuel: {_height = 0.3;};
     default {_height = 0.6;};
 };
 

--- a/Missionframework/functions/fn_getFobName.sqf
+++ b/Missionframework/functions/fn_getFobName.sqf
@@ -2,7 +2,7 @@
     File: fn_getFobName.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2020-05-17
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -19,4 +19,4 @@ params [
     ["_fob", [0, 0, 0], [[]], [2, 3]]
 ];
 
-military_alphabet param [KPLIB_sectors_fob findIf {(_x distance2d _fob) < 100}, ""]
+KPLIB_militaryAlphabet param [KPLIB_sectors_fob findIf {(_x distance2d _fob) < 100}, ""]

--- a/Missionframework/functions/fn_getMilitaryId.sqf
+++ b/Missionframework/functions/fn_getMilitaryId.sqf
@@ -2,7 +2,7 @@
     File: fn_getMilitaryId.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-09-14
-    Last Update: 2019-12-06
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,7 +23,7 @@ if (_number isEqualTo -1) exitWith {["No valid number given"] call BIS_fnc_error
 
 _number = _number + 1;
 private _return = [];
-private _alphabetCount = count military_alphabet;
+private _alphabetCount = count KPLIB_militaryAlphabet;
 private _remain = 0;
 
 while {_number > 0} do {
@@ -34,4 +34,4 @@ while {_number > 0} do {
 
 reverse _return;
 
-(_return apply {military_alphabet select _x}) joinString " "
+(_return apply {KPLIB_militaryAlphabet select _x}) joinString " "

--- a/Missionframework/functions/fn_getMobileRespawns.sqf
+++ b/Missionframework/functions/fn_getMobileRespawns.sqf
@@ -2,7 +2,7 @@
     File: fn_getMobileRespawns.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-11-25
-    Last Update: 2019-12-05
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 private _respawn_trucks = vehicles select {
-    (typeOf _x) in [Respawn_truck_typename, huron_typename] &&
+    (typeOf _x) in [KPLIB_b_mobileRespawn, KPLIB_b_potato01] &&
     {alive _x} &&
     {_x distance2d startbase > 500} &&
     {abs (speed _x) < 5} &&

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-29
-    Last Update: 2020-05-17
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -87,7 +87,7 @@ private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew"];
 
     // Only save player side, seized or captured objects
     if (
-        (!(_class in civilian_vehicles) || {_x getVariable ["KPLIB_seized", false]}) &&
+        (!(_class in KPLIB_c_vehicles) || {_x getVariable ["KPLIB_seized", false]}) &&
         (!((toLower _class) in KPLIB_o_allVeh_classes) || {_x getVariable ["KPLIB_captured", false]})
     ) then {
         _objectsToSave pushBack [_class, _savedPos, _savedVecDir, _savedVecUp, _hasCrew];
@@ -111,9 +111,9 @@ private ["_supplyValue", "_ammoValue", "_fuelValue"];
     // Sum all stored resources of current storage
     {
         switch ((typeOf _x)) do {
-            case KPLIB_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
-            case KPLIB_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
-            case KPLIB_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
+            case KPLIB_b_crateSupply: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
+            case KPLIB_b_crateAmmo: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
+            case KPLIB_b_crateFuel: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
             default {[format ["Invalid object (%1) at storage area", (typeOf _x)], "ERROR"] call KPLIB_fnc_log;};
         };
     } forEach (attachedObjects _x);
@@ -168,7 +168,7 @@ private _stats = [
     stats_secondary_objectives,
     stats_sectors_liberated,
     stats_sectors_lost,
-    stats_spartan_respawns,
+    stats_potato_respawns,
     stats_supplies_produced,
     stats_supplies_spent,
     stats_vehicles_recycled

--- a/Missionframework/functions/fn_getStoragePositions.sqf
+++ b/Missionframework/functions/fn_getStoragePositions.sqf
@@ -2,7 +2,7 @@
     File: fn_getStoragePositions.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-27
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -22,8 +22,8 @@ params [
 if (isNull _storage) exitWith {["Null object given"] call BIS_fnc_error; [[], 0]};
 
 private _data = [
-    [KPLIB_small_storage_building, [KPLIB_small_storage_positions, 4]],
-    [KPLIB_large_storage_building, [KPLIB_large_storage_positions, 6.5]]
+    [KPLIB_b_smallStorage, [KPLIB_small_storage_positions, 4]],
+    [KPLIB_b_largeStorage, [KPLIB_large_storage_positions, 6.5]]
 ] select {(typeOf _storage) isEqualTo (_x select 0)};
 
 if (_data isEqualTo []) exitWith {["No valid storage object given"] call BIS_fnc_error; [[], 0]};

--- a/Missionframework/functions/fn_potatoScan.sqf
+++ b/Missionframework/functions/fn_potatoScan.sqf
@@ -2,7 +2,7 @@
     File: fn_potatoScan.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-12-03
-    Last Update: 2019-12-07
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -15,7 +15,7 @@
         Potato 01 [OBJECT]
 */
 
-private _potatoes = vehicles select {typeof _x == huron_typename && alive _x};
+private _potatoes = vehicles select {typeof _x == KPLIB_b_potato01 && alive _x};
 if !(_potatoes isEqualTo []) then {
     _potatoes select 0
 } else {

--- a/Missionframework/functions/fn_setFobMass.sqf
+++ b/Missionframework/functions/fn_setFobMass.sqf
@@ -2,11 +2,11 @@
     File: fn_setFobMass.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-02
-    Last Update: 2020-04-06
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
-        Sets mass of FOB box to Max slingload weight of "huron_typename" lowered by 100.
+        Sets mass of FOB box to Max slingload weight of "KPLIB_b_potato01" lowered by 100.
         If max slingload mass is lower than 1000 its set to 1000.
         If it is higher than 3000 it's set to 3000.
 
@@ -23,7 +23,7 @@ params [
 
 if (isNull _box) exitWith {["Null object given"] call BIS_fnc_error; false};
 
-private _boxMass = getNumber(configFile >> "CfgVehicles" >> huron_typename >> "slingLoadMaxCargoMass") - 100;
+private _boxMass = getNumber(configFile >> "CfgVehicles" >> KPLIB_b_potato01 >> "slingLoadMaxCargoMass") - 100;
 _boxMass = 1000 max (_boxMass min 3000);
 
 if (local _box) then {

--- a/Missionframework/functions/fn_setVehicleSeized.sqf
+++ b/Missionframework/functions/fn_setVehicleSeized.sqf
@@ -2,7 +2,7 @@
     File: fn_setVehicleSeized.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-20
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -24,7 +24,7 @@ if (isNull _veh) exitWith {["Null object given"] call BIS_fnc_error; false};
 
 private _type = typeOf _veh;
 
-if !(_type in civilian_vehicles) exitWith {false};
+if !(_type in KPLIB_c_vehicles) exitWith {false};
 
 if !(_veh getVariable ["KPLIB_seized", false]) then {
     _veh setVariable ["KPLIB_seized", true, true];

--- a/Missionframework/functions/fn_sortStorage.sqf
+++ b/Missionframework/functions/fn_sortStorage.sqf
@@ -2,7 +2,7 @@
     File: fn_sortStorage.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-06-09
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -27,9 +27,9 @@ private _fuel = 0;
 
 {
     switch (typeOf _x) do {
-        case KPLIB_supply_crate: {_supply = _supply + (_x getVariable ["KPLIB_crate_value",0]);};
-        case KPLIB_ammo_crate: {_ammo = _ammo + (_x getVariable ["KPLIB_crate_value",0]);};
-        case KPLIB_fuel_crate: {_fuel = _fuel + (_x getVariable ["KPLIB_crate_value",0]);};
+        case KPLIB_b_crateSupply: {_supply = _supply + (_x getVariable ["KPLIB_crate_value",0]);};
+        case KPLIB_b_crateAmmo: {_ammo = _ammo + (_x getVariable ["KPLIB_crate_value",0]);};
+        case KPLIB_b_crateFuel: {_fuel = _fuel + (_x getVariable ["KPLIB_crate_value",0]);};
         default {[format ["Invalid object (%1) at storage area", (typeOf _x)], "ERROR"] call KPLIB_fnc_log;};
     };
     detach _x;

--- a/Missionframework/functions/fn_spawnCivilians.sqf
+++ b/Missionframework/functions/fn_spawnCivilians.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnCivilians.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-12-03
-    Last Update: 2020-05-17
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -40,7 +40,7 @@ for "_i" from 1 to _amount do {
 
     _civs pushBack (
         [
-            selectRandom civilians,
+            selectRandom KPLIB_c_units,
             [(((_sPos select 0) + (75 * _spread)) - (random (150 * _spread))), (((_sPos select 1) + (75 * _spread)) - (random (150 * _spread))), 0],
             _grp
         ] call KPLIB_fnc_createManagedUnit

--- a/Missionframework/functions/fn_spawnGuerillaGroup.sqf
+++ b/Missionframework/functions/fn_spawnGuerillaGroup.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnGuerillaGroup.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-08
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,10 +25,10 @@ params [
 private _tier = [] call KPLIB_fnc_getResistanceTier;
 private _cr_multi = [] call KPLIB_fnc_crGetMulti;
 if (_amount == 0) then {_amount = (6 + (round (random _cr_multi)) + (round (random _tier)));};
-private _weapons = missionNamespace getVariable ("KPLIB_guerilla_weapons_" + str _tier);
-private _uniforms = missionNamespace getVariable ("KPLIB_guerilla_uniforms_" + str _tier);
-private _vests = missionNamespace getVariable ("KPLIB_guerilla_vests_" + str _tier);
-private _headgear = missionNamespace getVariable ("KPLIB_guerilla_headgear_" + str _tier);
+private _weapons = missionNamespace getVariable ("KPLIB_r_weapons_" + str _tier);
+private _uniforms = missionNamespace getVariable ("KPLIB_r_uniforms_" + str _tier);
+private _vests = missionNamespace getVariable ("KPLIB_r_vests_" + str _tier);
+private _headgear = missionNamespace getVariable ("KPLIB_r_headgear_" + str _tier);
 
 // Spawn guerilla units
 private _grp = createGroup [KPLIB_side_resistance, true];
@@ -36,7 +36,7 @@ private _unit = objNull;
 private _weapon = [];
 for "_i" from 1 to _amount do {
     // Create unit
-    _unit = [selectRandom KPLIB_guerilla_units, _pos, _grp, "PRIVATE", 5] call KPLIB_fnc_createManagedUnit;
+    _unit = [selectRandom KPLIB_r_units, _pos, _grp, "PRIVATE", 5] call KPLIB_fnc_createManagedUnit;
 
     // Clear inventory
     removeAllWeapons _unit;
@@ -54,7 +54,7 @@ for "_i" from 1 to _amount do {
     _unit addItemToUniform "MiniGrenade";
     _unit addVest (selectRandom _vests);
     _unit addHeadgear (selectRandom _headgear);
-    if (_tier > 1) then {_unit addGoggles (selectRandom KPLIB_guerilla_facegear);};
+    if (_tier > 1) then {_unit addGoggles (selectRandom KPLIB_r_facegear);};
 
     // Add standard items
     _unit linkItem "ItemMap";

--- a/Missionframework/kp_objectInits.sqf
+++ b/Missionframework/kp_objectInits.sqf
@@ -39,12 +39,12 @@ KPLIB_objectInits = [
 
     // Add ViV and build action to FOB box/truck
     [
-        [FOB_box_typename, FOB_truck_typename],
+        [KPLIB_b_fobBox, KPLIB_b_fobTruck],
         {
             [_this] spawn {
                 params ["_fobBox"];
                 waitUntil {sleep 0.1; time > 0};
-                if ((typeOf _fobBox) isEqualTo FOB_box_typename) then {
+                if ((typeOf _fobBox) isEqualTo KPLIB_b_fobBox) then {
                     [_fobBox] call KPLIB_fnc_setFobMass;
                     [_fobBox] remoteExecCall ["KPLIB_fnc_setLoadableViV", 0, _fobBox];
                 };
@@ -55,7 +55,7 @@ KPLIB_objectInits = [
 
     // Add FOB building damage handler override and repack action
     [
-        [FOB_typename],
+        [KPLIB_b_fobBuilding],
         {
             _this addEventHandler ["HandleDamage", {0}];
             [_this] spawn {
@@ -68,7 +68,7 @@ KPLIB_objectInits = [
 
     // Add ViV action to Arsenal crate
     [
-        [Arsenal_typename],
+        [KPLIB_b_arsenal],
         {
             [_this] spawn {
                 params ["_arsenal"];
@@ -80,13 +80,13 @@ KPLIB_objectInits = [
 
     // Add storage type variable to built storage areas (only for FOB built/loaded ones)
     [
-        [KPLIB_small_storage_building, KPLIB_large_storage_building],
+        [KPLIB_b_smallStorage, KPLIB_b_largeStorage],
         {_this setVariable ["KPLIB_storage_type", 0, true];}
     ],
 
     // Add ACE variables to corresponding building types
     [
-        [KPLIB_recycle_building],
+        [KPLIB_b_logiStation],
         {_this setVariable ["ace_isRepairFacility", 1, true];}
     ],
     [

--- a/Missionframework/presets/civilians/apex.sqf
+++ b/Missionframework/presets/civilians/apex.sqf
@@ -2,7 +2,7 @@
     File: apex.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "C_Man_casual_1_F_tanoan",
     "C_Man_casual_2_F_tanoan",
     "C_Man_casual_3_F_tanoan",
@@ -34,7 +34,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "C_Quadbike_01_F",
     "C_Hatchback_01_F",
     "C_Hatchback_01_sport_F",

--- a/Missionframework/presets/civilians/cup_cherno.sqf
+++ b/Missionframework/presets/civilians/cup_cherno.sqf
@@ -2,7 +2,7 @@
     File: cup_cherno.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-19
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -18,7 +18,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "CUP_C_C_Assistant_01",
     "CUP_C_C_Citizen_02",
     "CUP_C_C_Citizen_01",
@@ -60,7 +60,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "CUP_C_Skoda_Blue_CIV",
     "CUP_C_Skoda_Green_CIV",
     "CUP_C_Skoda_Red_CIV",

--- a/Missionframework/presets/civilians/cup_takistan.sqf
+++ b/Missionframework/presets/civilians/cup_takistan.sqf
@@ -2,7 +2,7 @@
     File: cup_takistan.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-15
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -18,7 +18,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "CUP_C_TK_Man_04",
     "CUP_C_TK_Man_04_Jack",
     "CUP_C_TK_Man_04_Waist",
@@ -47,7 +47,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "CUP_C_TT650_TK_CIV",
     "CUP_C_S1203_CIV",
     "CUP_C_S1203_Ambulance_CIV",

--- a/Missionframework/presets/civilians/custom.sqf
+++ b/Missionframework/presets/civilians/custom.sqf
@@ -2,7 +2,7 @@
     File: custom.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "C_Man_Fisherman_01_F",
     "C_man_w_worker_F",
     "C_man_1_1_F",
@@ -43,7 +43,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "C_Quadbike_01_F",
     "C_Hatchback_01_F",
     "C_Hatchback_01_sport_F",

--- a/Missionframework/presets/civilians/germany.sqf
+++ b/Missionframework/presets/civilians/germany.sqf
@@ -2,7 +2,7 @@
     File: germany.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-08
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "C_Man_casual_1_F_euro",
     "C_Man_casual_1_F_euro",
     "C_Man_casual_2_F_euro",
@@ -37,7 +37,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "C_Truck_02_covered_F",
     "C_Truck_02_covered_F",
     "C_Truck_02_fuel_F",

--- a/Missionframework/presets/civilians/middle_eastern.sqf
+++ b/Missionframework/presets/civilians/middle_eastern.sqf
@@ -2,7 +2,7 @@
     File: middle_eastern.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "LOP_Tak_Civ_Random",
     "LOP_Tak_Civ_Man_06",
     "LOP_Tak_Civ_Man_08",
@@ -36,7 +36,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "LOP_TAK_Civ_Hatchback",
     "LOP_TAK_Civ_Landrover",
     "LOP_TAK_Civ_Offroad",

--- a/Missionframework/presets/civilians/rds_civ.sqf
+++ b/Missionframework/presets/civilians/rds_civ.sqf
@@ -2,7 +2,7 @@
     File: rds_civ.sqf
     Author: PSYKO-nz - https://github.com/PSYKO-nz
     Date: 2018-02-02
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "RDS_Assistant",
     "RDS_Citizen_Random",
     "RDS_Citizen2",
@@ -58,7 +58,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "RDS_Van_01_fuel_F",
     "RDS_Gaz24_Civ_03",
     "RDS_Gaz24_Civ_01",

--- a/Missionframework/presets/civilians/unsung.sqf
+++ b/Missionframework/presets/civilians/unsung.sqf
@@ -2,7 +2,7 @@
     File: unsung.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-06-04
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -16,7 +16,7 @@
 */
 
 // Civilian classnames.
-civilians = [
+KPLIB_c_units = [
     "uns_civilian1",
     "uns_civilian1_b1",
     "uns_civilian2",
@@ -28,7 +28,7 @@ civilians = [
 ];
 
 // Civilian vehicle classnames.
-civilian_vehicles = [
+KPLIB_c_vehicles = [
     "C_Truck_02_fuel_F",
     "C_Truck_02_transport_F",
     "C_Truck_02_covered_F"

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -91,16 +91,16 @@ switch (KPLIB_presetCivilians) do {
 
 // Prices for the blufor infantry squads (supplies, ammo, fuel)
 KPLIB_b_allSquads = [
-    [blufor_squad_inf_light,200,0,0],
-    [blufor_squad_inf,300,0,0],
-    [blufor_squad_at,200,250,0],
-    [blufor_squad_aa,200,250,0],
-    [blufor_squad_recon,250,0,0],
-    [blufor_squad_para,200,0,0]
+    [KPLIB_b_squadLight,200,0,0],
+    [KPLIB_b_squadInf,300,0,0],
+    [KPLIB_b_squadAT,200,250,0],
+    [KPLIB_b_squadAA,200,250,0],
+    [KPLIB_b_squadRecon,250,0,0],
+    [KPLIB_b_squadPara,200,0,0]
 ];
 
 // Squad names for build menu
-squads_names = [
+KPLIB_b_squadNames = [
     localize "STR_LIGHT_RIFLE_SQUAD",
     localize "STR_RIFLE_SQUAD",
     localize "STR_AT_SQUAD",
@@ -110,7 +110,7 @@ squads_names = [
 ];
 
 // Classnames of objects which should be ignored when building
-KPLIB_ignore_colisions_when_building = [
+KPLIB_b_collisionIgnoreObjects = [
     "Land_HelipadSquare_F",
     "Land_TentHangar_V1_F",
     "Land_runway_edgelight",
@@ -166,20 +166,20 @@ KPLIB_ignore_colisions_when_building = [
     Checking all preset arrays for missing mods and sort out not available classnames
 */
 // Blufor
-infantry_units                  = infantry_units                    select {[( _x select 0)] call KPLIB_fnc_checkClass};
-light_vehicles                  = light_vehicles                    select {[( _x select 0)] call KPLIB_fnc_checkClass};
-heavy_vehicles                  = heavy_vehicles                    select {[( _x select 0)] call KPLIB_fnc_checkClass};
-air_vehicles                    = air_vehicles                      select {[( _x select 0)] call KPLIB_fnc_checkClass};
-static_vehicles                 = static_vehicles                   select {[( _x select 0)] call KPLIB_fnc_checkClass};
-buildings                       = buildings                         select {[( _x select 0)] call KPLIB_fnc_checkClass};
-support_vehicles                = support_vehicles                  select {[( _x select 0)] call KPLIB_fnc_checkClass};
-blufor_squad_inf_light          = blufor_squad_inf_light            select {[_x] call KPLIB_fnc_checkClass};
-blufor_squad_inf                = blufor_squad_inf                  select {[_x] call KPLIB_fnc_checkClass};
-blufor_squad_at                 = blufor_squad_at                   select {[_x] call KPLIB_fnc_checkClass};
-blufor_squad_aa                 = blufor_squad_aa                   select {[_x] call KPLIB_fnc_checkClass};
-blufor_squad_recon              = blufor_squad_recon                select {[_x] call KPLIB_fnc_checkClass};
-blufor_squad_para               = blufor_squad_para                 select {[_x] call KPLIB_fnc_checkClass};
-elite_vehicles                  = elite_vehicles                    select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_infantry                = KPLIB_b_infantry                  select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_vehLight                = KPLIB_b_vehLight                  select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_vehHeavy                = KPLIB_b_vehHeavy                  select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_vehAir                  = KPLIB_b_vehAir                    select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_vehStatic               = KPLIB_b_vehStatic                 select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_objectsDeco             = KPLIB_b_objectsDeco               select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_vehSupport              = KPLIB_b_vehSupport                select {[( _x select 0)] call KPLIB_fnc_checkClass};
+KPLIB_b_squadLight              = KPLIB_b_squadLight                select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_squadInf                = KPLIB_b_squadInf                  select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_squadAT                 = KPLIB_b_squadAT                   select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_squadAA                 = KPLIB_b_squadAA                   select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_squadRecon              = KPLIB_b_squadRecon                select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_squadPara               = KPLIB_b_squadPara                 select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_b_vehToUnlock                  = KPLIB_b_vehToUnlock                    select {[_x] call KPLIB_fnc_checkClass};
 
 // Opfor
 KPLIB_o_militiaInfantry         = KPLIB_o_militiaInfantry           select {[_x] call KPLIB_fnc_checkClass};
@@ -193,12 +193,12 @@ KPLIB_o_helicopters             = KPLIB_o_helicopters               select {[_x]
 KPLIB_o_planes                  = KPLIB_o_planes                    select {[_x] call KPLIB_fnc_checkClass};
 
 // Resistance
-KPLIB_guerilla_units            = KPLIB_guerilla_units              select {[_x] call KPLIB_fnc_checkClass};
-KPLIB_guerilla_vehicles         = KPLIB_guerilla_vehicles           select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_r_units                   = KPLIB_r_units                     select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_r_vehicles                = KPLIB_r_vehicles                  select {[_x] call KPLIB_fnc_checkClass};
 
 // Civilians
-civilians                       = civilians                         select {[_x] call KPLIB_fnc_checkClass};
-civilian_vehicles               = civilian_vehicles                 select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_c_units                   = KPLIB_c_units                     select {[_x] call KPLIB_fnc_checkClass};
+KPLIB_c_vehicles                = KPLIB_c_vehicles                  select {[_x] call KPLIB_fnc_checkClass};
 
 // Misc
 KPLIB_transportConfigs          = KPLIB_transportConfigs            select {[_x select 0] call KPLIB_fnc_checkClass};
@@ -208,48 +208,48 @@ KPLIB_aiResupplySources         = KPLIB_aiResupplySources           select {[_x]
     Fetch arrays with only classnames from the blufor preset build arrays
     Beware that all classnames are converted to lowercase. Important for e.g. `in` checks, as it's case-sensitive.
 */
-KPLIB_b_infantry_classes        = infantry_units                    apply {toLower (_x select 0)};
-KPLIB_b_light_classes           = light_vehicles                    apply {toLower (_x select 0)};
-KPLIB_b_heavy_classes           = heavy_vehicles                    apply {toLower (_x select 0)};
-KPLIB_b_air_classes             = air_vehicles                      apply {toLower (_x select 0)};
-KPLIB_b_static_classes          = static_vehicles                   apply {toLower (_x select 0)};
-KPLIB_b_buildings_classes       = buildings                         apply {toLower (_x select 0)};
-KPLIB_b_support_classes         = support_vehicles                  apply {toLower (_x select 0)};
+KPLIB_b_inf_classes             = KPLIB_b_infantry                  apply {toLower (_x select 0)};
+KPLIB_b_light_classes           = KPLIB_b_vehLight                  apply {toLower (_x select 0)};
+KPLIB_b_heavy_classes           = KPLIB_b_vehHeavy                  apply {toLower (_x select 0)};
+KPLIB_b_air_classes             = KPLIB_b_vehAir                    apply {toLower (_x select 0)};
+KPLIB_b_static_classes          = KPLIB_b_vehStatic                 apply {toLower (_x select 0)};
+KPLIB_b_deco_classes            = KPLIB_b_objectsDeco               apply {toLower (_x select 0)};
+KPLIB_b_support_classes         = KPLIB_b_vehSupport                apply {toLower (_x select 0)};
 KPLIB_transport_classes         = KPLIB_transportConfigs            apply {toLower (_x select 0)};
 
-KPLIB_b_infantry_classes append (blufor_squad_inf_light + blufor_squad_inf + blufor_squad_at + blufor_squad_aa + blufor_squad_recon + blufor_squad_para);
-KPLIB_b_infantry_classes        = KPLIB_b_infantry_classes          apply {toLower _x};
-KPLIB_b_infantry_classes        = KPLIB_b_infantry_classes          arrayIntersect KPLIB_b_infantry_classes;
+KPLIB_b_inf_classes append (KPLIB_b_squadLight + KPLIB_b_squadInf + KPLIB_b_squadAT + KPLIB_b_squadAA + KPLIB_b_squadRecon + KPLIB_b_squadPara);
+KPLIB_b_inf_classes             = KPLIB_b_inf_classes               apply {toLower _x};
+KPLIB_b_inf_classes             = KPLIB_b_inf_classes               arrayIntersect KPLIB_b_inf_classes;
 
 /*
     Opfor squad compositions
 */
-KPLIB_o_squadStd    = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_heavyGunner, KPLIB_o_medic, KPLIB_o_marksman, KPLIB_o_grenadier, KPLIB_o_riflemanLAT];
-KPLIB_o_squadInf    = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_heavyGunner, KPLIB_o_heavyGunner, KPLIB_o_marksman, KPLIB_o_sharpshooter, KPLIB_o_sniper];
-KPLIB_o_squadTank   = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_riflemanLAT, KPLIB_o_riflemanLAT, KPLIB_o_atSpecialist, KPLIB_o_atSpecialist, KPLIB_o_atSpecialist];
-KPLIB_o_squadAir    = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_riflemanLAT, KPLIB_o_riflemanLAT, KPLIB_o_aaSpecialist, KPLIB_o_aaSpecialist, KPLIB_o_aaSpecialist];
+KPLIB_o_squadStd        = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_heavyGunner, KPLIB_o_medic, KPLIB_o_marksman, KPLIB_o_grenadier, KPLIB_o_riflemanLAT];
+KPLIB_o_squadInf        = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_heavyGunner, KPLIB_o_heavyGunner, KPLIB_o_marksman, KPLIB_o_sharpshooter, KPLIB_o_sniper];
+KPLIB_o_squadTank       = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_riflemanLAT, KPLIB_o_riflemanLAT, KPLIB_o_atSpecialist, KPLIB_o_atSpecialist, KPLIB_o_atSpecialist];
+KPLIB_o_squadAir        = [KPLIB_o_squadLeader, KPLIB_o_medic, KPLIB_o_machinegunner, KPLIB_o_riflemanLAT, KPLIB_o_riflemanLAT, KPLIB_o_aaSpecialist, KPLIB_o_aaSpecialist, KPLIB_o_aaSpecialist];
 
 /*
     Liberation specific collections
 */
-KPLIB_buildList                 = [[], infantry_units, light_vehicles, heavy_vehicles, air_vehicles, static_vehicles, buildings, support_vehicles, KPLIB_b_allSquads];
-KPLIB_crates                    = [KPLIB_supply_crate, KPLIB_ammo_crate, KPLIB_fuel_crate];
-KPLIB_airSlots                  = [KPLIB_heli_slot_building, KPLIB_plane_slot_building];
-KPLIB_storageBuildings          = [KPLIB_small_storage_building, KPLIB_large_storage_building];
-KPLIB_upgradeBuildings          = [KPLIB_recycle_building, KPLIB_air_vehicle_building, KPLIB_heli_slot_building, KPLIB_plane_slot_building];
-KPLIB_aiResupplySources append [Respawn_truck_typename, huron_typename, Arsenal_typename];
+KPLIB_buildList         = [[], KPLIB_b_infantry, KPLIB_b_vehLight, KPLIB_b_vehHeavy, KPLIB_b_vehAir, KPLIB_b_vehStatic, KPLIB_b_objectsDeco, KPLIB_b_vehSupport, KPLIB_b_allSquads];
+KPLIB_crates            = [KPLIB_b_crateSupply, KPLIB_b_crateAmmo, KPLIB_b_crateFuel];
+KPLIB_airSlots          = [KPLIB_b_slotHeli, KPLIB_b_slotPlane];
+KPLIB_storageBuildings  = [KPLIB_b_smallStorage, KPLIB_b_largeStorage];
+KPLIB_upgradeBuildings  = [KPLIB_b_logiStation, KPLIB_b_airControl, KPLIB_b_slotHeli, KPLIB_b_slotPlane];
+KPLIB_aiResupplySources append [KPLIB_b_mobileRespawn, KPLIB_b_potato01, KPLIB_b_arsenal];
 
-KPLIB_crates                    = KPLIB_crates              apply {toLower _x};
-KPLIB_airSlots                  = KPLIB_airSlots            apply {toLower _x};
-KPLIB_storageBuildings          = KPLIB_storageBuildings    apply {toLower _x};
-KPLIB_upgradeBuildings          = KPLIB_upgradeBuildings    apply {toLower _x};
-KPLIB_aiResupplySources         = KPLIB_aiResupplySources   apply {toLower _x};
+KPLIB_crates            = KPLIB_crates              apply {toLower _x};
+KPLIB_airSlots          = KPLIB_airSlots            apply {toLower _x};
+KPLIB_storageBuildings  = KPLIB_storageBuildings    apply {toLower _x};
+KPLIB_upgradeBuildings  = KPLIB_upgradeBuildings    apply {toLower _x};
+KPLIB_aiResupplySources = KPLIB_aiResupplySources   apply {toLower _x};
 
 /*
     Classname collections
 */
 // All land vehicle classnames
-KPLIB_allLandVeh_classes = [[], [huron_typename]] select (huron_typename isKindOf "Air");;
+KPLIB_allLandVeh_classes = [[], [KPLIB_b_potato01]] select (KPLIB_b_potato01 isKindOf "Air");;
 {
     KPLIB_allLandVeh_classes append _x;
 } forEach [
@@ -266,7 +266,7 @@ KPLIB_allLandVeh_classes = [[], [huron_typename]] select (huron_typename isKindO
 KPLIB_allLandVeh_classes = KPLIB_allLandVeh_classes arrayIntersect KPLIB_allLandVeh_classes;
 
 // All air vehicle classnames
-KPLIB_allAirVeh_classes = [[], [huron_typename]] select (huron_typename isKindOf "Air");
+KPLIB_allAirVeh_classes = [[], [KPLIB_b_potato01]] select (KPLIB_b_potato01 isKindOf "Air");
 {
     KPLIB_allAirVeh_classes append _x;
 } forEach [KPLIB_o_helicopters apply {toLower _x}, KPLIB_o_planes apply {toLower _x}, KPLIB_b_air_classes, KPLIB_b_support_classes select {_x isKindOf "Air"}];
@@ -310,10 +310,10 @@ KPLIB_typeAirClasses   = +KPLIB_b_air_classes;
         case (_x isKindOf "Air"):   {KPLIB_typeAirClasses      pushBack _x};
         default                     {KPLIB_typeLightClasses    pushBack _x};
     };
-} forEach (KPLIB_b_support_classes + [toLower huron_typename]);
+} forEach (KPLIB_b_support_classes + [toLower KPLIB_b_potato01]);
 
 // Military alphabet used for FOBs and convois
-military_alphabet = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-Ray", "Yankee", "Zulu"];
+KPLIB_militaryAlphabet = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-Ray", "Yankee", "Zulu"];
 
 // Misc variables
 markers_reset = [99999,99999,0];

--- a/Missionframework/presets/players/apex.sqf
+++ b/Missionframework/presets/players/apex.sqf
@@ -2,7 +2,7 @@
     File: apex.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -29,26 +29,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V4_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_T_Truck_01_box_F";                              // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "B_T_Truck_01_medical_F";                      // This is the mobile respawn (and medical) truck.
-huron_typename = "B_Heli_Transport_03_unarmed_F";                       // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "B_T_crew_F";                                       // This defines the crew for vehicles.
-pilot_classname = "B_T_Helipilot_F";                                    // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "B_Heli_Light_01_F";                      // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_T_Boat_Transport_01_F";                       // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "B_T_Truck_01_transport_F";                     // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_green_F";                 // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V4_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_T_Truck_01_box_F";                              // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "B_T_Truck_01_medical_F";                      // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "B_Heli_Transport_03_unarmed_F";                       // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "B_T_crew_F";                                       // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "B_T_Helipilot_F";                                    // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "B_Heli_Light_01_F";                      // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_T_Boat_Transport_01_F";                       // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "B_T_Truck_01_transport_F";                     // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_green_F";                 // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -58,7 +58,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["B_T_Soldier_F",20,0,0],                                           // Rifleman
     ["B_T_Soldier_LAT_F",30,0,0],                                       // Rifleman (AT)
     ["B_T_Soldier_GL_F",25,0,0],                                        // Grenadier
@@ -84,7 +84,7 @@ infantry_units = [
     ["B_T_Pilot_F",10,0,0]                                              // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_T_Quadbike_01_F",50,0,25],                                      // Quad Bike
     ["B_T_LSV_01_unarmed_F",75,0,50],                                   // Prowler
     ["B_T_LSV_01_armed_F",75,40,50],                                    // Prowler (HMG)
@@ -121,7 +121,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhsusf_m113_usarmy",200,40,100],                                  // M113A3 (M2)
     ["rhsusf_m113_usarmy_MK19",200,60,100],                             // M113A3 (Mk19)
     ["rhsusf_m113_usarmy_medical",200,0,100],                           // M113A3 (Medical)
@@ -156,7 +156,7 @@ heavy_vehicles = [
     ["B_T_MBT_01_mlrs_F",800,1750,400]                                  // M5 Sandstorm MLRS
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                             // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                             // AL-6 Pelican (Cargo)
     ["B_Heli_Light_01_F",200,0,100],                                    // MH-9 Hummingbird
@@ -213,7 +213,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["B_HMG_01_F",25,40,0],                                             // Mk30A HMG .50
     ["B_HMG_01_high_F",25,40,0],                                        // Mk30 HMG .50 (Raised)
     ["B_HMG_01_A_F",35,40,0],                                           // Mk30 HMG .50 (Autonomous)
@@ -227,7 +227,7 @@ static_vehicles = [
     ["B_SAM_System_03_F",250,500,0]                                     // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V4_F",0,0,0],
     ["Land_Cargo_Patrol_V4_F",0,0,0],
     ["Land_Cargo_Tower_V4_F",0,0,0],
@@ -306,17 +306,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -356,7 +356,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "B_T_Soldier_TL_F",
     "B_T_Soldier_F",
     "B_T_Soldier_F",
@@ -370,7 +370,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "B_T_Soldier_TL_F",
     "B_T_Soldier_LAT_F",
     "B_T_Soldier_LAT_F",
@@ -384,7 +384,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "B_T_Soldier_TL_F",
     "B_T_Soldier_F",
     "B_T_Soldier_F",
@@ -396,7 +396,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "B_T_Soldier_TL_F",
     "B_T_Soldier_F",
     "B_T_Soldier_F",
@@ -408,7 +408,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "B_T_Recon_TL_F",
     "B_T_Recon_F",
     "B_T_Recon_F",
@@ -422,7 +422,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "B_T_Soldier_PG_F",
     "B_T_Soldier_PG_F",
     "B_T_Soldier_PG_F",
@@ -436,11 +436,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                    // Mk.V SOCOM
     "rhsusf_m1a1aim_tuski_wd",                                          // M1A1SA (Tusk I)
     "B_T_MBT_01_TUSK_F",                                                // M2A4 Slammer UP

--- a/Missionframework/presets/players/baf_des.sqf
+++ b/Missionframework/presets/players/baf_des.sqf
@@ -2,7 +2,7 @@
     File: baf_des.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -26,26 +26,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                        // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                                // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                    // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                       // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "UK3CB_BAF_LandRover_Amb_FFR_Sand_A_DDPM";         // This is the mobile respawn (and medical) truck.
-huron_typename = "UK3CB_BAF_Merlin_HC3_18_DDPM";                            // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "UK3CB_BAF_Crewman_DDPM";                               // This defines the crew for vehicles.
-pilot_classname = "UK3CB_BAF_HeliPilot_Army_DDPM";                          // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "UK3CB_BAF_Wildcat_AH1_TRN_8A_DDPM";          // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                             // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhsusf_M977A4_BKIT_usarmy_d";                      // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";                 // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";                 // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                       // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                         // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                          // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                         // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                                   // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                                  // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                                 // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                        // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                                // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                    // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                       // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "UK3CB_BAF_LandRover_Amb_FFR_Sand_A_DDPM";         // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "UK3CB_BAF_Merlin_HC3_18_DDPM";                            // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "UK3CB_BAF_Crewman_DDPM";                               // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "UK3CB_BAF_HeliPilot_Army_DDPM";                          // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "UK3CB_BAF_Wildcat_AH1_TRN_8A_DDPM";          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                             // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhsusf_M977A4_BKIT_usarmy_d";                      // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";                 // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";                 // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                       // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                         // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                          // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                         // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                                   // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                                  // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                                 // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -55,7 +55,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                                 // T
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["UK3CB_BAF_Pointman_DDPM",15,0,0],                                     // Rifleman (Light)
     ["UK3CB_BAF_Rifleman_DDPM",20,0,0],                                     // Rifleman
     ["UK3CB_BAF_LAT_ILAW_DDPM",30,0,0],                                     // Rifleman (AT)
@@ -85,7 +85,7 @@ infantry_units = [
     ["UK3CB_BAF_Pilot_Army",10,0,0]                                         // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                            // Quad Bike
     ["B_LSV_01_unarmed_F",75,0,50],                                         // Prowler
     ["B_LSV_01_armed_F",75,40,50],                                          // Prowler (HMG)
@@ -114,7 +114,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                                 // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["RHS_M2A2_BUSKI",300,200,150],                                         // M2A2ODS (Busk I)
     ["RHS_M2A3_BUSKIII",300,250,175],                                       // M2A3 (Busk III)
     ["RHS_M6",300,250,175],                                                 // M6A2
@@ -123,7 +123,7 @@ heavy_vehicles = [
     ["rhsusf_m109d_usarmy",600,1250,300]                                    // M109A6
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                                 // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                                 // AL-6 Pelican (Cargo)
     ["UK3CB_BAF_Wildcat_AH1_TRN_8A_DDPM",225,0,125],                        // Wildcat AH1 8 Transport (Unarmed)
@@ -154,7 +154,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                     // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["UK3CB_BAF_Static_L7A2_Deployed_Low_DDPM",25,25,0],                    // L7A2 LMG (Low)
     ["UK3CB_BAF_Static_L7A2_Deployed_Mid_DDPM",25,25,0],                    // L7A2 LMG (Mid)
     ["UK3CB_BAF_Static_L7A2_Deployed_High_DDPM",25,25,0],                   // L7A2 LMG (High)
@@ -170,7 +170,7 @@ static_vehicles = [
     ["RHS_M119_D",100,200,0]                                                // M119A2
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V3_F",0,0,0],
     ["Land_Cargo_Patrol_V3_F",0,0,0],
     ["Land_Cargo_Tower_V3_F",0,0,0],
@@ -249,17 +249,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,75],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,75],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -285,7 +285,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "UK3CB_BAF_FT_DDPM",
     "UK3CB_BAF_Pointman_DDPM",
     "UK3CB_BAF_Pointman_DDPM",
@@ -299,7 +299,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "UK3CB_BAF_FT_DDPM",
     "UK3CB_BAF_LAT_ILAW_DDPM",
     "UK3CB_BAF_LAT_ILAW_DDPM",
@@ -313,7 +313,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "UK3CB_BAF_FT_DDPM",
     "UK3CB_BAF_Rifleman_DDPM",
     "UK3CB_BAF_Rifleman_DDPM",
@@ -325,7 +325,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "UK3CB_BAF_FT_DDPM",
     "UK3CB_BAF_Rifleman_DDPM",
     "UK3CB_BAF_Rifleman_DDPM",
@@ -337,7 +337,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "UK3CB_BAF_SC_DDPM_REC",
     "UK3CB_BAF_Pointman_DDPM_REC",
     "UK3CB_BAF_Pointman_DDPM_REC",
@@ -351,7 +351,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "UK3CB_BAF_Rifleman_DDPM",
     "UK3CB_BAF_Rifleman_DDPM",
     "UK3CB_BAF_Rifleman_DDPM",
@@ -365,11 +365,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                        // Mk.V SOCOM
     "RHS_M2A3_BUSKIII",                                                     // M2A3 (Busk III)
     "RHS_M6",                                                               // M6A2

--- a/Missionframework/presets/players/baf_mtp.sqf
+++ b/Missionframework/presets/players/baf_mtp.sqf
@@ -2,7 +2,7 @@
     File: baf_mtp.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -26,26 +26,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                        // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                                // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                    // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                       // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "UK3CB_BAF_LandRover_Amb_FFR_Green_A_MTP";         // This is the mobile respawn (and medical) truck.
-huron_typename = "UK3CB_BAF_Merlin_HC3_18_MTP";                             // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "UK3CB_BAF_Crewman_MTP";                                // This defines the crew for vehicles.
-pilot_classname = "UK3CB_BAF_HeliPilot_Army_MTP";                           // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "UK3CB_BAF_Wildcat_AH1_TRN_8A_MTP";           // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                             // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhsusf_M977A4_BKIT_usarmy_wd";                     // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";                 // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";                 // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                       // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                         // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                          // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                         // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                                   // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                                  // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                                 // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                        // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                                // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                    // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                       // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "UK3CB_BAF_LandRover_Amb_FFR_Green_A_MTP";         // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "UK3CB_BAF_Merlin_HC3_18_MTP";                             // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "UK3CB_BAF_Crewman_MTP";                                // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "UK3CB_BAF_HeliPilot_Army_MTP";                           // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "UK3CB_BAF_Wildcat_AH1_TRN_8A_MTP";           // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                             // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhsusf_M977A4_BKIT_usarmy_wd";                     // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";                 // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";                 // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                       // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                         // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                          // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                         // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                                   // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                                  // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                                 // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -55,7 +55,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                                 // T
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["UK3CB_BAF_Pointman_MTP",15,0,0],                                      // Rifleman (Light)
     ["UK3CB_BAF_Rifleman_MTP",20,0,0],                                      // Rifleman
     ["UK3CB_BAF_LAT_ILAW_MTP",30,0,0],                                      // Rifleman (AT)
@@ -85,7 +85,7 @@ infantry_units = [
     ["UK3CB_BAF_Pilot_Army",10,0,0]                                         // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                            // Quad Bike
     ["B_LSV_01_unarmed_F",75,0,50],                                         // Prowler
     ["B_LSV_01_armed_F",75,40,50],                                          // Prowler (HMG)
@@ -114,7 +114,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                                 // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["RHS_M2A2_BUSKI_WD",300,200,150],                                      // M2A2ODS (Busk I)
     ["RHS_M2A3_BUSKIII_wd",300,250,175],                                    // M2A3 (Busk III)
     ["RHS_M6_wd",300,250,175],                                              // M6A2
@@ -123,7 +123,7 @@ heavy_vehicles = [
     ["rhsusf_m109_usarmy",600,1250,300]                                     // M109A6
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                                 // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                                 // AL-6 Pelican (Cargo)
     ["UK3CB_BAF_Wildcat_AH1_TRN_8A_MTP",225,0,125],                         // Wildcat AH1 8 Transport (Unarmed)
@@ -154,7 +154,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                     // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["UK3CB_BAF_Static_L7A2_Deployed_Low_MTP",25,25,0],                     // L7A2 LMG (Low)
     ["UK3CB_BAF_Static_L7A2_Deployed_Mid_MTP",25,25,0],                     // L7A2 LMG (Mid)
     ["UK3CB_BAF_Static_L7A2_Deployed_High_MTP",25,25,0],                    // L7A2 LMG (High)
@@ -170,7 +170,7 @@ static_vehicles = [
     ["RHS_M119_WD",100,200,0]                                               // M119A2
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -249,17 +249,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,75],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,75],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -285,7 +285,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "UK3CB_BAF_FT_MTP",
     "UK3CB_BAF_Pointman_MTP",
     "UK3CB_BAF_Pointman_MTP",
@@ -299,7 +299,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "UK3CB_BAF_FT_MTP",
     "UK3CB_BAF_LAT_ILAW_MTP",
     "UK3CB_BAF_LAT_ILAW_MTP",
@@ -313,7 +313,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "UK3CB_BAF_FT_MTP",
     "UK3CB_BAF_Rifleman_MTP",
     "UK3CB_BAF_Rifleman_MTP",
@@ -325,7 +325,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "UK3CB_BAF_FT_MTP",
     "UK3CB_BAF_Rifleman_MTP",
     "UK3CB_BAF_Rifleman_MTP",
@@ -337,7 +337,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "UK3CB_BAF_SC_MTP_REC",
     "UK3CB_BAF_Pointman_MTP_REC",
     "UK3CB_BAF_Pointman_MTP_REC",
@@ -351,7 +351,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "UK3CB_BAF_Rifleman_MTP",
     "UK3CB_BAF_Rifleman_MTP",
     "UK3CB_BAF_Rifleman_MTP",
@@ -365,11 +365,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                        // Mk.V SOCOM
     "RHS_M2A3_BUSKIII_wd",                                                  // M2A3 (Busk III)
     "RHS_M6_wd",                                                            // M6A2

--- a/Missionframework/presets/players/bwmod.sqf
+++ b/Missionframework/presets/players/bwmod.sqf
@@ -2,7 +2,7 @@
     File: bwmod.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "rhsusf_M1078A1P2_B_WD_CP_fmtv_usarmy";            // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "rhsusf_M1085A1P2_B_WD_Medical_fmtv_usarmy";   // This is the mobile respawn (and medical) truck.
-huron_typename = "RHS_CH_47F";                                          // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "BWA3_Crew_Fleck";                                  // This defines the crew for vehicles.
-pilot_classname = "BWA3_Helipilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "RHS_MELB_MH6M";                          // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhsusf_M977A4_BKIT_usarmy_wd";                 // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "rhsusf_M1078A1P2_B_WD_CP_fmtv_usarmy";            // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "rhsusf_M1085A1P2_B_WD_Medical_fmtv_usarmy";   // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "RHS_CH_47F";                                          // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "BWA3_Crew_Fleck";                                  // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "BWA3_Helipilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "RHS_MELB_MH6M";                          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhsusf_M977A4_BKIT_usarmy_wd";                 // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["BWA3_Rifleman_lite_Fleck",15,0,0],                                // Rifleman (Light)
     ["BWA3_Rifleman_Fleck",20,0,0],                                     // Rifleman
     ["BWA3_RiflemanG27_Fleck",20,0,0],                                  // Rifleman (G27)
@@ -80,7 +80,7 @@ infantry_units = [
     ["rhsusf_airforce_jetpilot",10,0,0]                                 // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["rhsusf_m1025_w",100,0,50],                                        // M1025A2
     ["rhsusf_m1025_w_m2",100,40,50],                                    // M1025A2 (M2)
@@ -109,7 +109,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhsusf_m113_usarmy",200,40,100],                                  // M113A3 (M2)
     ["rhsusf_m113_usarmy_MK19",200,60,100],                             // M113A3 (Mk19)
     ["rhsusf_m113_usarmy_medical",200,0,100],                           // M113A3 (Medical)
@@ -123,7 +123,7 @@ heavy_vehicles = [
     ["rhsusf_m109_usarmy",600,1250,300]                                 // M109A6
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                             // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                             // AL-6 Pelican (Cargo)
     ["RHS_MELB_MH6M",200,0,100],                                        // MH-6M Little Bird
@@ -155,7 +155,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["RHS_M2StaticMG_MiniTripod_WD",25,40,0],                           // Mk2 HMG .50
     ["RHS_M2StaticMG_WD",25,40,0],                                      // Mk2 HMG .50 (Raised)
     ["RHS_MK19_TriPod_WD",25,60,0],                                     // Mk19 GMG 20mm
@@ -166,7 +166,7 @@ static_vehicles = [
     ["B_SAM_System_03_F",250,500,0]                                     // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -245,17 +245,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -278,7 +278,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "BWA3_TL_Fleck",
     "BWA3_Rifleman_lite_Fleck",
     "BWA3_Rifleman_lite_Fleck",
@@ -292,7 +292,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "BWA3_TL_Fleck",
     "BWA3_RiflemanAT_Pzf3_Fleck",
     "BWA3_RiflemanAT_Pzf3_Fleck",
@@ -306,7 +306,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "BWA3_TL_Fleck",
     "BWA3_Rifleman_Fleck",
     "BWA3_Rifleman_Fleck",
@@ -318,7 +318,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "BWA3_TL_Fleck",
     "BWA3_Rifleman_Fleck",
     "BWA3_Rifleman_Fleck",
@@ -330,7 +330,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "BWA3_recon_TL_Fleck",
     "BWA3_recon_Fleck",
     "BWA3_recon_Fleck",
@@ -344,7 +344,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
@@ -358,11 +358,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                    // Mk.V SOCOM
     "rhsusf_m1a1aim_tuski_wd",                                          // M1A1SA (Tusk I)
     "rhsusf_m1a2sep1tuskiiwd_usarmy",                                   // M1A2SEPv1 (Tusk II)

--- a/Missionframework/presets/players/bwmod_des.sqf
+++ b/Missionframework/presets/players/bwmod_des.sqf
@@ -2,7 +2,7 @@
     File: bwmod_des.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-10
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "rhsusf_M1078A1P2_B_D_CP_fmtv_usarmy";             // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "rhsusf_M1085A1P2_B_D_Medical_fmtv_usarmy";    // This is the mobile respawn (and medical) truck.
-huron_typename = "RHS_CH_47F";                                          // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "BWA3_Crew_Tropen";                                 // This defines the crew for vehicles.
-pilot_classname = "BWA3_Helipilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "RHS_MELB_MH6M";                          // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhsusf_M977A4_BKIT_usarmy_d";                  // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "rhsusf_M1078A1P2_B_D_CP_fmtv_usarmy";             // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "rhsusf_M1085A1P2_B_D_Medical_fmtv_usarmy";    // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "RHS_CH_47F";                                          // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "BWA3_Crew_Tropen";                                 // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "BWA3_Helipilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "RHS_MELB_MH6M";                          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhsusf_M977A4_BKIT_usarmy_d";                  // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["BWA3_Rifleman_lite_Tropen",15,0,0],                               // Rifleman (Light)
     ["BWA3_Rifleman_Tropen",20,0,0],                                    // Rifleman
     ["BWA3_RiflemanG27_Tropen",20,0,0],                                 // Rifleman (G27)
@@ -80,7 +80,7 @@ infantry_units = [
     ["rhsusf_airforce_jetpilot",10,0,0]                                 // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["rhsusf_m1025_d",100,0,50],                                        // M1025A2
     ["rhsusf_m1025_d_m2",100,40,50],                                    // M1025A2 (M2)
@@ -110,7 +110,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhsusf_m113d_usarmy",200,40,100],                                 // M113A3 (M2)
     ["rhsusf_m113d_usarmy_MK19",200,60,100],                            // M113A3 (Mk19)
     ["rhsusf_m113d_usarmy_medical",200,0,100],                          // M113A3 (Medical)
@@ -124,7 +124,7 @@ heavy_vehicles = [
     ["rhsusf_m109d_usarmy",600,1250,300]                                // M109A6
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                             // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                             // AL-6 Pelican (Cargo)
     ["RHS_MELB_MH6M",200,0,100],                                        // MH-6M Little Bird
@@ -156,7 +156,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["RHS_M2StaticMG_MiniTripod_D",25,40,0],                            // Mk2 HMG .50
     ["RHS_M2StaticMG_D",25,40,0],                                       // Mk2 HMG .50 (Raised)
     ["RHS_MK19_TriPod_D",25,60,0],                                      // Mk19 GMG 20mm
@@ -167,7 +167,7 @@ static_vehicles = [
     ["B_SAM_System_03_F",250,500,0]                                     // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V3_F",0,0,0],
     ["Land_Cargo_Patrol_V3_F",0,0,0],
     ["Land_Cargo_Tower_V3_F",0,0,0],
@@ -246,17 +246,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -280,7 +280,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "BWA3_TL_Tropen",
     "BWA3_Rifleman_lite_Tropen",
     "BWA3_Rifleman_lite_Tropen",
@@ -294,7 +294,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "BWA3_TL_Tropen",
     "BWA3_RiflemanAT_Pzf3_Tropen",
     "BWA3_RiflemanAT_Pzf3_Tropen",
@@ -308,7 +308,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "BWA3_TL_Tropen",
     "BWA3_Rifleman_Tropen",
     "BWA3_Rifleman_Tropen",
@@ -320,7 +320,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "BWA3_TL_Tropen",
     "BWA3_Rifleman_Tropen",
     "BWA3_Rifleman_Tropen",
@@ -332,7 +332,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "BWA3_recon_TL_Fleck",
     "BWA3_recon_Fleck",
     "BWA3_recon_Fleck",
@@ -346,7 +346,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
@@ -360,11 +360,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                    // Mk.V SOCOM
     "rhsusf_m1a1aim_tuski_d",                                           // M1A1SA (Tusk I)
     "rhsusf_m1a2sep1tuskiid_usarmy",                                    // M1A2SEPv1 (Tusk II)

--- a/Missionframework/presets/players/csat.sqf
+++ b/Missionframework/presets/players/csat.sqf
@@ -2,7 +2,7 @@
     File: csat.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-03
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "Land_Pod_Heli_Transport_04_box_F";                  // This is the FOB as a container.
-FOB_truck_typename = "O_Truck_03_device_F";                             // This is the FOB as a vehicle.
-Arsenal_typename = "O_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "O_Truck_03_medical_F";                        // This is the mobile respawn (and medical) truck.
-huron_typename = "O_Heli_Transport_04_F";                               // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "O_crew_F";                                         // This defines the crew for vehicles.
-pilot_classname = "O_helipilot_F";                                      // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "O_Heli_Light_02_unarmed_F";              // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "O_Truck_03_transport_F";                       // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "O_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "Land_Pod_Heli_Transport_04_box_F";                  // This is the FOB as a container.
+KPLIB_b_fobTruck = "O_Truck_03_device_F";                             // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "O_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "O_Truck_03_medical_F";                        // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "O_Heli_Transport_04_F";                               // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "O_crew_F";                                         // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "O_helipilot_F";                                      // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "O_Heli_Light_02_unarmed_F";              // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "O_Truck_03_transport_F";                       // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "O_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["O_Soldier_lite_F",15,0,0],                                        // Rifleman (Light)
     ["O_Soldier_F",20,0,0],                                             // Rifleman
     ["O_Soldier_LAT_F",30,0,0],                                         // Rifleman (AT)
@@ -70,7 +70,7 @@ infantry_units = [
     ["O_Pilot_F",10,0,0]                                                // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["O_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["O_LSV_02_unarmed_F",75,0,50],                                     // LSV Mk2
     ["O_LSV_02_armed_F",75,75,50],                                      // LSV Mk2 (M134)
@@ -87,7 +87,7 @@ light_vehicles = [
     ["O_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["O_APC_Wheeled_02_rcws_v2_F",200,150,150],                         // Otokar
     ["O_APC_Tracked_02_cannon_F",200,200,150],                          // Stalker
     ["O_APC_Tracked_02_AA_F",300,250,175],                              // Tigris
@@ -97,7 +97,7 @@ heavy_vehicles = [
     ["O_MBT_02_arty_F",600,1250,300]                                    // Sochor
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["O_UAV_01_F",75,0,25],                                             // Tayran
     ["O_UAV_06_F",80,0,30],                                             // Jinaah
     ["O_Heli_Light_02_unarmed_F",250,0,150],                            // Ka-60 Kasatka (unarmed)
@@ -114,7 +114,7 @@ air_vehicles = [
     ["O_T_VTOL_02_vehicle_dynamicLoadout_F",950,800,500]                // Xian (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["O_Static_Designator_02_F",25,0,0],                                // Remote Designator
     ["O_HMG_01_F",25,40,0],                                             // Mk30A HMG .50
     ["O_HMG_01_high_F",25,40,0],                                        // Mk30 HMG .50 (Raised)
@@ -128,7 +128,7 @@ static_vehicles = [
     ["O_SAM_System_04_F",250,500,0]                                     // S-750 Rhea
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V3_F",0,0,0],
     ["Land_Cargo_Patrol_V3_F",0,0,0],
     ["Land_Cargo_Tower_V3_F",0,0,0],
@@ -204,17 +204,17 @@ buildings = [
     ["Land_Razorwire_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,200,100,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
-    [Arsenal_typename,25,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,200,100,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
+    [KPLIB_b_arsenal,25,0,0],
     ["ACE_medicalSupplyCrate_advanced",10,0,0],
     ["Box_East_Support_F",10,0,0],
     ["Box_CSAT_Equip_F",10,0,0],
@@ -245,7 +245,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "O_Soldier_SL_F",
     "O_Soldier_TL_F",
     "O_Soldier_TL_F",
@@ -259,7 +259,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "O_Soldier_TL_F",
     "O_HeavyGunner_F",
     "O_Soldier_A_F",
@@ -273,7 +273,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "O_Soldier_TL_F",
     "O_Soldier_AT_F",
     "O_Soldier_HAT_F",
@@ -285,7 +285,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "O_Soldier_TL_F",
     "O_Soldier_AA_F",
     "O_Soldier_AAA_F",
@@ -297,7 +297,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "O_recon_TL_F",
     "O_recon_F",
     "O_recon_F",
@@ -311,7 +311,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "O_soldier_PG_F",
     "O_soldier_PG_F",
     "O_soldier_PG_F",
@@ -325,11 +325,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "O_MBT_04_cannon_F",                                                // T-14
     "O_MBT_04_command_F",                                               // T-14K
     "O_MBT_02_arty_F",                                                  // Sochor

--- a/Missionframework/presets/players/csat_apex.sqf
+++ b/Missionframework/presets/players/csat_apex.sqf
@@ -2,7 +2,7 @@
     File: csat_apex.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-03
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "Land_Pod_Heli_Transport_04_box_F";                  // This is the FOB as a container.
-FOB_truck_typename = "O_T_Truck_03_device_ghex_F";                      // This is the FOB as a vehicle.
-Arsenal_typename = "O_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "O_T_Truck_03_medical_ghex_F";                 // This is the mobile respawn (and medical) truck.
-huron_typename = "O_Heli_Transport_04_F";                               // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "O_T_Crew_F";                                       // This defines the crew for vehicles.
-pilot_classname = "O_T_Helipilot_F";                                    // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "O_Heli_Light_02_unarmed_F";              // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "O_T_Boat_Transport_01_F";                       // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "O_T_Truck_03_covered_ghex_F";                  // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_green_F";                 // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "O_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "Land_Pod_Heli_Transport_04_box_F";                  // This is the FOB as a container.
+KPLIB_b_fobTruck = "O_T_Truck_03_device_ghex_F";                      // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "O_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "O_T_Truck_03_medical_ghex_F";                 // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "O_Heli_Transport_04_F";                               // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "O_T_Crew_F";                                       // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "O_T_Helipilot_F";                                    // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "O_Heli_Light_02_unarmed_F";              // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "O_T_Boat_Transport_01_F";                       // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "O_T_Truck_03_covered_ghex_F";                  // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_green_F";                 // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "O_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["O_Soldier_lite_F",15,0,0],                                        // Rifleman (Light)
     ["O_T_Soldier_F",20,0,0],                                           // Rifleman
     ["O_T_Soldier_LAT_F",30,0,0],                                       // Rifleman (AT)
@@ -76,7 +76,7 @@ infantry_units = [
     ["O_T_Pilot_F",10,0,0]                                              // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["O_T_Quadbike_01_ghex_F",50,0,25],                                 // Quad Bike
     ["O_T_LSV_02_unarmed_F",75,0,50],                                   // LSV Mk2
     ["O_T_LSV_02_armed_F",75,75,50],                                    // LSV Mk2 (M134)
@@ -93,7 +93,7 @@ light_vehicles = [
     ["O_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["O_T_APC_Wheeled_02_rcws_v2_ghex_F",200,150,150],                  // Otokar
     ["O_T_APC_Tracked_02_cannon_ghex_F",200,200,150],                   // Stalker
     ["O_T_APC_Tracked_02_AA_ghex_F",300,250,175],                       // Tigris
@@ -103,7 +103,7 @@ heavy_vehicles = [
     ["O_T_MBT_02_arty_ghex_F",600,1250,300]                             // Sochor
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["O_UAV_01_F",75,0,25],                                             // Tayran
     ["O_UAV_06_F",80,0,30],                                             // Jinaah
     ["O_Heli_Light_02_unarmed_F",250,0,150],                            // Ka-60 Kasatka (unarmed)
@@ -120,7 +120,7 @@ air_vehicles = [
     ["O_T_VTOL_02_vehicle_dynamicLoadout_F",950,800,500]                // Xian (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["O_Static_Designator_02_F",25,0,0],                                // Remote Designator
     ["O_HMG_01_F",25,40,0],                                             // Mk30A HMG .50
     ["O_HMG_01_high_F",25,40,0],                                        // Mk30 HMG .50 (Raised)
@@ -134,7 +134,7 @@ static_vehicles = [
     ["O_SAM_System_04_F",250,500,0]                                     // S-750 Rhea
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -211,17 +211,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,200,100,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
-    [Arsenal_typename,25,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,200,100,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
+    [KPLIB_b_arsenal,25,0,0],
     ["ACE_medicalSupplyCrate_advanced",10,0,0],
     ["Box_East_Support_F",10,0,0],
     ["Box_CSAT_Equip_F",10,0,0],
@@ -252,7 +252,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "O_T_Soldier_SL_F",
     "O_T_Soldier_TL_F",
     "O_T_Soldier_TL_F",
@@ -266,7 +266,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "O_T_Soldier_TL_F",
     "O_HeavyGunner_F",
     "O_Soldier_A_F",
@@ -280,7 +280,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "O_T_Soldier_TL_F",
     "O_T_Soldier_AT_F",
     "O_T_Soldier_AAT_F",
@@ -292,7 +292,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "O_T_Soldier_TL_F",
     "O_T_Soldier_AA_F",
     "O_T_Soldier_AAA_F",
@@ -304,7 +304,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "O_T_Recon_TL_F",
     "O_T_Recon_F",
     "O_T_Recon_F",
@@ -318,7 +318,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "O_T_Soldier_PG_F",
     "O_T_Soldier_PG_F",
     "O_T_Soldier_PG_F",
@@ -332,11 +332,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "O_T_MBT_04_cannon_F",                                             // T-14
     "O_T_MBT_04_command_F",                                            // T-14K
     "O_T_MBT_02_arty_ghex_F",                                          // Sochor

--- a/Missionframework/presets/players/cup_acr_desert.sqf
+++ b/Missionframework/presets/players/cup_acr_desert.sqf
@@ -2,7 +2,7 @@
     File: cup_acr_desert.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-22
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_B_T810_Repair_CZ_DES";                        // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_LR_Ambulance_CZ_D";                     // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_Mi171Sh_Unarmed_ACR";                           // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_CZ_Crew_DES";                                // This defines the crew for vehicles.
-pilot_classname = "CUP_B_CZ_Pilot_DES";                                 // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "B_Heli_Light_01_F";                      // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_T810_Unarmed_CZ_DES";                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_B_T810_Repair_CZ_DES";                        // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_LR_Ambulance_CZ_D";                     // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_Mi171Sh_Unarmed_ACR";                           // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_CZ_Crew_DES";                                // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_CZ_Pilot_DES";                                 // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "B_Heli_Light_01_F";                      // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_T810_Unarmed_CZ_DES";                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_CZ_Soldier_DES",15,0,0],                                    // Rifleman
     ["CUP_B_CZ_Soldier_backpack_DES",20,0,0],                           // Rifleman (Backpack)
     ["CUP_B_CZ_Soldier_RPG_DES",30,0,0],                                // Rifleman (RPG)
@@ -78,7 +78,7 @@ infantry_units = [
     ["CUP_B_CZ_Pilot_DES",10,0,0]                                       // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_UAZ_Unarmed_ACR",100,0,50],                                 // UAZ
     ["CUP_B_UAZ_Open_ACR",100,0,50],                                    // UAZ (Open)
     ["CUP_B_UAZ_MG_ACR",100,40,50],                                     // UAZ (DShKM)
@@ -100,7 +100,7 @@ light_vehicles = [
     ["CUP_B_T810_Armed_CZ_DES",125,60,75]                               // Tatra T810 (MG/Covered)
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_BRDM2_HQ_CZ_Des",200,25,200],                               // BRDM-2 (HQ) (Desert)
     ["CUP_B_BRDM2_CZ_Des",200,200,200],                                 // BRDM-2 (Desert)
     ["I_APC_Wheeled_03_cannon_F",500,400,300],                          // Pandur II
@@ -112,7 +112,7 @@ heavy_vehicles = [
     ["CUP_B_T72_CZ",800,500,450]                                        // T-72M4CZ
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_Mi171Sh_ACR",700,600,500],                                  // Mi-171Sh (Rockets)
     ["CUP_B_Mi35_Dynamic_CZ",850,1000,550],                             // Mi-35
     ["CUP_B_Mi35_Dynamic_CZ_Dark",850,1000,550],                        // Mi-35 (Dark)
@@ -123,14 +123,14 @@ air_vehicles = [
     ["I_Plane_Fighter_04_F",1500,1400,800]                              // JAS 39 Gripen
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_DSHKM_ACR",25,40,0],                                        // DShKM
     ["CUP_B_AGS_ACR",35,60,0],                                          // AGS-30
     ["CUP_B_2b14_82mm_ACR",80,150,0],                                   // Podnos 2B14
     ["CUP_B_RBS70_ACR",100,200,0]                                       // RBS 70
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -207,17 +207,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -240,7 +240,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_CZ_Soldier_SL_DES",
     "CUP_B_CZ_Soldier_DES",
     "CUP_B_CZ_Soldier_DES",
@@ -254,7 +254,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_CZ_Soldier_SL_DES",
     "CUP_B_CZ_Soldier_RPG_DES",
     "CUP_B_CZ_Soldier_RPG_DES",
@@ -268,7 +268,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_CZ_Soldier_SL_DES",
     "CUP_B_CZ_Soldier_DES",
     "CUP_B_CZ_Soldier_DES",
@@ -280,7 +280,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_CZ_Soldier_SL_DES",
     "CUP_B_CZ_Soldier_DES",
     "CUP_B_CZ_Soldier_DES",
@@ -292,7 +292,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_CZ_SpecOps_TL_DES",
     "CUP_B_CZ_SpecOps_Recon_DES",
     "CUP_B_CZ_SpecOps_Recon_DES",
@@ -306,7 +306,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_CZ_Soldier_DES",
     "CUP_B_CZ_Soldier_DES",
     "CUP_B_CZ_Soldier_DES",
@@ -320,11 +320,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_Dingo_CZ_Des",                                               // Dingo 2 (MG) (Desert)
     "CUP_B_Dingo_GL_CZ_Des",                                            // Dingo 2 (GL) (Desert)
     "QIN_Titus_WDL",                                                    // Nexter Titus

--- a/Missionframework/presets/players/cup_acr_woodland.sqf
+++ b/Missionframework/presets/players/cup_acr_woodland.sqf
@@ -2,7 +2,7 @@
     File: cup_acr_woodland.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-22
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_B_T810_Repair_CZ_WDL";                        // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_LR_Ambulance_CZ_W";                     // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_Mi171Sh_Unarmed_ACR";                           // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_CZ_Crew_WDL";                                // This defines the crew for vehicles.
-pilot_classname = "CUP_B_CZ_Pilot_WDL";                                 // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "B_Heli_Light_01_F";                      // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_T810_Unarmed_CZ_WDL";                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_B_T810_Repair_CZ_WDL";                        // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_LR_Ambulance_CZ_W";                     // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_Mi171Sh_Unarmed_ACR";                           // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_CZ_Crew_WDL";                                // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_CZ_Pilot_WDL";                                 // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "B_Heli_Light_01_F";                      // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_T810_Unarmed_CZ_WDL";                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_CZ_Soldier_WDL",15,0,0],                                    // Rifleman
     ["CUP_B_CZ_Soldier_backpack_WDL",20,0,0],                           // Rifleman (Backpack)
     ["CUP_B_CZ_Soldier_RPG_WDL",30,0,0],                                // Rifleman (RPG)
@@ -78,7 +78,7 @@ infantry_units = [
     ["CUP_B_CZ_Pilot_WDL",10,0,0]                                       // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_UAZ_Unarmed_ACR",100,0,50],                                 // UAZ
     ["CUP_B_UAZ_Open_ACR",100,0,50],                                    // UAZ (Open)
     ["CUP_B_UAZ_MG_ACR",100,40,50],                                     // UAZ (DShKM)
@@ -96,7 +96,7 @@ light_vehicles = [
     ["CUP_B_T810_Armed_CZ_WDL",125,60,75]                               // Tatra T810 (MG/Covered)
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_BRDM2_HQ_CZ",200,25,200],                                   // BRDM-2 (HQ)
     ["CUP_B_BRDM2_CZ",200,200,200],                                     // BRDM-2
     ["CUP_B_RM70_CZ",300,750,175],                                      // RM-70
@@ -109,7 +109,7 @@ heavy_vehicles = [
     ["CUP_B_T72_CZ",800,500,450]                                        // T-72M4CZ
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_Mi171Sh_ACR",700,600,500],                                  // Mi-171Sh (Rockets)
     ["CUP_B_Mi35_Dynamic_CZ",850,1000,550],                             // Mi-35
     ["CUP_B_Mi35_Dynamic_CZ_Dark",850,1000,550],                        // Mi-35 (Dark)
@@ -120,14 +120,14 @@ air_vehicles = [
     ["I_Plane_Fighter_04_F",1500,1400,800]                              // JAS 39 Gripen
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_DSHKM_ACR",25,40,0],                                        // DShKM
     ["CUP_B_AGS_ACR",35,60,0],                                          // AGS-30
     ["CUP_B_2b14_82mm_ACR",80,150,0],                                   // Podnos 2B14
     ["CUP_B_RBS70_ACR",100,200,0]                                       // RBS 70
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -204,17 +204,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -237,7 +237,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_CZ_Soldier_SL_WDL",
     "CUP_B_CZ_Soldier_WDL",
     "CUP_B_CZ_Soldier_WDL",
@@ -251,7 +251,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_CZ_Soldier_SL_WDL",
     "CUP_B_CZ_Soldier_RPG_WDL",
     "CUP_B_CZ_Soldier_RPG_WDL",
@@ -265,7 +265,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_CZ_Soldier_SL_WDL",
     "CUP_B_CZ_Soldier_WDL",
     "CUP_B_CZ_Soldier_WDL",
@@ -277,7 +277,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_CZ_Soldier_SL_WDL",
     "CUP_B_CZ_Soldier_WDL",
     "CUP_B_CZ_Soldier_WDL",
@@ -289,7 +289,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_CZ_SpecOps_TL_WDL",
     "CUP_B_CZ_SpecOps_Recon_WDL",
     "CUP_B_CZ_SpecOps_Recon_WDL",
@@ -303,7 +303,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_CZ_Soldier_WDL",
     "CUP_B_CZ_Soldier_WDL",
     "CUP_B_CZ_Soldier_WDL",
@@ -317,11 +317,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_Dingo_CZ_Wdl",                                               // Dingo 2 (MG) (Woodland)
     "CUP_B_Dingo_GL_CZ_Wdl",                                            // Dingo 2 (GL) (Woodland)
     "QIN_Titus_WDL",                                                    // Nexter Titus

--- a/Missionframework/presets/players/cup_baf_desert.sqf
+++ b/Missionframework/presets/players/cup_baf_desert.sqf
@@ -2,7 +2,7 @@
     File: cup_baf_desert.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-15
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_B_MTVR_Repair_USA";                           // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_LR_Ambulance_GB_D";                     // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_CH47F_GB";                                      // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_BAF_Soldier_Crew_DDPM";                      // This defines the crew for vehicles.
-pilot_classname = "CUP_B_BAF_Soldier_Helipilot_DDPM";                   // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_B_SA330_Puma_HC2_BAF";               // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_MTVR_BAF_DES";                           // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_B_MTVR_Repair_USA";                           // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_LR_Ambulance_GB_D";                     // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_CH47F_GB";                                      // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_BAF_Soldier_Crew_DDPM";                      // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_BAF_Soldier_Helipilot_DDPM";                   // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_B_SA330_Puma_HC2_BAF";               // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_MTVR_BAF_DES";                           // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_BAF_Soldier_RiflemanLite_DDPM",15,0,0],                     // Rifleman (Light)
     ["CUP_B_BAF_Soldier_Rifleman_DDPM",20,0,0],                         // Rifleman
     ["CUP_B_BAF_Soldier_RiflemanAT_DDPM",30,0,0],                       // Rifleman (AT)
@@ -83,7 +83,7 @@ infantry_units = [
     ["CUP_B_BAF_Soldier_Pilot_DDPM",10,0,0]                             // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_LR_Transport_GB_D",75,0,50],                                // Land Rover 110 Transport
     ["CUP_B_LR_MG_GB_D",75,50,50],                                      // Land Rover 110 (M2)
     ["CUP_B_LR_Special_M2_GB_D",100,80,50],                             // Land Rover 110 (M2 Special)
@@ -99,7 +99,7 @@ light_vehicles = [
     ["CUP_B_MTVR_BAF_DES",125,0,75]                                     // MTVR Transport
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_FV432_Bulldog_GB_D",300,100,150],                           // FV432 Bulldog M240
     ["CUP_B_FV432_Bulldog_GB_D_RWS",300,250,150],                       // FV432 Bulldog M2 RWS
     ["CUP_B_MCV80_GB_D",300,450,275],                                   // MCV-80 Warrior
@@ -110,7 +110,7 @@ heavy_vehicles = [
     ["CUP_B_Challenger2_2CD_BAF",500,800,450]                           // FV4034 Challenger 2 (Two-Color Desert)
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_AW159_Unarmed_RN_Blackcat",225,0,125],                      // AW159 Wildcat (Black Cat, Unarmed)
     ["CUP_B_AW159_Unarmed_GB",225,0,125],                               // AW159 Wildcat (Green, Unarmed)
     ["CUP_B_AW159_Unarmed_RN_Grey",225,0,125],                          // AW159 Wildcat (Grey, Unarmed)
@@ -123,7 +123,7 @@ air_vehicles = [
     ["CUP_B_F35B_Stealth_BAF",1500,1750,450]                            // F-35B Lightning II (Stealth)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_L111A1_BAF_DDPM",25,40,0],                                  // L111A1 Machine Gun
     ["CUP_B_L111A1_MiniTripod_BAF_DDPM",25,40,0],                       // L111A1 Minitripod
     ["CUP_WV_B_CRAM",500,500,0],                                        // C-RAM
@@ -133,7 +133,7 @@ static_vehicles = [
     ["CUP_B_L16A2_BAF_DDPM",80,150,0]                                   // L16A2 81mm Mortar
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -210,17 +210,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -243,7 +243,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_BAF_Soldier_TeamLeader_DDPM",
     "CUP_B_BAF_Soldier_Rifleman_DDPM",
     "CUP_B_BAF_Soldier_Rifleman_DDPM",
@@ -257,7 +257,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_BAF_Soldier_TeamLeader_DDPM",
     "CUP_B_BAF_Soldier_RiflemanLAT_DDPM",
     "CUP_B_BAF_Soldier_RiflemanLAT_DDPM",
@@ -271,7 +271,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_BAF_Soldier_TeamLeader_DDPM",
     "CUP_B_BAF_Soldier_Rifleman_DDPM",
     "CUP_B_BAF_Soldier_Rifleman_DDPM",
@@ -283,7 +283,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_BAF_Soldier_TeamLeader_DDPM",
     "CUP_B_BAF_Soldier_Rifleman_DDPM",
     "CUP_B_BAF_Soldier_Rifleman_DDPM",
@@ -295,7 +295,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_BAF_Soldier_TeamLeader_MTP",
     "CUP_B_BAF_Soldier_Rifleman_MTP",
     "CUP_B_BAF_Soldier_Rifleman_MTP",
@@ -309,7 +309,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_BAF_Soldier_Paratrooper_DDPM",
     "CUP_B_BAF_Soldier_Paratrooper_DDPM",
     "CUP_B_BAF_Soldier_Paratrooper_DDPM",
@@ -323,11 +323,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_MCV80_GB_D_SLAT",                                            // MCV-80 Warrior (SLAT)
     "CUP_B_FV510_GB_D",                                                 // FV510 Warrior
     "CUP_B_FV510_GB_D_SLAT",                                            // FV510 Warrior (SLAT)

--- a/Missionframework/presets/players/cup_baf_woodland.sqf
+++ b/Missionframework/presets/players/cup_baf_woodland.sqf
@@ -2,7 +2,7 @@
     File: cup_baf_woodland.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-15
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_B_MTVR_Repair_USA";                           // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_FV432_GB_Ambulance";                    // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_CH47F_GB";                                      // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_BAF_Soldier_Crew_DPM";                       // This defines the crew for vehicles.
-pilot_classname = "CUP_B_BAF_Soldier_Helipilot_DPM";                    // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_B_SA330_Puma_HC2_BAF";               // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_MTVR_BAF_WOOD";                          // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_B_MTVR_Repair_USA";                           // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_FV432_GB_Ambulance";                    // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_CH47F_GB";                                      // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_BAF_Soldier_Crew_DPM";                       // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_BAF_Soldier_Helipilot_DPM";                    // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_B_SA330_Puma_HC2_BAF";               // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_MTVR_BAF_WOOD";                          // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_BAF_Soldier_RiflemanLite_DPM",15,0,0],                      // Rifleman (Light)
     ["CUP_B_BAF_Soldier_Rifleman_DPM",20,0,0],                          // Rifleman
     ["CUP_B_BAF_Soldier_RiflemanAT_DPM",30,0,0],                        // Rifleman (AT)
@@ -83,7 +83,7 @@ infantry_units = [
     ["CUP_B_BAF_Soldier_Pilot_DPM",10,0,0]                              // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_LR_Transport_GB_W",75,0,50],                                // Land Rover 110 (Transport) Woodland
     ["CUP_B_LR_Ambulance_GB_W",75,0,50],                                // Land Rover 110 (Ambulance) Woodland
     ["CUP_B_LR_MG_GB_W",75,50,50],                                      // Land Rover 110 (M2) Woodland
@@ -100,7 +100,7 @@ light_vehicles = [
     ["CUP_B_MTVR_BAF_WOOD",125,0,75]                                    // MTVR Transport
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_FV432_Bulldog_GB_W",300,100,150],                           // FV432 Bulldog M240 [Woodland]
     ["CUP_B_FV432_Bulldog_GB_W_RWS",300,250,150],                       // FV432 Bulldog M2 RWS [Woodland]
     ["CUP_B_FV432_Mortar",350,500,150],                                 // FV432 Mortar
@@ -112,7 +112,7 @@ heavy_vehicles = [
     ["CUP_B_Challenger2_2CW_BAF",500,800,450]                           // FV4034 Challenger 2 (Two-Color Woodland)
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_AW159_Unarmed_RN_Blackcat",225,0,125],                      // AW159 Wildcat (Black Cat, Unarmed)
     ["CUP_B_AW159_Unarmed_GB",225,0,125],                               // AW159 Wildcat (Green, Unarmed)
     ["CUP_B_AW159_Unarmed_RN_Grey",225,0,125],                          // AW159 Wildcat (Grey, Unarmed)
@@ -125,7 +125,7 @@ air_vehicles = [
     ["CUP_B_F35B_Stealth_BAF",1500,1750,450]                            // F-35B Lightning II (Stealth)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_L111A1_BAF_DPM",25,40,0],                                   // L111A1 Machine Gun
     ["CUP_B_L111A1_MiniTripod_BAF_DPM",25,40,0],                        // L111A1 Minitripod
     ["CUP_WV_B_CRAM",500,500,0],                                        // C-RAM
@@ -135,7 +135,7 @@ static_vehicles = [
     ["CUP_B_L16A2_BAF_DPM",80,150,0]                                    // L16A2 81mm Mortar
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -212,17 +212,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -246,7 +246,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_BAF_Soldier_TeamLeader_DPM",
     "CUP_B_BAF_Soldier_Rifleman_DPM",
     "CUP_B_BAF_Soldier_Rifleman_DPM",
@@ -260,7 +260,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_BAF_Soldier_TeamLeader_DPM",
     "CUP_B_BAF_Soldier_RiflemanLAT_DPM",
     "CUP_B_BAF_Soldier_RiflemanLAT_DPM",
@@ -274,7 +274,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_BAF_Soldier_TeamLeader_DPM",
     "CUP_B_BAF_Soldier_Rifleman_DPM",
     "CUP_B_BAF_Soldier_Rifleman_DPM",
@@ -286,7 +286,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_BAF_Soldier_TeamLeader_DPM",
     "CUP_B_BAF_Soldier_Rifleman_DPM",
     "CUP_B_BAF_Soldier_Rifleman_DPM",
@@ -298,7 +298,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_BAF_Soldier_TeamLeader_MTP",
     "CUP_B_BAF_Soldier_Rifleman_MTP",
     "CUP_B_BAF_Soldier_Rifleman_MTP",
@@ -312,7 +312,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_BAF_Soldier_Paratrooper_DPM",
     "CUP_B_BAF_Soldier_Paratrooper_DPM",
     "CUP_B_BAF_Soldier_Paratrooper_DPM",
@@ -326,11 +326,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_MCV80_GB_W_SLAT",                                            // MCV-80 Warrior (SLAT - Woodland)
     "CUP_B_FV432_Mortar",                                               // FV432 Mortar
     "CUP_B_FV510_GB_W",                                                 // FV510 Warrior (Woodland)

--- a/Missionframework/presets/players/cup_cdf.sqf
+++ b/Missionframework/presets/players/cup_cdf.sqf
@@ -2,7 +2,7 @@
     File: cup_cdf.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-17
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_BMP2_AMB_CDF";                          // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_MI6A_CDF";                                      // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_CDF_Crew_FST";                               // This defines the crew for vehicles.
-pilot_classname = "CUP_B_CDF_Pilot_FST";                                // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "B_Heli_Light_01_F";                      // These are the little birds which spawn on the Freedom or at Chimera bas
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_Ural_Open_CDF";                          // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_BMP2_AMB_CDF";                          // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_MI6A_CDF";                                      // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_CDF_Crew_FST";                               // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_CDF_Pilot_FST";                                // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "B_Heli_Light_01_F";                      // These are the additional helicopters which spawn on the Freedom or at Chimera bas
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_Ural_Open_CDF";                          // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_CDF_Soldier_FST",20,0,0],                                   // Rifleman
     ["CUP_B_CDF_Soldier_RPG18_FST",30,0,0],                             // Rifleman (RPG-18)
     ["CUP_B_CDF_Soldier_GL_FST",25,0,0],                                // Grenadier
@@ -77,7 +77,7 @@ infantry_units = [
     ["CUP_B_CDF_Pilot_FST",10,0,0]                                      // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_S1203_Ambulance_CDF",75,0,50],                              // Škoda S1203 (Ambulance)
     ["CUP_B_UAZ_Unarmed_CDF",75,0,50],                                  // UAZ
     ["CUP_B_UAZ_MG_CDF",100,60,50],                                     // UAZ (DShKM)
@@ -93,7 +93,7 @@ light_vehicles = [
     ["CUP_B_Ural_CDF",125,0,75]                                         // Ural
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_BRDM2_CDF",200,200,125],                                    // BRDM-2
     ["CUP_B_BRDM2_ATGM_CDF",200,400,125],                               // BRDM-2 (ATGM)
     ["CUP_B_BTR60_CDF",300,200,125],                                    // BTR-60PB
@@ -106,7 +106,7 @@ heavy_vehicles = [
     ["CUP_B_T72_CDF",600,500,250]                                       // T-72
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_Mi17_CDF",300,100,300],                                     // Mi-8MT
     ["CUP_B_Pchela1T_CDF",100,0,50],                                    // Pchela-1T
     ["CUP_B_Mi24_D_Dynamic_CDF",700,600,300],                           // Mi-24D
@@ -114,7 +114,7 @@ air_vehicles = [
     ["CUP_B_SU34_CDF",1200,1000,500]                                    // Su-34
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_DSHKM_CDF",25,40,0],                                        // DShKM
     ["CUP_B_DSHkM_MiniTripod_CDF",25,40,0],                             // DShKM Minitripod
     ["CUP_B_AGS_CDF",25,60,0],                                          // AGS-30
@@ -127,7 +127,7 @@ static_vehicles = [
     ["CUP_B_D30_CDF",200,250,0]                                         // D-30
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -205,17 +205,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -238,7 +238,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_CDF_Soldier_TL_FST",
     "CUP_B_CDF_Soldier_FST",
     "CUP_B_CDF_Soldier_FST",
@@ -252,7 +252,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_CDF_Soldier_TL_FST",
     "CUP_B_CDF_Soldier_RPG18_FST",
     "CUP_B_CDF_Soldier_RPG18_FST",
@@ -266,7 +266,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_CDF_Soldier_TL_FST",
     "CUP_B_CDF_Soldier_FST",
     "CUP_B_CDF_Soldier_FST",
@@ -278,7 +278,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_CDF_Soldier_TL_FST",
     "CUP_B_CDF_Soldier_FST",
     "CUP_B_CDF_Soldier_FST",
@@ -290,7 +290,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_CDF_Soldier_TL_MNT",
     "CUP_B_CDF_SOldier_MNT",
     "CUP_B_CDF_Soldier_GL_MNT",
@@ -304,7 +304,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_CDF_Soldier_FST",
     "CUP_B_CDF_Soldier_FST",
     "CUP_B_CDF_Soldier_FST",
@@ -318,11 +318,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_BTR60_CDF",                                                  // BTR-60 PB
     "CUP_B_BM21_CDF",                                                   // BM-21
     "CUP_B_BMP2_CDF",                                                   // BMP-2

--- a/Missionframework/presets/players/cup_chdkz.sqf
+++ b/Missionframework/presets/players/cup_chdkz.sqf
@@ -2,7 +2,7 @@
     File: cup_chdkz.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2020-04-21
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_O_BMP_HQ_CHDKZ";                              // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_O_BMP2_AMB_CHDKZ";                        // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_O_MI6A_CHDKZ";                                    // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_O_INS_Crew";                                   // This defines the crew for vehicles.
-pilot_classname = "CUP_O_INS_Pilot";                                    // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_O_Mi8_medevac_CHDKZ";                // These are the little birds which spawn on the Freedom or at Chimera bas
-KPLIB_boat_classname = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_O_Ural_Open_CHDKZ";                        // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_O_BMP_HQ_CHDKZ";                              // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_O_BMP2_AMB_CHDKZ";                        // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_O_MI6A_CHDKZ";                                    // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_O_INS_Crew";                                   // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_O_INS_Pilot";                                    // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_O_Mi8_medevac_CHDKZ";                // These are the additional helicopters which spawn on the Freedom or at Chimera bas
+KPLIB_b_addBoat = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_O_Ural_Open_CHDKZ";                        // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_O_INS_Soldier",20,0,0],                                       // Rifleman
     ["CUP_O_INS_Soldier_LAT",30,0,0],                                   // Rifleman (RPG-18)
     ["CUP_O_INS_Soldier_GL",25,0,0],                                    // Grenadier
@@ -74,7 +74,7 @@ infantry_units = [
     ["CUP_O_INS_Pilot",10,0,0]                                          // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_O_Datsun_4seat",50,0,25],                                     // Datsun 620 Pickup Woodland
     ["CUP_O_Datsun_PK",50,10,25],                                       // Datsun 620 Pickup (PK)
     ["CUP_O_Datsun_AA",75,150,25],                                      // Datsun 620 Pickup (AA)
@@ -90,7 +90,7 @@ light_vehicles = [
     ["CUP_O_Ural_CHDKZ",150,0,75]                                       // Ural
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_O_BRDM2_CHDKZ",200,200,150],                                  // BRDM-2
     ["CUP_O_BRDM2_ATGM_CHDKZ",200,400,150],                             // BRDM-2 (ATGM)
     ["CUP_O_BTR60_CHDKZ",300,200,200],                                  // BTR-60PB
@@ -104,11 +104,11 @@ heavy_vehicles = [
     ["CUP_O_T72_CHDKZ",700,500,300]                                     // T-72
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_O_Mi8_CHDKZ",400,100,400]                                     // Mi-8MT
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_O_DSHKM_ChDKZ",25,40,0],                                      // DShKM
     ["CUP_O_DSHkM_MiniTripod_ChDKZ",25,40,0],                           // DShKM Minitripod
     ["CUP_O_AGS_ChDKZ",25,60,0],                                        // AGS-30
@@ -120,7 +120,7 @@ static_vehicles = [
     ["CUP_O_D30_ChDKZ",200,250,0]                                       // D-30
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -196,17 +196,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -229,7 +229,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_O_INS_Officer",
     "CUP_O_INS_Woodlander3",
     "CUP_O_INS_Worker2",
@@ -243,7 +243,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_O_INS_Officer",
     "CUP_O_INS_Soldier_LAT",
     "CUP_O_INS_Soldier_LAT",
@@ -257,7 +257,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_O_INS_Officer",
     "CUP_O_INS_Soldier_LAT",
     "CUP_O_INS_Soldier_LAT",
@@ -269,7 +269,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_O_INS_Officer",
     "CUP_O_INS_Soldier",
     "CUP_O_INS_Soldier",
@@ -281,7 +281,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_O_RUS_Soldier_TL",
     "CUP_O_RUS_SpecOps_Scout",
     "CUP_O_RUS_SpecOps_Night",
@@ -294,7 +294,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_O_INS_Soldier_LAT",
     "CUP_O_INS_Soldier_LAT",
     "CUP_O_INS_Soldier_LAT",
@@ -308,11 +308,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_O_BTR60_CHDKZ",                                                // BTR-60 PB
     "CUP_O_BM21_CHDKZ",                                                 // BM-21
     "CUP_O_BMP2_CHDKZ",                                                 // BMP-2

--- a/Missionframework/presets/players/cup_sla.sqf
+++ b/Missionframework/presets/players/cup_sla.sqf
@@ -2,7 +2,7 @@
     File: cup_sla.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2020-04-24
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_O_BMP_HQ_sla";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_O_BMP2_AMB_sla";                          // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_O_Mi8_SLA_1";                                     // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_O_sla_Crew";                                   // This defines the crew for vehicles.
-pilot_classname = "CUP_O_sla_Pilot";                                    // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_O_UH1H_slick_SLA";                   // These are the little birds which spawn on the Freedom or at Chimera bas
-KPLIB_boat_classname = "CUP_O_PBX_SLA";                                 // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_O_Ural_Open_SLA";                          // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_O_BMP_HQ_sla";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_O_BMP2_AMB_sla";                          // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_O_Mi8_SLA_1";                                     // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_O_sla_Crew";                                   // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_O_sla_Pilot";                                    // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_O_UH1H_slick_SLA";                   // These are the additional helicopters which spawn on the Freedom or at Chimera bas
+KPLIB_b_addBoat = "CUP_O_PBX_SLA";                                 // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_O_Ural_Open_SLA";                          // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_O_sla_Soldier",15,0,0],                                       // Rifleman
     ["CUP_O_SLA_Soldier_Backpack",20,0,0],                              // Rifleman (Backpack)
     ["CUP_O_sla_Soldier_AT",30,0,0],                                    // Rifleman (RPG-7)
@@ -77,7 +77,7 @@ infantry_units = [
     ["CUP_O_sla_Pilot",10,0,0]                                          // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_O_UAZ_Unarmed_SLA",100,0,50],                                 // UAZ
     ["CUP_O_UAZ_MG_SLA",125,60,50],                                     // UAZ (DShKM)
     ["CUP_O_UAZ_AGS30_SLA",125,80,50],                                  // UAZ (AGS-30)
@@ -90,7 +90,7 @@ light_vehicles = [
     ["CUP_O_Ural_SLA",150,0,75]                                         // Ural
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_O_BRDM2_SLA",200,200,150],                                    // BRDM-2
     ["CUP_O_BRDM2_ATGM_SLA",200,400,150],                               // BRDM-2 (ATGM)
     ["CUP_O_BTR60_SLA",300,200,200],                                    // BTR-60PB
@@ -104,7 +104,7 @@ heavy_vehicles = [
     ["CUP_O_T72_SLA",700,500,300]                                       // T-72
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_O_UH1H_armed_SLA",400,250,250],                               // UH-1H (Armed)
     ["CUP_O_UH1H_gunship_SLA",500,350,250],                             // UH-1H (Gunship)
     ["CUP_O_Mi8_SLA_2",500,350,300],                                    // Mi-8MTV3
@@ -114,7 +114,7 @@ air_vehicles = [
     ["CUP_O_SU34_SLA",1200,1000,500]                                    // Su-34
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_O_DSHKM_SLA",25,40,0],                                        // DShKM
     ["CUP_O_DSHkM_MiniTripod_SLA",25,40,0],                             // DShKM Minitripod
     ["CUP_O_AGS_SLA",25,60,0],                                          // AGS-30
@@ -126,7 +126,7 @@ static_vehicles = [
     ["CUP_O_D30_SLA",200,250,0]                                         // D-30
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -202,17 +202,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -237,7 +237,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_O_sla_Soldier_SL",
     "CUP_O_sla_Soldier",
     "CUP_O_sla_Soldier",
@@ -251,7 +251,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_O_sla_Soldier_SL",
     "CUP_O_sla_Soldier_LAT",
     "CUP_O_sla_Soldier_LAT",
@@ -265,7 +265,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_O_sla_Soldier_SL",
     "CUP_O_sla_Soldier_AAT",
     "CUP_O_sla_Soldier_AAT",
@@ -277,7 +277,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_O_sla_Soldier_SL",
     "CUP_O_sla_Soldier_Backpack",
     "CUP_O_sla_Soldier_Backpack",
@@ -289,7 +289,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_O_sla_SpecOps_TL",
     "CUP_O_sla_SpecOps",
     "CUP_O_sla_SpecOps_Demo",
@@ -300,7 +300,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_O_sla_Officer_urban",
     "CUP_O_sla_Officer_urban",
     "CUP_O_sla_Officer_urban",
@@ -314,11 +314,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_O_BTR60_SLA",                                                  // BTR-60 PB
     "CUP_O_BM21_SLA",                                                   // BM-21
     "CUP_O_BMP2_SLA",                                                   // BMP-2

--- a/Missionframework/presets/players/cup_takistan.sqf
+++ b/Missionframework/presets/players/cup_takistan.sqf
@@ -2,7 +2,7 @@
     File: cup_takistan.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2020-04-25
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -23,26 +23,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "CUP_O_BMP_HQ_TKA";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_O_M113_Med_TKA";                          // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_O_MI6A_TKA";                                      // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_O_TK_Crew";                                    // This defines the crew for vehicles.
-pilot_classname = "CUP_O_TK_Pilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_O_UH1H_slick_TKA";                   // These are the little birds which spawn on the Freedom or at Chimera bas
-KPLIB_boat_classname = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_O_Ural_Open_TKA";                          // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "CUP_O_BMP_HQ_TKA";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_O_M113_Med_TKA";                          // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_O_MI6A_TKA";                                      // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_O_TK_Crew";                                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_O_TK_Pilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_O_UH1H_slick_TKA";                   // These are the additional helicopters which spawn on the Freedom or at Chimera bas
+KPLIB_b_addBoat = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_O_Ural_Open_TKA";                          // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "O_Radar_System_02_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -52,7 +52,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_O_TK_Soldier",15,0,0],                                        // Rifleman
     ["CUP_O_TK_Soldier_Backpack",20,0,0],                               // Rifleman (backpack)
     ["CUP_O_TK_Soldier_AT",30,0,0],                                     // Rifleman (RPG-7)
@@ -75,7 +75,7 @@ infantry_units = [
     ["CUP_O_TK_Pilot",10,0,0]                                           // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_O_Hilux_unarmed_TK_INS",50,0,50],                             // Hilux
     ["CUP_O_Hilux_M2_TK_INS",50,60,50],                                 // Hilux (M2)
     ["CUP_O_Hilux_DSHKM_TK_INS",50,60,50],                              // Hilux (DShKM)
@@ -99,7 +99,7 @@ light_vehicles = [
     ["CUP_O_Ural_TKA",150,0,75]                                         // Ural
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_O_Hilux_armored_zu23_TK_INS",100,150,75],                     // Hilux Armored (ZU-23-2)
     ["CUP_O_Hilux_armored_BTR60_TK_INS",100,200,75],                    // Hilux Armored (BTR-60)
     ["CUP_O_Hilux_armored_BMP1_TK_INS",100,350,75],                     // Hilux Armored (BMP-1)
@@ -122,7 +122,7 @@ heavy_vehicles = [
     ["CUP_O_T72_TKA",700,500,300]                                       // T-72
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_O_UH1H_armed_TKA",400,250,250],                               // UH-1H (Armed)
     ["CUP_O_UH1H_gunship_TKA",500,350,250],                             // UH-1H (Gunship)
     ["CUP_O_Mi17_TK",500,350,300],                                      // Mi-8MT
@@ -133,7 +133,7 @@ air_vehicles = [
     ["CUP_O_Su25_Dyn_TKA",1000,850,400]                                 // Su-25 Frogfoot
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_O_KORD_high_TK",25,40,0],                                     // KORD
     ["CUP_O_KORD_TK",25,40,0],                                          // KORD Minitripod
     ["CUP_O_AGS_TK",25,60,0],                                           // AGS-30
@@ -144,7 +144,7 @@ static_vehicles = [
     ["CUP_O_D30_TK",200,250,0]                                          // D-30
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -220,17 +220,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -253,7 +253,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_O_TK_Soldier_SL",
     "CUP_O_TK_Soldier",
     "CUP_O_TK_Soldier",
@@ -267,7 +267,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_O_TK_Soldier_SL",
     "CUP_O_TK_Soldier_LAT",
     "CUP_O_TK_Soldier_LAT",
@@ -281,7 +281,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_O_TK_Soldier_SL",
     "CUP_O_TK_Soldier_AAT",
     "CUP_O_TK_Soldier_AAT",
@@ -293,7 +293,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_O_TK_Soldier_SL",
     "CUP_O_TK_Soldier_Backpack",
     "CUP_O_TK_Soldier_Backpack",
@@ -305,7 +305,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_O_TK_SpecOps_TL",
     "CUP_O_TK_SpecOps",
     "CUP_O_TK_SpecOps",
@@ -316,7 +316,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_O_TK_Soldier_LAT",
     "CUP_O_TK_Soldier_LAT",
     "CUP_O_TK_Soldier_LAT",
@@ -330,11 +330,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_O_BTR60_TKA",                                                  // BTR-60 PB
     "CUP_O_BM21_TKA",                                                   // BM-21
     "CUP_O_BMP2_TKA",                                                   // BMP-2

--- a/Missionframework/presets/players/cup_usa_desert.sqf
+++ b/Missionframework/presets/players/cup_usa_desert.sqf
@@ -2,7 +2,7 @@
     File: cup_usa_desert.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-17
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,26 +25,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_HMMWV_Ambulance_USA";                   // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_CH47F_USA";                                     // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_US_Crew";                                    // This defines the crew for vehicles.
-pilot_classname = "CUP_B_US_Pilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_B_MH6M_USA";                         // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_MTVR_USA";                               // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_HMMWV_Ambulance_USA";                   // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_CH47F_USA";                                     // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_US_Crew";                                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_US_Pilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_B_MH6M_USA";                         // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_MTVR_USA";                               // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -54,7 +54,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_US_Soldier",20,0,0],                                        // Rifleman
     ["CUP_B_US_Soldier_LAT",30,0,0],                                    // Rifleman (AT)
     ["CUP_B_US_Soldier_GL",25,0,0],                                     // Grenadier
@@ -78,7 +78,7 @@ infantry_units = [
     ["CUP_B_US_Pilot",10,0,0]                                           // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_HMMWV_Unarmed_USA",75,0,50],                                // HMMWV (Unarmed)
     ["CUP_B_HMMWV_M2_USA",75,60,50],                                    // HMMWV M2
     ["CUP_B_HMMWV_MK19_USA",75,80,50],                                  // HMMWV MK19
@@ -93,7 +93,7 @@ light_vehicles = [
     ["CUP_B_MTVR_USA",125,0,75]                                         // MTVR
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_M1126_ICV_M2_Desert_Slat",200,150,125],                     // M1126 ICV M2 CROWS (Desert - Slat)
     ["CUP_B_M1126_ICV_MK19_Desert_Slat",200,200,125],                   // M1126 ICV MK19 CROWS (Desert - Slat)
     ["CUP_B_M1128_MGS_Desert_Slat",200,500,125],                        // M1128 MGS (Desert - Slat)
@@ -109,7 +109,7 @@ heavy_vehicles = [
     ["CUP_B_M270_DPICM_USA",800,1750,400]                               // M270 MLRS (DPICM)
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_UH60M_Unarmed_FFV_MEV_US",300,0,200],                       // UH-60M MEDVAC (Unarmed/FFV)
     ["CUP_B_UH60M_US",300,25,200],                                      // UH-60M
     ["CUP_B_UH60M_FFV_US",300,50,200],                                  // UH-60M (FFV)
@@ -136,7 +136,7 @@ air_vehicles = [
     ["CUP_B_AH6X_USA",300,0,100]                                        // AH-6X Littlebird ULB
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_M2StaticMG_US",25,40,0],                                    // M2 Machine Gun
     ["CUP_B_M2StaticMG_MiniTripod_US",25,40,0],                         // M2 Minitripod
     ["CUP_B_TOW_TriPod_US",50,100,0],                                   // TOW Tripod
@@ -148,7 +148,7 @@ static_vehicles = [
     ["CUP_B_M119_US",100,200,0]                                         // M119
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -226,17 +226,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -272,7 +272,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -286,7 +286,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier_LAT",
     "CUP_B_US_Soldier_LAT",
@@ -300,7 +300,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -312,7 +312,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -324,7 +324,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_US_SpecOps_TL",
     "CUP_B_US_SpecOps",
     "CUP_B_US_SpecOps_Assault",
@@ -338,7 +338,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -352,11 +352,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_WV_B_CRAM",                                                    // C-RAM
     "CUP_WV_B_SS_Launcher",                                             // Mk-29 GMLS
     "CUP_WV_B_RAM_Launcher",                                            // Mk-49 GMLS

--- a/Missionframework/presets/players/cup_usa_woodland.sqf
+++ b/Missionframework/presets/players/cup_usa_woodland.sqf
@@ -2,7 +2,7 @@
     File: cup_usa_woodland.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-17
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,26 +25,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_HMMWV_Ambulance_USA";                   // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_CH47F_USA";                                     // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_US_Crew";                                    // This defines the crew for vehicles.
-pilot_classname = "CUP_B_US_Pilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_B_MH6M_USA";                         // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_MTVR_USA";                               // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_HMMWV_Ambulance_USA";                   // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_CH47F_USA";                                     // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_US_Crew";                                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_US_Pilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_B_MH6M_USA";                         // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_MTVR_USA";                               // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -54,7 +54,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_US_Soldier",20,0,0],                                        // Rifleman
     ["CUP_B_US_Soldier_LAT",30,0,0],                                    // Rifleman (AT)
     ["CUP_B_US_Soldier_GL",25,0,0],                                     // Grenadier
@@ -78,7 +78,7 @@ infantry_units = [
     ["CUP_B_US_Pilot",10,0,0]                                           // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_HMMWV_Unarmed_USA",75,0,50],                                // HMMWV (Unarmed)
     ["CUP_B_HMMWV_M2_USA",75,60,50],                                    // HMMWV M2
     ["CUP_B_HMMWV_MK19_USA",75,80,50],                                  // HMMWV MK19
@@ -93,7 +93,7 @@ light_vehicles = [
     ["CUP_B_MTVR_USA",125,0,75]                                         // MTVR
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_M1126_ICV_M2_Woodland_Slat",200,150,125],                   // M1126 ICV M2 CROWS (Woodland - Slat)
     ["CUP_B_M1126_ICV_MK19_Woodland_Slat",200,200,125],                 // M1126 ICV MK19 CROWS (Woodland - Slat)
     ["CUP_B_M1128_MGS_Woodland_Slat",200,500,125],                      // M1128 MGS (Woodland - Slat)
@@ -110,7 +110,7 @@ heavy_vehicles = [
     ["CUP_B_M270_DPICM_USA",800,1750,400]                               // M270 MLRS (DPICM)
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_UH60M_Unarmed_FFV_MEV_US",300,0,200],                       // UH-60M MEDVAC (Unarmed/FFV)
     ["CUP_B_UH60M_US",300,25,200],                                      // UH-60M
     ["CUP_B_UH60M_FFV_US",300,50,200],                                  // UH-60M (FFV)
@@ -138,7 +138,7 @@ air_vehicles = [
     ["CUP_B_AH6X_USA",300,0,100]                                        // AH-6X Littlebird ULB
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_M2StaticMG_US",25,40,0],                                    // M2 Machine Gun
     ["CUP_B_M2StaticMG_MiniTripod_US",25,40,0],                         // M2 Minitripod
     ["CUP_B_TOW_TriPod_US",50,100,0],                                   // TOW Tripod
@@ -150,7 +150,7 @@ static_vehicles = [
     ["CUP_B_M119_US",100,200,0]                                         // M119
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -228,17 +228,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -274,7 +274,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -288,7 +288,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier_LAT",
     "CUP_B_US_Soldier_LAT",
@@ -302,7 +302,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -314,7 +314,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_US_Soldier_SL",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -326,7 +326,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_US_SpecOps_TL",
     "CUP_B_US_SpecOps",
     "CUP_B_US_SpecOps_Assault",
@@ -340,7 +340,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
     "CUP_B_US_Soldier",
@@ -354,11 +354,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_WV_B_CRAM",                                                    // C-RAM
     "CUP_WV_B_SS_Launcher",                                             // Mk-29 GMLS
     "CUP_WV_B_RAM_Launcher",                                            // Mk-49 GMLS

--- a/Missionframework/presets/players/cup_usmc_desert.sqf
+++ b/Missionframework/presets/players/cup_usmc_desert.sqf
@@ -2,7 +2,7 @@
     File: cup_usmc_desert.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-15
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,26 +25,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_HMMWV_Ambulance_USA";                   // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_CH53E_USMC";                                    // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_USMC_Crewman_FROG_DES";                      // This defines the crew for vehicles.
-pilot_classname = "CUP_B_USMC_Pilot";                                   // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_B_UH1Y_UNA_USMC";                    // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "CUP_B_Zodiac_USMC";                             // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_MTVR_USA";                               // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_HMMWV_Ambulance_USA";                   // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_CH53E_USMC";                                    // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_USMC_Crewman_FROG_DES";                      // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_USMC_Pilot";                                   // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_B_UH1Y_UNA_USMC";                    // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "CUP_B_Zodiac_USMC";                             // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_MTVR_USA";                               // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -54,7 +54,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_USMC_Soldier_FROG_DES",20,0,0],                             // Rifleman
     ["CUP_B_USMC_Soldier_LAT_FROG_DES",30,0,0],                         // Rifleman (M136)
     ["CUP_B_USMC_Soldier_GL_FROG_DES",25,0,0],                          // Grenadier
@@ -78,7 +78,7 @@ infantry_units = [
     ["CUP_B_USMC_Pilot",10,0,0]                                         // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_M1030_USMC",50,0,25],                                       // M1030
     ["CUP_B_HMMWV_Unarmed_USA",75,0,50],                                // HMMWV (Unarmed)
     ["CUP_B_HMMWV_M2_USA",75,60,50],                                    // HMMWV M2
@@ -93,7 +93,7 @@ light_vehicles = [
     ["CUP_B_RHIB2Turret_USMC",250,200,100]                              // RHIB (Mk19)
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_LAV25_desert_USMC",200,175,125],                            // LAV-25A1 (Desert)
     ["CUP_B_LAV25M240_desert_USMC",200,200,125],                        // LAV-25A1 (M240) (Desert)
     ["CUP_B_LAV25_HQ_desert_USMC",200,50,125],                          // LAV-C2 (Desert)
@@ -106,7 +106,7 @@ heavy_vehicles = [
     ["CUP_B_M270_DPICM_USMC",800,1750,400]                              // M270 MLRS (DPICM)
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_UH1Y_MEV_USMC",200,0,100],                                  // UH-1Y Venom (MEDVAC)
     ["CUP_B_UH1Y_Gunship_Dynamic_USMC",200,100,100],                    // UH-1Y Venom (Gunship)
     ["CUP_B_MH60S_FFV_USMC",250,25,200],                                // MH-60S Seahawk (FFV)
@@ -134,7 +134,7 @@ air_vehicles = [
     ["CUP_B_MV22_VIV_USMC",750,0,500]                                   // MV-22B Osprey (VIV)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_M2StaticMG_USMC",25,40,0],                                  // M2 Machine Gun
     ["CUP_B_M2StaticMG_MiniTripod_USMC",25,40,0],                       // M2 Minitripod
     ["CUP_B_TOW_TriPod_USMC",50,100,0],                                 // TOW Tripod
@@ -146,7 +146,7 @@ static_vehicles = [
     ["CUP_B_M119_USMC",100,200,0]                                       // M119
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -223,17 +223,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -270,7 +270,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_USMC_Soldier_SL_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
@@ -284,7 +284,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_USMC_Soldier_SL_FROG_DES",
     "CUP_B_USMC_Soldier_LAT_FROG_DES",
     "CUP_B_USMC_Soldier_LAT_FROG_DES",
@@ -298,7 +298,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_USMC_Soldier_SL_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
@@ -310,7 +310,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_USMC_Soldier_SL_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
@@ -322,7 +322,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_FR_Soldier_TL_DES",
     "CUP_B_FR_Soldier_Assault_DES",
     "CUP_B_FR_Soldier_Assault_DES",
@@ -336,7 +336,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_USMC_Soldier_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
     "CUP_B_USMC_Soldier_FROG_DES",
@@ -350,11 +350,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_F35B_USMC",                                                  // F-35B Lightning II
     "CUP_WV_B_CRAM",                                                    // C-RAM
     "CUP_WV_B_SS_Launcher",                                             // Mk-29 GMLS

--- a/Missionframework/presets/players/cup_usmc_woodland.sqf
+++ b/Missionframework/presets/players/cup_usmc_woodland.sqf
@@ -2,7 +2,7 @@
     File: cup_usmc_woodland.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-15
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,26 +25,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "CUP_B_HMMWV_Ambulance_USMC";                  // This is the mobile respawn (and medical) truck.
-huron_typename = "CUP_B_CH53E_USMC";                                    // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "CUP_B_USMC_Crewman_FROG_WDL";                      // This defines the crew for vehicles.
-pilot_classname = "CUP_B_USMC_Pilot";                                   // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "CUP_B_UH1Y_UNA_USMC";                    // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "CUP_B_Zodiac_USMC";                             // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "CUP_B_MTVR_USMC";                              // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "CUP_B_HMMWV_Ambulance_USMC";                  // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "CUP_B_CH53E_USMC";                                    // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "CUP_B_USMC_Crewman_FROG_WDL";                      // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "CUP_B_USMC_Pilot";                                   // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "CUP_B_UH1Y_UNA_USMC";                    // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "CUP_B_Zodiac_USMC";                             // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "CUP_B_MTVR_USMC";                              // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -54,7 +54,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["CUP_B_USMC_Soldier_FROG_WDL",20,0,0],                             // Rifleman
     ["CUP_B_USMC_Soldier_LAT_FROG_WDL",30,0,0],                         // Rifleman (M136)
     ["CUP_B_USMC_Soldier_GL_FROG_WDL",25,0,0],                          // Grenadier
@@ -78,7 +78,7 @@ infantry_units = [
     ["CUP_B_USMC_Pilot",10,0,0]                                         // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["CUP_B_M1030_USMC",50,0,25],                                       // M1030
     ["CUP_B_HMMWV_Unarmed_USMC",75,0,50],                               // HMMWV (Unarmed)
     ["CUP_B_HMMWV_M1114_USMC",75,30,50],                                // HMMWV M240
@@ -94,7 +94,7 @@ light_vehicles = [
     ["CUP_B_RHIB2Turret_USMC",250,200,100]                              // RHIB (Mk19)
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["CUP_B_LAV25_green",200,175,125],                                  // LAV-25A1 (Olive)
     ["CUP_B_LAV25M240_green",200,200,125],                              // LAV-25A1 (M240) (Olive)
     ["CUP_B_LAV25_HQ_green",200,50,125],                                // LAV-C2 (Olive)
@@ -107,7 +107,7 @@ heavy_vehicles = [
     ["CUP_B_M270_DPICM_USMC",800,1750,400]                              // M270 MLRS (DPICM)
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["CUP_B_UH1Y_MEV_USMC",200,0,100],                                  // UH-1Y Venom (MEDVAC)
     ["CUP_B_UH1Y_Gunship_Dynamic_USMC",200,100,100],                    // UH-1Y Venom (Gunship)
     ["CUP_B_MH60S_FFV_USMC",250,25,200],                                // MH-60S Seahawk (FFV)
@@ -135,7 +135,7 @@ air_vehicles = [
     ["CUP_B_MV22_VIV_USMC",750,0,500]                                   // MV-22B Osprey (VIV)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["CUP_B_M2StaticMG_USMC",25,40,0],                                  // M2 Machine Gun
     ["CUP_B_M2StaticMG_MiniTripod_USMC",25,40,0],                       // M2 Minitripod
     ["CUP_B_TOW_TriPod_USMC",50,100,0],                                 // TOW Tripod
@@ -147,7 +147,7 @@ static_vehicles = [
     ["CUP_B_M119_USMC",100,200,0]                                       // M119
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -224,17 +224,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -271,7 +271,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "CUP_B_USMC_Soldier_SL_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
@@ -285,7 +285,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "CUP_B_USMC_Soldier_SL_FROG_WDL",
     "CUP_B_USMC_Soldier_LAT_FROG_WDL",
     "CUP_B_USMC_Soldier_LAT_FROG_WDL",
@@ -299,7 +299,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "CUP_B_USMC_Soldier_SL_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
@@ -311,7 +311,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "CUP_B_USMC_Soldier_SL_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
@@ -323,7 +323,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "CUP_B_FR_Soldier_TL_WDL",
     "CUP_B_FR_Soldier_Assault_WDL",
     "CUP_B_FR_Soldier_Assault_WDL",
@@ -337,7 +337,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "CUP_B_USMC_Soldier_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
     "CUP_B_USMC_Soldier_FROG_WDL",
@@ -351,11 +351,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "CUP_B_F35B_USMC",                                                  // F-35B Lightning II
     "CUP_WV_B_CRAM",                                                    // C-RAM
     "CUP_WV_B_SS_Launcher",                                             // Mk-29 GMLS

--- a/Missionframework/presets/players/custom.sqf
+++ b/Missionframework/presets/players/custom.sqf
@@ -2,7 +2,7 @@
     File: custom.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -29,26 +29,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_Truck_01_box_F";                                // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "B_Truck_01_medical_F";                        // This is the mobile respawn (and medical) truck.
-huron_typename = "B_Heli_Transport_03_unarmed_F";                       // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "B_crew_F";                                         // This defines the crew for vehicles.
-pilot_classname = "B_Helipilot_F";                                      // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "B_Heli_Light_01_F";                      // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "B_Truck_01_transport_F";                       // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding     = "Land_Cargo_HQ_V1_F";                         // This is the main FOB HQ building.
+KPLIB_b_fobBox          = "B_Slingload_01_Cargo_F";                     // This is the FOB as a container.
+KPLIB_b_fobTruck        = "B_Truck_01_box_F";                           // This is the FOB as a vehicle.
+KPLIB_b_arsenal         = "B_supplyCrate_F";                            // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn   = "B_Truck_01_medical_F";                       // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01        = "B_Heli_Transport_03_unarmed_F";              // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit        = "B_crew_F";                                   // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit   = "B_Helipilot_F";                              // This defines the pilot for helicopters.
+KPLIB_b_addHeli         = "B_Heli_Light_01_F";                          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat         = "B_Boat_Transport_01_F";                      // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck       = "B_Truck_01_transport_F";                     // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage    = "ContainmentArea_02_sand_F";                  // A small storage area for resources.
+KPLIB_b_largeStorage    = "ContainmentArea_01_sand_F";                  // A large storage area for resources.
+KPLIB_b_logiStation     = "Land_RepairDepot_01_tan_F";                  // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl      = "B_Radar_System_01_F";                        // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli        = "Land_HelipadSquare_F";                       // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane       = "Land_TentHangar_V1_F";                       // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply     = "CargoNet_01_box_F";                          // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo       = "B_CargoNet_01_ammo_F";                       // This defines the ammunition crates.
+KPLIB_b_crateFuel       = "CargoNet_01_barrels_F";                      // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -58,7 +58,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["B_Soldier_lite_F",15,0,0],                                        // Rifleman (Light)
     ["B_Soldier_F",20,0,0],                                             // Rifleman
     ["B_soldier_LAT_F",30,0,0],                                         // Rifleman (AT)
@@ -90,7 +90,7 @@ infantry_units = [
     ["B_Pilot_F",10,0,0]                                                // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["B_LSV_01_unarmed_F",75,0,50],                                     // Prowler
     ["B_LSV_01_armed_F",75,40,50],                                      // Prowler (HMG)
@@ -131,7 +131,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhsusf_m113_usarmy",200,40,100],                                  // M113A3 (M2)
     ["rhsusf_m113_usarmy_MK19",200,60,100],                             // M113A3 (Mk19)
     ["rhsusf_m113_usarmy_medical",200,0,100],                           // M113A3 (Medical)
@@ -162,7 +162,7 @@ heavy_vehicles = [
     ["B_MBT_01_mlrs_F",800,1750,400]                                    // M5 Sandstorm MLRS
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                             // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                             // AL-6 Pelican (Cargo)
     ["B_Heli_Light_01_F",200,0,100],                                    // MH-9 Hummingbird
@@ -219,7 +219,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["B_HMG_01_F",25,40,0],                                             // Mk30A HMG .50
     ["B_HMG_01_high_F",25,40,0],                                        // Mk30 HMG .50 (Raised)
     ["B_HMG_01_A_F",35,40,0],                                           // Mk30 HMG .50 (Autonomous)
@@ -233,7 +233,7 @@ static_vehicles = [
     ["B_SAM_System_03_F",250,500,0]                                     // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -312,17 +312,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -362,7 +362,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "B_Soldier_TL_F",
     "B_Soldier_F",
     "B_Soldier_F",
@@ -376,7 +376,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "B_Soldier_TL_F",
     "B_Soldier_LAT_F",
     "B_Soldier_LAT_F",
@@ -390,7 +390,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "B_Soldier_TL_F",
     "B_Soldier_F",
     "B_Soldier_F",
@@ -402,7 +402,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "B_Soldier_TL_F",
     "B_Soldier_F",
     "B_Soldier_F",
@@ -414,7 +414,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "B_recon_TL_F",
     "B_recon_F",
     "B_recon_F",
@@ -428,7 +428,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "B_soldier_PG_F",
     "B_soldier_PG_F",
     "B_soldier_PG_F",
@@ -442,11 +442,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                    // Mk.V SOCOM
     "rhsusf_m1a1aim_tuski_wd",                                          // M1A1SA (Tusk I)
     "B_MBT_01_TUSK_F",                                                  // M2A4 Slammer UP

--- a/Missionframework/presets/players/enoch.sqf
+++ b/Missionframework/presets/players/enoch.sqf
@@ -2,7 +2,7 @@
     File: enoch.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-07-24
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V4_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "B_T_Truck_01_box_F";                              // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "I_E_Truck_02_Medical_F";                      // This is the mobile respawn (and medical) truck.
-huron_typename = "B_Heli_Transport_03_unarmed_F";                       // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "I_E_Crew_F";                                       // This defines the crew for vehicles.
-pilot_classname = "I_E_Helipilot_F";                                    // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "B_Heli_Light_01_F";                      // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_T_Boat_Transport_01_F";                       // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "I_E_Truck_02_transport_F";                     // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_green_F";                 // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "I_E_Radar_System_01_F";                   // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V4_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "B_T_Truck_01_box_F";                              // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "I_E_Truck_02_Medical_F";                      // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "B_Heli_Transport_03_unarmed_F";                       // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "I_E_Crew_F";                                       // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "I_E_Helipilot_F";                                    // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "B_Heli_Light_01_F";                      // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_T_Boat_Transport_01_F";                       // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "I_E_Truck_02_transport_F";                     // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_green_F";                 // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "I_E_Radar_System_01_F";                   // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["I_E_Soldier_lite_F",15,0,0],                                      // Rifleman (Light)
     ["I_E_Soldier_F",20,0,0],                                           // Rifleman
     ["I_E_Soldier_LAT2_F",30,0,0],                                      // Rifleman (AT)
@@ -77,7 +77,7 @@ infantry_units = [
     ["B_T_Pilot_F",10,0,0]                                              // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["I_E_Quadbike_01_F",50,0,25],                                      // Quad Bike
     ["I_E_Offroad_01_F",60,0,35],                                       // Offroad
     ["I_E_Offroad_01_covered_F",60,0,35],                               // Offroad (Covered)
@@ -96,7 +96,7 @@ light_vehicles = [
     ["B_T_Boat_Armed_01_minigun_F",200,80,75]                           // Speedboat Minigun
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["B_T_APC_Wheeled_01_cannon_F",200,75,125],                         // AMV-7 Marshall
     ["I_E_APC_tracked_03_cannon_F",300,150,150],                        // FV-720 Odyniec
     ["B_T_APC_Tracked_01_AA_F",300,250,175],                            // IFV-6a Cheetah
@@ -107,7 +107,7 @@ heavy_vehicles = [
     ["I_E_Truck_02_MRL_F",600,1250,300]                                 // Zamak MRL
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["I_E_UAV_01_F",75,0,25],                                           // AR-2 Darter
     ["I_E_UAV_06_F",80,0,30],                                           // AL-6 Pelican
     ["B_Heli_Light_01_F",200,0,100],                                    // MH-9 Hummingbird
@@ -126,7 +126,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["B_W_Static_Designator_01_F",25,0,0],                              // Remote Designator
     ["I_E_HMG_01_F",25,40,0],                                           // Mk30A HMG .50
     ["I_E_HMG_01_high_F",25,40,0],                                      // Mk30 HMG .50 (Raised)
@@ -140,7 +140,7 @@ static_vehicles = [
     ["I_E_SAM_System_03_F",250,500,0]                                   // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V4_F",0,0,0],
     ["Land_Cargo_Patrol_V4_F",0,0,0],
     ["Land_Cargo_Tower_V4_F",0,0,0],
@@ -220,17 +220,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,200,100,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
-    [Arsenal_typename,25,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,200,100,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
+    [KPLIB_b_arsenal,25,0,0],
     ["ACE_medicalSupplyCrate_advanced",10,0,0],
     ["Box_East_Support_F",10,0,0],
     ["Box_CSAT_Equip_F",10,0,0],
@@ -259,7 +259,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "I_E_Soldier_TL_F",
     "I_E_Soldier_F",
     "I_E_Soldier_F",
@@ -273,7 +273,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "I_E_Soldier_TL_F",
     "I_E_Soldier_LAT2_F",
     "I_E_Soldier_LAT2_F",
@@ -287,7 +287,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "I_E_Soldier_TL_F",
     "I_E_Soldier_F",
     "I_E_Soldier_F",
@@ -299,7 +299,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "I_E_Soldier_TL_F",
     "I_E_Soldier_F",
     "I_E_Soldier_F",
@@ -311,7 +311,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "B_T_Recon_TL_F",
     "B_T_Recon_F",
     "B_T_Recon_F",
@@ -325,7 +325,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "B_T_Soldier_PG_F",
     "B_T_Soldier_PG_F",
     "B_T_Soldier_PG_F",
@@ -339,11 +339,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "B_T_MBT_01_TUSK_F",                                                // M2A4 Slammer UP
     "B_T_AFV_Wheeled_01_cannon_F",                                      // Rhino MGS
     "B_T_AFV_Wheeled_01_up_cannon_F",                                   // Rhino MGS UP

--- a/Missionframework/presets/players/gm_east.sqf
+++ b/Missionframework/presets/players/gm_east.sqf
@@ -2,7 +2,7 @@
     File: gm_east.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
-FOB_box_typename = "gm_gc_army_brdm2um";                                // This is the FOB as a container/BRDM (due to lack of proper container transport in GM German EAST).
-FOB_truck_typename = "gm_gc_army_btr60pu12";                            // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "gm_gc_army_ural375d_medic";                   // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_gc_army_btr60pa";                                  // This is Spartan 01, a multipurpose mobile respawn as a command BTR60.
-crewman_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                // This defines the crew for vehicles.
-pilot_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                  // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "gm_gc_bgs_p601";                         // Little birds replaced with unimog for container transportation.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "gm_gc_army_ural4320_cargo";                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
+KPLIB_b_fobBox = "gm_gc_army_brdm2um";                                // This is the FOB as a container/BRDM (due to lack of proper container transport in GM German EAST).
+KPLIB_b_fobTruck = "gm_gc_army_btr60pu12";                            // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "gm_gc_army_ural375d_medic";                   // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "gm_gc_army_btr60pa";                                  // This is Potato 01, a multipurpose mobile respawn as a command BTR60.
+KPLIB_b_crewUnit = "gm_gc_army_crew_mpiaks74nk_80_blk";                // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "gm_gc_army_crew_mpiaks74nk_80_blk";                  // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "gm_gc_bgs_p601";                         // Little birds replaced with unimog for container transportation.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "gm_gc_army_ural4320_cargo";                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["gm_gc_army_rifleman_mpiak74n_80_str",20,0,0],                     // Rifleman
     ["gm_gc_army_antitank_mpiak74n_rpg7_80_str",30,0,0],                // Rifleman (AT)
     ["gm_gc_army_machinegunner_lmgrpk_80_str",25,0,0],                  // Light Machinegunner
@@ -60,14 +60,14 @@ infantry_units = [
     ["gm_gc_army_crew_mpiaks74nk_80_blk",10,0,0]                        // Crewman
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["gm_gc_army_bicycle_01_oli",10,0,0],                               // Service Bicycle
     ["gm_gc_army_p601",50,0,25],                                        // Trabant
     ["gm_gc_army_ural4320_cargo",125,30,75],                            // Ural Transport
     ["B_Boat_Transport_01_F",100,0,25]                                  // Assault Boat
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["gm_gc_army_brdm2",200,40,100],                                    // BRDM2
     ["gm_gc_army_btr60pb",200,150,125],                                 // BTR-60PB
     ["gm_gc_army_zsu234v1",300,250,200],                                // Shilka
@@ -75,7 +75,7 @@ heavy_vehicles = [
     ["gm_gc_army_t55a",450,550,250]                                     // T-55
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["len_mi8amt_nva",225,0,125],                                       // Mi8AMT
     ["len_mi24d_CAS_nva",550,550,250],                                  // Mi-24D (CAS)
     ["len_mi24d_AT_nva",550,550,250],                                   // Mi-24D (AT)
@@ -86,11 +86,11 @@ air_vehicles = [
     ["len_l39_nva",1200,1250,650]                                       // Aero L-39
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["gm_gc_army_fagot_launcher_tripod",50,100,0]                       // Static FAGOT
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V4_F",0,0,0],
     ["Land_Cargo_Patrol_V4_F",0,0,0],
     ["Land_Cargo_Tower_V4_F",0,0,0],
@@ -170,17 +170,17 @@ buildings = [
     ["land_gm_sandbags_01_door_02",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,200,500,0],
-    [FOB_truck_typename,300,500,100],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,200,500,0],
+    [KPLIB_b_fobTruck,300,500,100],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -202,7 +202,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "gm_gc_army_squadleader_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
@@ -216,7 +216,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "gm_gc_army_squadleader_mpiak74n_80_str",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_str",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_str",
@@ -230,7 +230,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "gm_gc_army_squadleader_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
@@ -242,7 +242,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "gm_gc_army_squadleader_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
@@ -254,7 +254,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "gm_gc_army_squadleader_mpiak74n_80_str",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_str",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_str",
@@ -269,7 +269,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "gm_gc_army_rifleman_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
     "gm_gc_army_rifleman_mpiak74n_80_str",
@@ -283,11 +283,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "gm_gc_army_t55a",                                                   // T-55
     "len_mi24d_AT_nva",                                                  // Mi-24D (AT)
     "len_mi24p_AT_nva",                                                  // Mi-24P (AT)

--- a/Missionframework/presets/players/gm_east_win.sqf
+++ b/Missionframework/presets/players/gm_east_win.sqf
@@ -2,7 +2,7 @@
     File: gm_east_win.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
-FOB_box_typename = "gm_gc_army_brdm2um_win";                            // This is the FOB as a container/BRDM (due to lack of proper container transport in GM German EAST).
-FOB_truck_typename = "gm_gc_army_btr60pu12_win";                        // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "gm_gc_army_ural375d_medic_win";               // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_gc_army_btr60pa_win";                              // This is Spartan 01, a multipurpose mobile respawn as a command BTR60.
-crewman_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                // This defines the crew for vehicles.
-pilot_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                  // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "gm_gc_bgs_p601";                         // Little birds replaced with unimog for container transportation.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "gm_gc_army_ural4320_cargo";                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
+KPLIB_b_fobBox = "gm_gc_army_brdm2um_win";                            // This is the FOB as a container/BRDM (due to lack of proper container transport in GM German EAST).
+KPLIB_b_fobTruck = "gm_gc_army_btr60pu12_win";                        // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "gm_gc_army_ural375d_medic_win";               // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "gm_gc_army_btr60pa_win";                              // This is Potato 01, a multipurpose mobile respawn as a command BTR60.
+KPLIB_b_crewUnit = "gm_gc_army_crew_mpiaks74nk_80_blk";                // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "gm_gc_army_crew_mpiaks74nk_80_blk";                  // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "gm_gc_bgs_p601";                         // Little birds replaced with unimog for container transportation.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "gm_gc_army_ural4320_cargo";                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["gm_gc_army_rifleman_mpiak74n_80_win",20,0,0],                     // Rifleman
     ["gm_gc_army_antitank_mpiak74n_rpg7_80_win",30,0,0],                // Rifleman (AT)
     ["gm_gc_army_machinegunner_lmgrpk_80_win",25,0,0],                  // Light Machinegunner
@@ -60,14 +60,14 @@ infantry_units = [
     ["gm_gc_army_crew_mpiaks74nk_80_blk",10,0,0]                        // Crewman
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["gm_gc_army_bicycle_01_oli",10,0,0],                               // Service Bicycle
     ["gm_gc_army_p601",50,0,25],                                        // Trabant
     ["gm_gc_army_ural4320_cargo_win",125,30,75],                        // Ural Transport
     ["B_Boat_Transport_01_F",100,0,25]                                  // Assault Boat
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["gm_gc_army_brdm2_win",200,40,100],                                // BRDM2
     ["gm_gc_army_btr60pb_win",200,150,125],                             // BTR-60PB
     ["gm_gc_army_zsu234v1_win",300,250,200],                            // Shilka
@@ -75,7 +75,7 @@ heavy_vehicles = [
     ["gm_gc_army_t55a_win",450,550,250]                                 // T-55
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["len_mi8amt_nva",225,0,125],                                       // Mi8AMT
     ["len_mi24d_CAS_nva",550,550,250],                                  // Mi-24D (CAS)
     ["len_mi24d_AT_nva",550,550,250],                                   // Mi-24D (AT)
@@ -86,11 +86,11 @@ air_vehicles = [
     ["len_l39_nva",1200,1250,650]                                       // Aero L-39
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["gm_gc_army_fagot_launcher_tripod",50,100,0]                       // Static FAGOT
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V4_F",0,0,0],
     ["Land_Cargo_Patrol_V4_F",0,0,0],
     ["Land_Cargo_Tower_V4_F",0,0,0],
@@ -170,17 +170,17 @@ buildings = [
     ["land_gm_sandbags_01_door_02",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,200,500,0],
-    [FOB_truck_typename,300,500,100],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,200,500,0],
+    [KPLIB_b_fobTruck,300,500,100],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -202,7 +202,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "gm_gc_army_squadleader_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
@@ -216,7 +216,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "gm_gc_army_squadleader_mpiak74n_80_win",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_win",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_win",
@@ -230,7 +230,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "gm_gc_army_squadleader_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
@@ -242,7 +242,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "gm_gc_army_squadleader_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
@@ -254,7 +254,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "gm_gc_army_squadleader_mpiak74n_80_win",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_win",
     "gm_gc_army_antitank_mpiak74n_rpg7_80_win",
@@ -269,7 +269,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "gm_gc_army_rifleman_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
     "gm_gc_army_rifleman_mpiak74n_80_win",
@@ -283,11 +283,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "gm_gc_army_t55a_win",                                               // T-55,
     "len_mi24d_AT_nva",                                                  // Mi-24D (AT)
     "len_mi24p_AT_nva",                                                  // Mi-24P (AT)

--- a/Missionframework/presets/players/gm_west.sqf
+++ b/Missionframework/presets/players/gm_west.sqf
@@ -2,7 +2,7 @@
     File: gm_west.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-04-30
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
-FOB_box_typename = "gm_ge_army_shelteraceI_command";                    // This is the FOB as a container.
-FOB_truck_typename = "gm_ge_army_bpz2a0";                               // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "gm_ge_army_u1300l_medic";                     // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_ge_army_m113a1g_command";                          // This is Spartan 01, a multipurpose mobile respawn as a command M113.
-crewman_classname = "gm_ge_army_crew_mp2a1_80_oli";                     // This defines the crew for vehicles.
-pilot_classname = "gm_ge_army_crew_mp2a1_80_oli";                       // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "gm_ge_army_u1300l_container";            // Little birds replaced with unimog for container transportation.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "gm_ge_army_kat1_454_cargo";                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
+KPLIB_b_fobBox = "gm_ge_army_shelteraceI_command";                    // This is the FOB as a container.
+KPLIB_b_fobTruck = "gm_ge_army_bpz2a0";                               // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "gm_ge_army_u1300l_medic";                     // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "gm_ge_army_m113a1g_command";                          // This is Potato 01, a multipurpose mobile respawn as a command M113.
+KPLIB_b_crewUnit = "gm_ge_army_crew_mp2a1_80_oli";                     // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "gm_ge_army_crew_mp2a1_80_oli";                       // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "gm_ge_army_u1300l_container";            // Little birds replaced with unimog for container transportation.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "gm_ge_army_kat1_454_cargo";                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["gm_ge_army_rifleman_g3a3_80_ols",20,0,0],                         // Rifleman
     ["gm_ge_army_antitank_g3a3_pzf44_80_ols",30,0,0],                   // Rifleman (AT)
     ["gm_ge_army_grenadier_g3a3_80_ols",25,0,0],                        // Grenadier
@@ -62,7 +62,7 @@ infantry_units = [
     ["gm_ge_army_crew_mp2a1_80_oli",10,0,0]                             // Crewman
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["gm_ge_army_bicycle_01_oli",10,0,0],                               // Service Bicycle
     ["gm_ge_army_k125",50,0,25],                                        // K125 Bike
     ["gm_ge_army_iltis_cargo",100,0,50],                                // Truck 0.5t
@@ -73,7 +73,7 @@ light_vehicles = [
     ["B_Boat_Transport_01_F",100,0,25]                                  // Assault Boat
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["gm_ge_army_m113a1g_apc",200,40,100],                              // M113A3 (MG3)
     ["gm_ge_army_m113a1g_apc_milan",200,60,100],                        // M113A3 (MILAN)
     ["gm_ge_army_m113a1g_medic",200,0,100],                             // M113A3 (Medical)
@@ -86,15 +86,15 @@ heavy_vehicles = [
     ["gm_ge_army_Leopard1a3a1",550,550,250]                             // Leopard 1A3A1
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["len_uh1d_bw",225,0,125]                                           // BW UH-1D
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["gm_ge_army_milan_launcher_tripod",50,100,0]                       // Static MILAN
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V4_F",0,0,0],
     ["Land_Cargo_Patrol_V4_F",0,0,0],
     ["Land_Cargo_Tower_V4_F",0,0,0],
@@ -174,17 +174,17 @@ buildings = [
     ["land_gm_sandbags_01_door_02",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,200,500,0],
-    [FOB_truck_typename,300,500,100],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,200,500,0],
+    [KPLIB_b_fobTruck,300,500,100],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -206,7 +206,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "gm_ge_army_squadleader_g3a3_p2a1_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
@@ -220,7 +220,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "gm_ge_army_squadleader_g3a3_p2a1_80_ols",
     "gm_ge_army_antitank_g3a3_pzf44_80_ols",
     "gm_ge_army_antitank_g3a3_pzf44_80_ols",
@@ -234,7 +234,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "gm_ge_army_squadleader_g3a3_p2a1_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
@@ -246,7 +246,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "gm_ge_army_squadleader_g3a3_p2a1_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
@@ -258,7 +258,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "gm_ge_army_squadleader_g3a3_p2a1_80_ols",
     "gm_ge_army_antitank_g3a3_pzf44_80_ols",
     "gm_ge_army_antitank_g3a3_pzf44_80_ols",
@@ -273,7 +273,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "gm_ge_army_rifleman_g3a3_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
     "gm_ge_army_rifleman_g3a3_80_ols",
@@ -287,11 +287,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "gm_ge_army_Leopard1a1a2",                                          // Leopard 1A1A2
     "gm_ge_army_Leopard1a3a1"                                           // Leopard 1A3A1
 ];

--- a/Missionframework/presets/players/gm_west_win.sqf
+++ b/Missionframework/presets/players/gm_west_win.sqf
@@ -2,7 +2,7 @@
     File: gm_west_win.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
-FOB_box_typename = "gm_ge_army_shelteraceI_command_win";                // This is the FOB as a container.
-FOB_truck_typename = "gm_ge_army_bpz2a0_win";                           // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "gm_ge_army_u1300l_medic_win_rc";              // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_ge_army_m113a1g_command_win";                      // This is Spartan 01, a multipurpose mobile respawn as a command M113.
-crewman_classname = "gm_ge_army_crew_mp2a1_80_win";                     // This defines the crew for vehicles.
-pilot_classname = "gm_ge_army_crew_mp2a1_80_win";                       // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "gm_ge_army_u1300l_container_win";        // Little birds replaced with unimog for container transportation.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "gm_ge_army_kat1_454_cargo_win";                // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "land_gm_tower_bt_6_fuest_80";                           // This is the main FOB HQ building.
+KPLIB_b_fobBox = "gm_ge_army_shelteraceI_command_win";                // This is the FOB as a container.
+KPLIB_b_fobTruck = "gm_ge_army_bpz2a0_win";                           // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "gm_ge_army_u1300l_medic_win_rc";              // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "gm_ge_army_m113a1g_command_win";                      // This is Potato 01, a multipurpose mobile respawn as a command M113.
+KPLIB_b_crewUnit = "gm_ge_army_crew_mp2a1_80_win";                     // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "gm_ge_army_crew_mp2a1_80_win";                       // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "gm_ge_army_u1300l_container_win";        // Little birds replaced with unimog for container transportation.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "gm_ge_army_kat1_454_cargo_win";                // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "land_gm_euro_shed_03";                        // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "land_gm_radiotower_01";                   // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["gm_ge_army_rifleman_g3a3_parka_80_win",20,0,0],                   // Rifleman
     ["gm_ge_army_antitank_g3a3_pzf44_parka_80_win",30,0,0],             // Rifleman (AT)
     ["gm_ge_army_grenadier_g3a3_parka_80_win",25,0,0],                  // Grenadier
@@ -62,7 +62,7 @@ infantry_units = [
     ["gm_ge_army_crew_mp2a1_80_oli",10,0,0]                             // Crewman
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["gm_ge_army_bicycle_01_oli",10,0,0],                               // Service Bicycle
     ["gm_ge_army_k125",50,0,25],                                        // K125 Bike
     ["gm_ge_army_iltis_cargo_win",100,0,50],                            // Truck 0.5t
@@ -73,7 +73,7 @@ light_vehicles = [
     ["B_Boat_Transport_01_F",100,0,25]                                  // Assault Boat
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["gm_ge_army_m113a1g_apc_win",200,40,100],                          // M113A3 (MG3)
     ["gm_ge_army_m113a1g_apc_milan_win",200,60,100],                    // M113A3 (MILAN)
     ["gm_ge_army_m113a1g_medic",200,0,100],                             // M113A3 (Medical)
@@ -86,15 +86,15 @@ heavy_vehicles = [
     ["gm_ge_army_Leopard1a3a1_win",550,550,250]                         // Leopard 1A3A1
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["len_uh1d_bw",225,0,125]                                           // BW UH-1D
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["gm_ge_army_milan_launcher_tripod",50,100,0]                       // Static MILAN
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V4_F",0,0,0],
     ["Land_Cargo_Patrol_V4_F",0,0,0],
     ["Land_Cargo_Tower_V4_F",0,0,0],
@@ -174,17 +174,17 @@ buildings = [
     ["land_gm_sandbags_01_door_02",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,200,500,0],
-    [FOB_truck_typename,300,500,100],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,200,500,0],
+    [KPLIB_b_fobTruck,300,500,100],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -206,7 +206,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "gm_ge_army_squadleader_g3a3_p2a1_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
@@ -220,7 +220,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "gm_ge_army_squadleader_g3a3_p2a1_parka_80_win",
     "gm_ge_army_antitank_g3a3_pzf44_parka_80_win",
     "gm_ge_army_antitank_g3a3_pzf44_parka_80_win",
@@ -234,7 +234,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "gm_ge_army_squadleader_g3a3_p2a1_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
@@ -246,7 +246,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "gm_ge_army_squadleader_g3a3_p2a1_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
@@ -258,7 +258,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "gm_ge_army_squadleader_g3a3_p2a1_parka_80_win",
     "gm_ge_army_antitank_g3a3_pzf44_parka_80_win",
     "gm_ge_army_antitank_g3a3_pzf44_parka_80_win",
@@ -273,7 +273,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "gm_ge_army_rifleman_g3a3_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
     "gm_ge_army_rifleman_g3a3_parka_80_win",
@@ -287,11 +287,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "gm_ge_army_Leopard1a1a2_win",                                      // Leopard 1A1A2
     "gm_ge_army_Leopard1a3a1_win"                                       // Leopard 1A3A1
 ];

--- a/Missionframework/presets/players/rhs_afrf.sqf
+++ b/Missionframework/presets/players/rhs_afrf.sqf
@@ -2,7 +2,7 @@
     File: rhs_afrf.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-14
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "rhs_gaz66_r142_msv";                              // This is the FOB as a vehicle.
-Arsenal_typename = "O_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "rhs_gaz66_ap2_msv";                           // This is the mobile respawn (and medical) truck.
-huron_typename = "RHS_Mi8mt_vvs";                                       // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "rhs_msv_emr_armoredcrew";                          // This defines the crew for vehicles.
-pilot_classname = "rhs_pilot_combat_heli";                              // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "rhs_ka60_grey";                          // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhs_kamaz5350_flatbed_vdv";                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_forest_F";           // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_forest_F";           // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "rhs_prv13";                               // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "rhs_gaz66_r142_msv";                              // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "O_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "rhs_gaz66_ap2_msv";                           // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "RHS_Mi8mt_vvs";                                       // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "rhs_msv_emr_armoredcrew";                          // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "rhs_pilot_combat_heli";                              // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "rhs_ka60_grey";                          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "O_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhs_kamaz5350_flatbed_vdv";                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_forest_F";           // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_forest_F";           // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "rhs_prv13";                               // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["rhs_vdv_rifleman_lite",15,0,0],                                   // Rifleman (Light)
     ["rhs_vdv_rifleman",20,0,0],                                        // Rifleman
     ["rhs_vdv_LAT",30,0,0],                                             // Rifleman (LAT)
@@ -73,7 +73,7 @@ infantry_units = [
     ["rhs_pilot",10,0,0]                                                // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["O_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["rhs_uaz_vdv",50,0,45],                                            // UAZ
     ["rhs_uaz_open_vdv",50,0,45],                                       // UAZ (Open)
@@ -100,7 +100,7 @@ light_vehicles = [
     ["O_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhs_bmp1k_vdv",200,40,100],                                       // BMP-1K
     ["rhs_bmp2k_vdv",240,150,100],                                      // BMP-2K
     ["rhs_bmd2m",260,170,120],                                          // BMD-2M (Berezhok)
@@ -116,7 +116,7 @@ heavy_vehicles = [
     ["rhs_2s3_tv",600,1250,300]                                         // 2S3M1
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["O_UAV_01_F",75,0,25],                                             // AR-2 Tayran
     ["O_UAV_06_F",80,0,30],                                             // AL-6 Jinaah (Cargo)
     ["rhs_ka60_c",200,0,100],                                           // KA-60
@@ -131,7 +131,7 @@ air_vehicles = [
     ["rhs_mig29s_vvsc",1250,1250,450]                                   // Mig-29S
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["RHS_NSV_TriPod_VDV",25,40,0],                                     // NSV Low Tripod
     ["rhs_KORD_high_VDV",25,40,0],                                      // KORD High Tripod
     ["RHS_AGS30_TriPod_VDV",25,60,0],                                   // AGS30 Low Tripod
@@ -143,7 +143,7 @@ static_vehicles = [
     ["rhs_D30_at_vdv",100,200,0]                                        // D-30 AT
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -222,17 +222,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -254,7 +254,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "rhs_vdv_sergeant    ",
     "rhs_vdv_rifleman",
     "rhs_vdv_LAT",
@@ -268,7 +268,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "rhs_vdv_sergeant    ",
     "rhs_vdv_rifleman",
     "rhs_vdv_LAT",
@@ -282,7 +282,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "rhs_vdv_sergeant    ",
     "rhs_vdv_rifleman",
     "rhs_vdv_LAT",
@@ -294,7 +294,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "rhs_vdv_sergeant    ",
     "rhs_vdv_rifleman",
     "rhs_vdv_LAT",
@@ -306,7 +306,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "rhs_vdv_recon_sergeant",
     "rhs_vdv_rifleman",
     "rhs_vdv_recon_grenadier",
@@ -320,7 +320,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "rhs_vdv_recon_rifleman",
     "rhs_vdv_recon_rifleman",
     "rhs_vdv_recon_rifleman_lat",
@@ -334,11 +334,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhs_t80ue1",                                                       // T-80UE1
     "rhs_t90a_tv",                                                      // T-90A
     "rhs_t90sab_tv",                                                    // T-90SA (2016)

--- a/Missionframework/presets/players/rhs_usaf_des.sqf
+++ b/Missionframework/presets/players/rhs_usaf_des.sqf
@@ -2,7 +2,7 @@
     File: rhs_usaf_des.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,26 +25,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "rhsusf_M1078A1P2_B_D_CP_fmtv_usarmy";             // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "rhsusf_M1085A1P2_B_D_Medical_fmtv_usarmy";    // This is the mobile respawn (and medical) truck.
-huron_typename = "RHS_CH_47F";                                          // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "rhsusf_army_ocp_combatcrewman";                    // This defines the crew for vehicles.
-pilot_classname = "rhsusf_army_ocp_helipilot";                          // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "RHS_MELB_MH6M";                          // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhsusf_M977A4_BKIT_usarmy_d";                  // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V3_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "rhsusf_M1078A1P2_B_D_CP_fmtv_usarmy";             // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "rhsusf_M1085A1P2_B_D_Medical_fmtv_usarmy";    // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "RHS_CH_47F";                                          // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "rhsusf_army_ocp_combatcrewman";                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "rhsusf_army_ocp_helipilot";                          // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "RHS_MELB_MH6M";                          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhsusf_M977A4_BKIT_usarmy_d";                  // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -54,7 +54,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["rhsusf_army_ocp_riflemanl",15,0,0],                               // Rifleman (Light)
     ["rhsusf_army_ocp_rifleman",20,0,0],                                // Rifleman
     ["rhsusf_army_ocp_riflemanat",30,0,0],                              // Rifleman (AT)
@@ -83,7 +83,7 @@ infantry_units = [
     ["rhsusf_airforce_jetpilot",10,0,0]                                 // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["rhsusf_mrzr4_d",75,0,25],                                         // MRZR 4
     ["rhsusf_m1025_d",100,0,50],                                        // M1025A2
@@ -120,7 +120,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhsusf_m113d_usarmy",200,40,100],                                 // M113A3 (M2)
     ["rhsusf_m113d_usarmy_MK19",200,60,100],                            // M113A3 (Mk19)
     ["rhsusf_m113d_usarmy_medical",200,0,100],                          // M113A3 (Medical)
@@ -133,7 +133,7 @@ heavy_vehicles = [
     ["rhsusf_m109d_usarmy",600,1250,300]                                // M109A6
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                             // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                             // AL-6 Pelican (Cargo)
     ["RHS_MELB_MH6M",200,0,100],                                        // MH-6M Little Bird
@@ -177,7 +177,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["RHS_M2StaticMG_MiniTripod_D",25,40,0],                            // Mk2 HMG .50
     ["RHS_M2StaticMG_D",25,40,0],                                       // Mk2 HMG .50 (Raised)
     ["RHS_MK19_TriPod_D",25,60,0],                                      // Mk19 GMG 20mm
@@ -188,7 +188,7 @@ static_vehicles = [
     ["B_SAM_System_03_F",250,500,0]                                     // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V3_F",0,0,0],
     ["Land_Cargo_Patrol_V3_F",0,0,0],
     ["Land_Cargo_Tower_V3_F",0,0,0],
@@ -267,17 +267,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -316,7 +316,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_rifleman",
     "rhsusf_army_ocp_rifleman",
@@ -330,7 +330,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_riflemanat",
     "rhsusf_army_ocp_riflemanat",
@@ -344,7 +344,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_rifleman",
     "rhsusf_army_ocp_rifleman",
@@ -356,7 +356,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_rifleman",
     "rhsusf_army_ocp_rifleman",
@@ -368,7 +368,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "rhsusf_usmc_recon_marpat_d_teamleader",
     "rhsusf_usmc_recon_marpat_d_rifleman",
     "rhsusf_usmc_recon_marpat_d_rifleman",
@@ -382,7 +382,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
@@ -396,11 +396,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                    // Mk.V SOCOM
     "rhsusf_m1a1aim_tuski_d",                                           // M1A1SA (Tusk I)
     "rhsusf_m1a2sep1tuskiid_usarmy",                                    // M1A2SEPv1 (Tusk II)

--- a/Missionframework/presets/players/rhs_usaf_wdl.sqf
+++ b/Missionframework/presets/players/rhs_usaf_wdl.sqf
@@ -2,7 +2,7 @@
     File: rhs_usaf_wdl.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -25,26 +25,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "rhsusf_M1078A1P2_B_WD_CP_fmtv_usarmy";            // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "rhsusf_M1085A1P2_B_WD_Medical_fmtv_usarmy";   // This is the mobile respawn (and medical) truck.
-huron_typename = "RHS_CH_47F";                                          // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "rhsusf_army_ocp_combatcrewman";                    // This defines the crew for vehicles.
-pilot_classname = "rhsusf_army_ocp_helipilot";                          // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "RHS_MELB_MH6M";                          // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "rhsusf_M977A4_BKIT_usarmy_wd";                 // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "rhsusf_M1078A1P2_B_WD_CP_fmtv_usarmy";            // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "rhsusf_M1085A1P2_B_WD_Medical_fmtv_usarmy";   // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "RHS_CH_47F";                                          // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "rhsusf_army_ocp_combatcrewman";                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "rhsusf_army_ocp_helipilot";                          // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "RHS_MELB_MH6M";                          // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "B_Boat_Transport_01_F";                         // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "rhsusf_M977A4_BKIT_usarmy_wd";                 // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_RepairDepot_01_tan_F";                   // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "B_Radar_System_01_F";                     // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -54,7 +54,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["rhsusf_army_ocp_riflemanl",15,0,0],                               // Rifleman (Light)
     ["rhsusf_army_ocp_rifleman",20,0,0],                                // Rifleman
     ["rhsusf_army_ocp_riflemanat",30,0,0],                              // Rifleman (AT)
@@ -83,7 +83,7 @@ infantry_units = [
     ["rhsusf_airforce_jetpilot",10,0,0]                                 // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["rhsusf_m1025_w",100,0,50],                                        // M1025A2
     ["rhsusf_m1025_w_m2",100,40,50],                                    // M1025A2 (M2)
@@ -113,7 +113,7 @@ light_vehicles = [
     ["B_SDV_01_F",150,0,50]                                             // SDV
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["rhsusf_m113_usarmy",200,40,100],                                  // M113A3 (M2)
     ["rhsusf_m113_usarmy_MK19",200,60,100],                             // M113A3 (Mk19)
     ["rhsusf_m113_usarmy_medical",200,0,100],                           // M113A3 (Medical)
@@ -126,7 +126,7 @@ heavy_vehicles = [
     ["rhsusf_m109_usarmy",600,1250,300]                                 // M109A6
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["B_UAV_01_F",75,0,25],                                             // AR-2 Darter
     ["B_UAV_06_F",80,0,30],                                             // AL-6 Pelican (Cargo)
     ["RHS_MELB_MH6M",200,0,100],                                        // MH-6M Little Bird
@@ -170,7 +170,7 @@ air_vehicles = [
     ["B_T_VTOL_01_vehicle_F",750,0,500]                                 // V-44 X Blackfish (Vehicle)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["RHS_M2StaticMG_MiniTripod_WD",25,40,0],                           // Mk2 HMG .50
     ["RHS_M2StaticMG_WD",25,40,0],                                      // Mk2 HMG .50 (Raised)
     ["RHS_MK19_TriPod_WD",25,60,0],                                     // Mk19 GMG 20mm
@@ -181,7 +181,7 @@ static_vehicles = [
     ["B_SAM_System_03_F",250,500,0]                                     // MIM-145 Defender
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -260,17 +260,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -306,7 +306,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_rifleman",
     "rhsusf_army_ocp_rifleman",
@@ -320,7 +320,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_riflemanat",
     "rhsusf_army_ocp_riflemanat",
@@ -334,7 +334,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_rifleman",
     "rhsusf_army_ocp_rifleman",
@@ -346,7 +346,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "rhsusf_army_ocp_teamleader",
     "rhsusf_army_ocp_rifleman",
     "rhsusf_army_ocp_rifleman",
@@ -358,7 +358,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "rhsusf_usmc_recon_marpat_wd_teamleader",
     "rhsusf_usmc_recon_marpat_wd_rifleman",
     "rhsusf_usmc_recon_marpat_wd_rifleman",
@@ -372,7 +372,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
     "rhsusf_army_ocp_rifleman_101st",
@@ -386,11 +386,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "rhsusf_mkvsoc",                                                    // Mk.V SOCOM
     "rhsusf_m1a1aim_tuski_wd",                                          // M1A1SA (Tusk I)
     "rhsusf_m1a2sep1tuskiiwd_usarmy",                                   // M1A2SEPv1 (Tusk II)

--- a/Missionframework/presets/players/sfp_des.sqf
+++ b/Missionframework/presets/players/sfp_des.sqf
@@ -2,7 +2,7 @@
     File: sfp_des.sqf
     Author: Dahlgren - https://github.com/Dahlgren
     Date: 2017-07-24
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "sfp_tgb1112";                                     // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "sfp_patgb203_ambulance";                      // This is the mobile respawn (and medical) truck.
-huron_typename = "sfp_hkp4";                                            // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "sfp_m90d_crew";                                    // This defines the crew for vehicles.
-pilot_classname = "sfp_m90w_pilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "sfp_hkp9";                               // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "sfp_strb90";                                    // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "sfp_tgb40";                                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_CarService_F";                           // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "Land_Radar_Small_F";                      // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "sfp_tgb1112";                                     // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "sfp_patgb203_ambulance";                      // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "sfp_hkp4";                                            // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "sfp_m90d_crew";                                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "sfp_m90w_pilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "sfp_hkp9";                               // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "sfp_strb90";                                    // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "sfp_tgb40";                                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_CarService_F";                           // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "Land_Radar_Small_F";                      // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["sfp_m90d_rifleman_tshirt",15,0,0],                                // Rifleman (Light)
     ["sfp_m90d_rifleman_ak5",20,0,0],                                   // Rifleman
     ["sfp_m90d_at_specialist_pskott86",30,0,0],                         // Rifleman (AT)
@@ -77,7 +77,7 @@ infantry_units = [
     ["sfp_m90w_pilot",10,0,0]                                           // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["sfp_tgb16_desert",100,0,50],                                      // Tgb 16
     ["sfp_tgb16_rws",100,40,50],                                        // Tgb 16 (RWS)
@@ -90,13 +90,13 @@ light_vehicles = [
     ["sfp_strb90_rws",200,80,75]                                        // Strb 90 (RWS)
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["sfp_strf90c_desert",200,40,100],                                  // Strf 90
     ["sfp_lvkv90c_desert",200,60,100],                                  // Lvkv 90
     ["sfp_strv122",400,350,225]                                         // Strb 122
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["sfp_uav01",80,0,30],                                              // UAV 01 Ugglan
     ["sfp_uav03",75,0,25],                                              // UAV 03 Örnen
     ["sfp_uav_skeldar",80,0,30],                                        // UAV Skeldar
@@ -112,7 +112,7 @@ air_vehicles = [
     ["sfp_jas39_rb15",1250,1500,450]                                    // JAS 39 (Rb15)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["sfp_ksp88",25,40,0],                                              // Ksp 88
     ["sfp_grsp",25,60,0],                                               // Grsp
     ["sfp_rbs17",30,60,0],                                              // RBS 17
@@ -125,7 +125,7 @@ static_vehicles = [
 ];
 
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -204,17 +204,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -237,7 +237,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "sfp_m90d_squadleader",
     "sfp_m90d_automaticrifleman_ksp90",
     "sfp_m90d_rifleman_ak5",
@@ -249,7 +249,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "sfp_m90d_squadleader",
     "sfp_m90d_machinegunner_ksp58",
     "sfp_m90d_at_specialist_grg86",
@@ -261,7 +261,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "sfp_m90d_teamleader",
     "sfp_m90d_at_specialist_grg86",
     "sfp_m90d_at_loader_grg86",
@@ -269,12 +269,12 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     // No man portable AA in SFP
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "sfp_m90d_sog_teamleader",
     "sfp_m90d_sog_ksp90",
     "sfp_m90d_sog_explosive_specialist",
@@ -284,7 +284,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "sfp_m90d_sog_teamleader",
     "sfp_m90d_sog_ksp90",
     "sfp_m90d_sog_explosive_specialist",
@@ -294,11 +294,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "sfp_strf90c_desert",                                               // Strf 90
     "sfp_lvkv90c_desert",                                               // Lvkv 90
     "sfp_strv122",                                                      // Strv 122

--- a/Missionframework/presets/players/sfp_wdl.sqf
+++ b/Missionframework/presets/players/sfp_wdl.sqf
@@ -2,7 +2,7 @@
     File: sfp_des.sqf
     Author: Dahlgren - https://github.com/Dahlgren
     Date: 2017-07-24
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "sfp_tgb1112";                                     // This is the FOB as a vehicle.
-Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "sfp_patgb203_ambulance";                      // This is the mobile respawn (and medical) truck.
-huron_typename = "sfp_hkp4";                                            // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "sfp_m90w_crew";                                    // This defines the crew for vehicles.
-pilot_classname = "sfp_m90w_pilot";                                     // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "sfp_hkp9";                               // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "sfp_strb90";                                    // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "sfp_tgb40";                                    // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "Land_CarService_F";                           // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "Land_Radar_Small_F";                      // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "Land_Cargo_HQ_V1_F";                                    // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "sfp_tgb1112";                                     // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "sfp_patgb203_ambulance";                      // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "sfp_hkp4";                                            // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "sfp_m90w_crew";                                    // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "sfp_m90w_pilot";                                     // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "sfp_hkp9";                               // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "sfp_strb90";                                    // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "sfp_tgb40";                                    // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "Land_CarService_F";                           // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "Land_Radar_Small_F";                      // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "Land_HelipadSquare_F";                      // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "Land_TentHangar_V1_F";                     // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["sfp_m90w_rifleman_tshirt",15,0,0],                                // Rifleman (Light)
     ["sfp_m90w_rifleman_ak5",20,0,0],                                   // Rifleman
     ["sfp_m90w_at_specialist_pskott86",30,0,0],                         // Rifleman (AT)
@@ -77,7 +77,7 @@ infantry_units = [
     ["sfp_m90w_pilot",10,0,0]                                           // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["B_Quadbike_01_F",50,0,25],                                        // Quad Bike
     ["sfp_tgb16",100,0,50],                                             // Tgb 16
     ["sfp_tgb16_rws",100,40,50],                                        // Tgb 16 (RWS)
@@ -103,13 +103,13 @@ light_vehicles = [
     ["sfp_rbb_norrkoping",1000,1000,300]                                // HMS Norrkoping
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["sfp_strf90c",200,40,100],                                         // Strf 90
     ["sfp_lvkv90c",200,60,100],                                         // Lvkv 90
     ["sfp_strv122",400,350,225]                                         // Strv 122
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["sfp_uav01",80,0,30],                                              // UAV 01 Ugglan
     ["sfp_uav03",75,0,25],                                              // UAV 03 Örnen
     ["sfp_uav_skeldar",80,0,30],                                        // UAV Skeldar
@@ -125,7 +125,7 @@ air_vehicles = [
     ["sfp_jas39_rb15",1250,1500,450]                                    // JAS 39 (Rb15)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["sfp_ksp88",25,40,0],                                              // Ksp 88
     ["sfp_grsp",25,60,0],                                               // Grsp
     ["sfp_rbs17",30,60,0],                                              // RBS 17
@@ -138,7 +138,7 @@ static_vehicles = [
 ];
 
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["Land_Cargo_House_V1_F",0,0,0],
     ["Land_Cargo_Patrol_V1_F",0,0,0],
     ["Land_Cargo_Tower_V1_F",0,0,0],
@@ -217,17 +217,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -250,7 +250,7 @@ support_vehicles = [
 */
 
 // Light infantry squad.
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "sfp_m90w_squadleader",
     "sfp_m90w_automaticrifleman_ksp90",
     "sfp_m90w_rifleman_ak5",
@@ -262,7 +262,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad.
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "sfp_m90w_squadleader",
     "sfp_m90w_machinegunner_ksp58",
     "sfp_m90w_at_specialist_grg86",
@@ -274,7 +274,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad.
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "sfp_m90w_teamleader",
     "sfp_m90w_at_specialist_grg86",
     "sfp_m90w_at_loader_grg86",
@@ -282,12 +282,12 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad.
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     // No man portable AA in SFP
 ];
 
 // Force recon squad.
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "sfp_m90w_sog_teamleader",
     "sfp_m90w_sog_ksp90",
     "sfp_m90w_sog_explosive_specialist",
@@ -297,7 +297,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad.
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "sfp_m90w_sog_teamleader",
     "sfp_m90w_sog_ksp90",
     "sfp_m90w_sog_explosive_specialist",
@@ -307,11 +307,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "sfp_strf90c",                                                      // Strf 90
     "sfp_lvkv90c",                                                      // Lvkv 90
     "sfp_strv122",                                                      // Strv 122

--- a/Missionframework/presets/players/unsung.sqf
+++ b/Missionframework/presets/players/unsung.sqf
@@ -2,7 +2,7 @@
     File: unsung.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-06-04
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -21,26 +21,26 @@
     The same classnames for different purposes may cause various unpredictable issues with player actions.
     Or not, just don't try!
 */
-FOB_typename = "LAND_sb_bunker_main";                                   // This is the main FOB HQ building.
-FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
-FOB_truck_typename = "uns_M35A2_fuel";                                  // This is the FOB as a vehicle.
-Arsenal_typename = "uns_resupply_crate_US";                             // This is the virtual arsenal as portable supply crates.
-Respawn_truck_typename = "uns_M577_amb";                                // This is the mobile respawn (and medical) truck.
-huron_typename = "uns_h21c";                                            // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
-crewman_classname = "uns_US_25ID_STY3";                                 // This defines the crew for vehicles.
-pilot_classname = "uns_pilot1";                                         // This defines the pilot for helicopters.
-KPLIB_little_bird_classname = "uns_H13_transport_CAV";                  // These are the little birds which spawn on the Freedom or at Chimera base.
-KPLIB_boat_classname = "UNS_Zodiac_W";                                  // These are the boats which spawn at the stern of the Freedom.
-KPLIB_truck_classname = "uns_M35A2_Open";                               // These are the trucks which are used in the logistic convoy system.
-KPLIB_small_storage_building = "ContainmentArea_02_sand_F";             // A small storage area for resources.
-KPLIB_large_storage_building = "ContainmentArea_01_sand_F";             // A large storage area for resources.
-KPLIB_recycle_building = "uns_motorpool1_repair";                       // The building defined to unlock FOB recycling functionality.
-KPLIB_air_vehicle_building = "LAND_uns_signaltower";                    // The building defined to unlock FOB air vehicle functionality.
-KPLIB_heli_slot_building = "LAND_uns_Heli_pad";                         // The helipad used to increase the GLOBAL rotary-wing cap.
-KPLIB_plane_slot_building = "UNS_Hanger_repair";                        // The hangar used to increase the GLOBAL fixed-wing cap.
-KPLIB_supply_crate = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
-KPLIB_ammo_crate = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
-KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
+KPLIB_b_fobBuilding = "LAND_sb_bunker_main";                                   // This is the main FOB HQ building.
+KPLIB_b_fobBox = "B_Slingload_01_Cargo_F";                            // This is the FOB as a container.
+KPLIB_b_fobTruck = "uns_M35A2_fuel";                                  // This is the FOB as a vehicle.
+KPLIB_b_arsenal = "uns_resupply_crate_US";                             // This is the virtual arsenal as portable supply crates.
+KPLIB_b_mobileRespawn = "uns_M577_amb";                                // This is the mobile respawn (and medical) truck.
+KPLIB_b_potato01 = "uns_h21c";                                            // This is Potato 01, a multipurpose mobile respawn as a helicopter.
+KPLIB_b_crewUnit = "uns_US_25ID_STY3";                                 // This defines the crew for vehicles.
+KPLIB_b_heliPilotUnit = "uns_pilot1";                                         // This defines the pilot for helicopters.
+KPLIB_b_addHeli = "uns_H13_transport_CAV";                  // These are the additional helicopters which spawn on the Freedom or at Chimera base.
+KPLIB_b_addBoat = "UNS_Zodiac_W";                                  // These are the boats which spawn at the stern of the Freedom.
+KPLIB_b_logiTruck = "uns_M35A2_Open";                               // These are the trucks which are used in the logistic convoy system.
+KPLIB_b_smallStorage = "ContainmentArea_02_sand_F";             // A small storage area for resources.
+KPLIB_b_largeStorage = "ContainmentArea_01_sand_F";             // A large storage area for resources.
+KPLIB_b_logiStation = "uns_motorpool1_repair";                       // The building defined to unlock FOB recycling functionality.
+KPLIB_b_airControl = "LAND_uns_signaltower";                    // The building defined to unlock FOB air vehicle functionality.
+KPLIB_b_slotHeli = "LAND_uns_Heli_pad";                         // The helipad used to increase the GLOBAL rotary-wing cap.
+KPLIB_b_slotPlane = "UNS_Hanger_repair";                        // The hangar used to increase the GLOBAL fixed-wing cap.
+KPLIB_b_crateSupply = "CargoNet_01_box_F";                               // This defines the supply crates, as in resources.
+KPLIB_b_crateAmmo = "B_CargoNet_01_ammo_F";                              // This defines the ammunition crates.
+KPLIB_b_crateFuel = "CargoNet_01_barrels_F";                             // This defines the fuel crates.
 
 /*
     --- Friendly classnames ---
@@ -50,7 +50,7 @@ KPLIB_fuel_crate = "CargoNet_01_barrels_F";                             // This 
     The above example is the NATO IFV-6a Cheetah, it costs 300 supplies, 150 ammunition and 150 fuel to build.
     IMPORTANT: The last element inside each array must have no comma at the end!
 */
-infantry_units = [
+KPLIB_b_infantry = [
     ["uns_US_25ID_STY3",15,0,0],                                        // Sentry
     ["uns_US_25ID_RF6",20,0,0],                                         // Rifleman
     ["uns_US_25ID_AT",30,0,0],                                          // Rifleman (AT)
@@ -74,7 +74,7 @@ infantry_units = [
     ["uns_pil1",10,0,0]                                                 // Pilot
 ];
 
-light_vehicles = [
+KPLIB_b_vehLight = [
     ["uns_m274",50,0,25],                                               // M-274 Mule
     ["uns_m274_m60",50,25,25],                                          // M-274 Mule (M60)
     ["uns_willys",75,0,50],                                             // M-151 MUTT
@@ -91,7 +91,7 @@ light_vehicles = [
     ["uns_PBR_M10",200,80,75]                                           // PBR Mk. II (M10 Flamethrower)
 ];
 
-heavy_vehicles = [
+KPLIB_b_vehHeavy = [
     ["uns_xm706e2",100,50,100],                                         // XM-706-E2 Commando
     ["uns_xm706e1",100,60,100],                                         // XM-706-E1 Commando (30 cal)
     ["uns_M113_30cal",200,75,100],                                      // M-113 ACAV (30 cal)
@@ -112,7 +112,7 @@ heavy_vehicles = [
     ["uns_m110sp",600,750,300]                                          // M-110 Self-Propelled Gun
 ];
 
-air_vehicles = [
+KPLIB_b_vehAir = [
     ["uns_H13_transport_CAV",100,0,80],                                 // UH-13B
     ["uns_H13_amphib_CAV",100,0,80],                                    // OH-13C CSAR
     ["uns_H13_medevac_CAV",100,0,80],                                   // MH-13E Medevac
@@ -149,7 +149,7 @@ air_vehicles = [
     ["uns_F4E_CAS",800,600,400]                                         // F-4E Phantom II (CAS)
 ];
 
-static_vehicles = [
+KPLIB_b_vehStatic = [
     ["uns_US_SearchLight",20,0,0],                                      // Searchlight
     ["uns_m60_low",25,40,0],                                            // M60 7.62mm (low)
     ["uns_m60_high",25,40,0],                                           // M60 7.62mm (high)
@@ -166,7 +166,7 @@ static_vehicles = [
     ["Uns_M114_artillery",100,200,0]                                    // M-114A1 155mm Howitzer
 ];
 
-buildings = [
+KPLIB_b_objectsDeco = [
     ["uns_FlagCarrierUS",0,0,0],
     ["uns_FlagCarrier101AB",0,0,0],
     ["uns_FlagCarrier25ID",0,0,0],
@@ -277,17 +277,17 @@ buildings = [
     ["Land_ClutterCutter_large_F",0,0,0]
 ];
 
-support_vehicles = [
-    [Arsenal_typename,100,200,0],
-    [Respawn_truck_typename,200,0,100],
-    [FOB_box_typename,300,500,0],
-    [FOB_truck_typename,300,500,75],
-    [KPLIB_small_storage_building,0,0,0],
-    [KPLIB_large_storage_building,0,0,0],
-    [KPLIB_recycle_building,250,0,0],
-    [KPLIB_air_vehicle_building,1000,0,0],
-    [KPLIB_heli_slot_building,250,0,0],
-    [KPLIB_plane_slot_building,500,0,0],
+KPLIB_b_vehSupport = [
+    [KPLIB_b_arsenal,100,200,0],
+    [KPLIB_b_mobileRespawn,200,0,100],
+    [KPLIB_b_fobBox,300,500,0],
+    [KPLIB_b_fobTruck,300,500,75],
+    [KPLIB_b_smallStorage,0,0,0],
+    [KPLIB_b_largeStorage,0,0,0],
+    [KPLIB_b_logiStation,250,0,0],
+    [KPLIB_b_airControl,1000,0,0],
+    [KPLIB_b_slotHeli,250,0,0],
+    [KPLIB_b_slotPlane,500,0,0],
     ["ACE_medicalSupplyCrate_advanced",50,0,0],
     ["ACE_Box_82mm_Mo_HE",50,40,0],
     ["ACE_Box_82mm_Mo_Smoke",50,10,0],
@@ -310,7 +310,7 @@ support_vehicles = [
 */
 
 // Light infantry squad
-blufor_squad_inf_light = [
+KPLIB_b_squadLight = [
     "uns_US_25ID_SL",
     "uns_US_25ID_RF6",
     "uns_US_25ID_RF6",
@@ -324,7 +324,7 @@ blufor_squad_inf_light = [
 ];
 
 // Heavy infantry squad
-blufor_squad_inf = [
+KPLIB_b_squadInf = [
     "uns_US_25ID_SL",
     "uns_US_25ID_AT",
     "uns_US_25ID_AT",
@@ -338,7 +338,7 @@ blufor_squad_inf = [
 ];
 
 // AT specialists squad
-blufor_squad_at = [
+KPLIB_b_squadAT = [
     "uns_US_25ID_SL",
     "uns_US_25ID_RF6",
     "uns_US_25ID_RF6",
@@ -350,7 +350,7 @@ blufor_squad_at = [
 ];
 
 // AA specialists squad
-blufor_squad_aa = [
+KPLIB_b_squadAA = [
     "uns_US_25ID_SL",
     "uns_US_25ID_RF6",
     "uns_US_25ID_RF6",
@@ -362,7 +362,7 @@ blufor_squad_aa = [
 ];
 
 // Force recon squad
-blufor_squad_recon = [
+KPLIB_b_squadRecon = [
     "uns_men_US_1AC_SL",
     "uns_men_US_1AC_TPR1",
     "uns_men_US_1AC_TPR2",
@@ -376,7 +376,7 @@ blufor_squad_recon = [
 ];
 
 // Paratroopers squad (The units of this squad will automatically get parachutes on build)
-blufor_squad_para = [
+KPLIB_b_squadPara = [
     "uns_men_US_5SFG_SP13",
     "uns_men_US_5SFG_SP13",
     "uns_men_US_5SFG_SP13",
@@ -390,11 +390,11 @@ blufor_squad_para = [
 ];
 
 /*
-    --- Elite vehicles ---
+    --- Vehicles to unlock ---
     Classnames below have to be unlocked by capturing military bases.
     Which base locks a vehicle is randomized on the first start of the campaign.
 */
-elite_vehicles = [
+KPLIB_b_vehToUnlock = [
     "uns_A1J_CAS",                                                      // A-1H Skyraider (CAS)
     "uns_A7_CAS",                                                       // A-7D Corsair II (CAS)
     "uns_F4E_CAS",                                                      // F-4E Phantom II (CAS)

--- a/Missionframework/presets/resistance/apex.sqf
+++ b/Missionframework/presets/resistance/apex.sqf
@@ -2,7 +2,7 @@
     File: apex.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-08
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -17,7 +17,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "I_C_Soldier_Bandit_1_F",
     "I_C_Soldier_Bandit_2_F",
     "I_C_Soldier_Bandit_3_F",
@@ -29,7 +29,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "I_C_Offroad_02_LMG_F",
     "I_C_Offroad_02_AT_F"
 ];
@@ -40,7 +40,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["arifle_AKM_F","30Rnd_762x39_Mag_F",4,"",""],
     ["arifle_AKS_F","30Rnd_545x39_Mag_F",4,"",""],
     ["hgun_PDW2000_F","30Rnd_9x21_Mag",4,"",""],
@@ -49,7 +49,7 @@ KPLIB_guerilla_weapons_1 = [
     ["SMG_05_F","30Rnd_9x21_Mag_SMG_02",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["arifle_Katiba_F","30Rnd_65x39_caseless_green",4,"optic_ACO_grn",""],
     ["arifle_Mk20_plain_F","30Rnd_556x45_Stanag",4,"optic_ACO_grn",""],
     ["arifle_TRG21_F","30Rnd_556x45_Stanag",4,"optic_ACO_grn",""],
@@ -58,7 +58,7 @@ KPLIB_guerilla_weapons_2 = [
     ["srifle_DMR_06_olive_F","20Rnd_762x51_Mag",5,"optic_Hamr","bipod_01_F_blk"]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["arifle_CTAR_blk_F","30Rnd_580x42_Mag_F",4,"optic_MRCO",""],
     ["arifle_SPAR_01_blk_F","30Rnd_556x45_Stanag",4,"optic_MRCO",""],
     ["arifle_SPAR_03_blk_F","20Rnd_762x51_Mag",5,"optic_MRCO",""],
@@ -70,7 +70,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "U_C_Poloshirt_blue",
     "U_C_Poloshirt_burgundy",
     "U_C_Poloshirt_salmon",
@@ -87,7 +87,7 @@ KPLIB_guerilla_uniforms_1 = [
     "U_Marshal"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "U_I_C_Soldier_Bandit_1_F",
     "U_I_C_Soldier_Bandit_2_F",
     "U_I_C_Soldier_Bandit_3_F",
@@ -103,7 +103,7 @@ KPLIB_guerilla_uniforms_2 = [
     "U_I_G_resistanceLeader_F"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "U_BG_Guerilla1_1",
     "U_BG_Guerilla1_2_F",
     "U_BG_Guerrilla_6_1",
@@ -116,7 +116,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -131,7 +131,7 @@ KPLIB_guerilla_vests_1 = [
     "V_BandollierB_ghex_F"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_Chestrig_rgr",
     "V_Chestrig_khk",
     "V_Chestrig_oli",
@@ -144,7 +144,7 @@ KPLIB_guerilla_vests_2 = [
     "V_HarnessOGL_ghex_F"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_TacVest_brn",
     "V_TacVest_khk",
     "V_TacVest_oli",
@@ -157,7 +157,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -182,7 +182,7 @@ KPLIB_guerilla_headgear_1 = [
     "H_Cap_blk"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "H_Bandanna_blu",
     "H_Bandanna_sand",
     "H_Bandanna_gry",
@@ -200,7 +200,7 @@ KPLIB_guerilla_headgear_2 = [
     "H_MilCap_dgtl"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "H_ShemagOpen_khk",
     "H_ShemagOpen_tan",
     "H_Shemag_olive",
@@ -214,7 +214,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/cup_napa.sqf
+++ b/Missionframework/presets/resistance/cup_napa.sqf
@@ -2,7 +2,7 @@
     File: cup_napa.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-21
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -19,7 +19,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "CUP_I_GUE_Soldier_AR",
     "CUP_I_GUE_Engineer",
     "CUP_I_GUE_Commander",
@@ -31,7 +31,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "CUP_I_Datsun_PK_Random",
     "CUP_I_Datsun_PK_Random",
     "CUP_I_Datsun_PK_Random",
@@ -52,7 +52,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["CUP_srifle_CZ550","CUP_5x_22_LR_17_HMR_M",10,"",""],
     ["CUP_srifle_CZ550_rail","CUP_5x_22_LR_17_HMR_M",10,"optic_mrco",""],
     ["CUP_srifle_LeeEnfield","CUP_10x_303_M",10,"",""],
@@ -61,7 +61,7 @@ KPLIB_guerilla_weapons_1 = [
     ["CUP_arifle_AK47_Early","CUP_30Rnd_762x39_AK47_M",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["CUP_arifle_AK47_Early","CUP_30Rnd_762x39_AK47_M",4,"",""],
     ["CUP_arifle_AK47_Early","CUP_30Rnd_762x39_AK47_M",4,"",""],
     ["CUP_arifle_AKM","CUP_30Rnd_762x39_AK47_M",4,"cup_optic_pso_1_ak_open",""],
@@ -70,7 +70,7 @@ KPLIB_guerilla_weapons_2 = [
     ["CUP_smg_SA61","CUP_50Rnd_B_765x17_Ball_M",5,"",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["CUP_arifle_AK47_Early","CUP_30Rnd_762x39_AK47_M",4,"",""],
     ["CUP_arifle_AK74M","CUP_30Rnd_545x39_AK74M_M",4,"cup_optic_kobra",""],
     ["CUP_arifle_AK74M_GL","CUP_30Rnd_545x39_AK74M_M",4,"cup_optic_kobra",""],
@@ -82,7 +82,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "CUP_U_I_Villager_03",
     "CUP_U_I_Woodlander03",
     "CUP_U_I_Woodlander_02",
@@ -95,7 +95,7 @@ KPLIB_guerilla_uniforms_1 = [
 
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "CUP_I_B_PMC_Unit_20",
     "CUP_I_B_PMC_Unit_19",
     "CUP_I_B_PMC_Unit_11",
@@ -106,7 +106,7 @@ KPLIB_guerilla_uniforms_2 = [
     "CUP_I_B_PMC_Unit_22"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "CUP_U_I_GUE_Flecktarn2",
     "CUP_U_I_GUE_Flecktarn3",
     "CUP_U_I_GUE_Flecktarn",
@@ -119,7 +119,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "CUP_V_I_Guerilla_Jacket",
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
@@ -135,7 +135,7 @@ KPLIB_guerilla_vests_1 = [
     "V_BandollierB_ghex_F"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_TacVestIR_blk",
     "V_Chestrig_rgr",
     "V_Chestrig_khk",
@@ -149,7 +149,7 @@ KPLIB_guerilla_vests_2 = [
     "V_HarnessOGL_ghex_F"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_TacVest_oli",
     "CUP_V_RUS_Smersh_2",
     "CUP_V_I_Carrier_Belt",
@@ -160,7 +160,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -179,7 +179,7 @@ KPLIB_guerilla_headgear_1 = [
     "CUP_H_C_Beanie_04"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "H_Bandanna_blu",
     "H_Bandanna_sand",
     "H_Bandanna_gry",
@@ -197,7 +197,7 @@ KPLIB_guerilla_headgear_2 = [
     "H_MilCap_dgtl"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "H_Shemag_olive",
     "H_Shemag_olive_hs",
     "H_Shemag_olive",
@@ -209,7 +209,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/cup_takistan.sqf
+++ b/Missionframework/presets/resistance/cup_takistan.sqf
@@ -2,7 +2,7 @@
     File: cup_takistan.sqf
     Author: Eogos - https://github.com/Eogos
     Date: 2019-07-15
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -19,7 +19,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "CUP_I_TK_GUE_Soldier_MG",
     "CUP_I_TK_GUE_Mechanic",
     "CUP_I_TK_GUE_Commander",
@@ -31,7 +31,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "CUP_I_Datsun_PK_TK",
     "CUP_I_Hilux_AGS30_TK",
     "CUP_I_Hilux_DSHKM_TK",
@@ -55,7 +55,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["bnae_mk1_virtual","10Rnd_303_Magazine",8,"",""],
     ["bnae_mk1_t_virtual","10Rnd_303_Magazine",8,"bnae_scope_v3_virtual",""],
     ["bnae_m97_virtual","6Rnd_Slug_Magazine",10,"",""],
@@ -66,7 +66,7 @@ KPLIB_guerilla_weapons_1 = [
     ["CUP_arifle_AK47","CUP_30Rnd_762x39_AK47_M",6,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["bnae_mk1_t_virtual","10Rnd_303_Magazine",8,"bnae_scope_v3_virtual",""],
     ["CUP_arifle_AK47","CUP_30Rnd_762x39_AK47_M",6,"",""],
     ["CUP_arifle_AK47","CUP_30Rnd_762x39_AK47_M",6,"cup_optic_kobra",""],
@@ -75,7 +75,7 @@ KPLIB_guerilla_weapons_2 = [
     ["CUP_arifle_RPK74","CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M",3,"",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["CUP_arifle_FNFAL","CUP_20Rnd_762x51_FNFAL_M",5,"",""],
     ["CUP_arifle_AK47","CUP_30Rnd_762x39_AK47_M",6,"",""],
     ["CUP_arifle_AK47","CUP_30Rnd_762x39_AK47_M",6,"cup_optic_kobra",""],
@@ -87,7 +87,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "CUP_O_TKI_Khet_Jeans_04",
     "CUP_O_TKI_Khet_Jeans_03",
     "CUP_O_TKI_Khet_Jeans_02",
@@ -105,7 +105,7 @@ KPLIB_guerilla_uniforms_1 = [
 
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "U_BG_Guerilla2_3",
     "U_BG_Guerilla2_1",
     "U_BG_Guerilla2_1",
@@ -121,7 +121,7 @@ KPLIB_guerilla_uniforms_2 = [
     "U_I_G_resistanceLeader_F"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "U_BG_Guerilla1_1",
     "U_BG_Guerilla1_2_F",
     "U_BG_Guerrilla_6_1",
@@ -134,7 +134,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -165,7 +165,7 @@ KPLIB_guerilla_vests_1 = [
     "CUP_V_OI_TKI_Jacket5_04"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_Chestrig_rgr",
     "V_Chestrig_khk",
     "V_Chestrig_oli",
@@ -180,7 +180,7 @@ KPLIB_guerilla_vests_2 = [
     "V_HarnessOGL_ghex_F"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_TacVest_brn",
     "V_TacVest_khk",
     "V_TacVest_oli",
@@ -198,7 +198,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "CUP_H_TKI_Lungee_Open_01",
     "CUP_H_TK_Lungee",
     "CUP_H_TKI_Lungee_Open_02",
@@ -232,7 +232,7 @@ KPLIB_guerilla_headgear_1 = [
     "CUP_H_TKI_SkullCap_06"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "CUP_H_TKI_Lungee_Open_01",
     "CUP_H_TK_Lungee",
     "CUP_H_TKI_Lungee_Open_02",
@@ -266,7 +266,7 @@ KPLIB_guerilla_headgear_2 = [
     "CUP_H_TKI_SkullCap_06"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "CUP_H_TKI_Lungee_Open_01",
     "CUP_H_TK_Lungee",
     "CUP_H_TKI_Lungee_Open_02",
@@ -301,7 +301,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/custom.sqf
+++ b/Missionframework/presets/resistance/custom.sqf
@@ -2,7 +2,7 @@
     File: custom.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-10-07
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -17,7 +17,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "I_G_Soldier_AR_F",
     "I_G_engineer_F",
     "I_G_officer_F",
@@ -29,7 +29,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "I_G_Offroad_01_armed_F",
     "I_G_Offroad_01_AT_F"
 ];
@@ -40,7 +40,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["arifle_AKM_F","30Rnd_762x39_Mag_F",4,"",""],
     ["arifle_AKS_F","30Rnd_545x39_Mag_F",4,"",""],
     ["hgun_PDW2000_F","30Rnd_9x21_Mag",4,"",""],
@@ -49,7 +49,7 @@ KPLIB_guerilla_weapons_1 = [
     ["SMG_05_F","30Rnd_9x21_Mag_SMG_02",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["arifle_Katiba_F","30Rnd_65x39_caseless_green",4,"optic_ACO_grn",""],
     ["arifle_Mk20_plain_F","30Rnd_556x45_Stanag",4,"optic_ACO_grn",""],
     ["arifle_TRG21_F","30Rnd_556x45_Stanag",4,"optic_ACO_grn",""],
@@ -58,7 +58,7 @@ KPLIB_guerilla_weapons_2 = [
     ["srifle_DMR_06_olive_F","20Rnd_762x51_Mag",5,"optic_Hamr","bipod_01_F_blk"]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["arifle_CTAR_blk_F","30Rnd_580x42_Mag_F",4,"optic_MRCO",""],
     ["arifle_SPAR_01_blk_F","30Rnd_556x45_Stanag",4,"optic_MRCO",""],
     ["arifle_SPAR_03_blk_F","20Rnd_762x51_Mag",5,"optic_MRCO",""],
@@ -70,7 +70,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "U_C_Poloshirt_blue",
     "U_C_Poloshirt_burgundy",
     "U_C_Poloshirt_salmon",
@@ -87,7 +87,7 @@ KPLIB_guerilla_uniforms_1 = [
     "U_Marshal"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "U_I_C_Soldier_Bandit_1_F",
     "U_I_C_Soldier_Bandit_2_F",
     "U_I_C_Soldier_Bandit_3_F",
@@ -103,7 +103,7 @@ KPLIB_guerilla_uniforms_2 = [
     "U_I_G_resistanceLeader_F"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "U_BG_Guerilla1_1",
     "U_BG_Guerilla1_2_F",
     "U_BG_Guerrilla_6_1",
@@ -116,7 +116,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -131,7 +131,7 @@ KPLIB_guerilla_vests_1 = [
     "V_BandollierB_ghex_F"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_Chestrig_rgr",
     "V_Chestrig_khk",
     "V_Chestrig_oli",
@@ -144,7 +144,7 @@ KPLIB_guerilla_vests_2 = [
     "V_HarnessOGL_ghex_F"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_TacVest_brn",
     "V_TacVest_khk",
     "V_TacVest_oli",
@@ -157,7 +157,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -182,7 +182,7 @@ KPLIB_guerilla_headgear_1 = [
     "H_Cap_blk"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "H_Bandanna_blu",
     "H_Bandanna_sand",
     "H_Bandanna_gry",
@@ -200,7 +200,7 @@ KPLIB_guerilla_headgear_2 = [
     "H_MilCap_dgtl"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "H_ShemagOpen_khk",
     "H_ShemagOpen_tan",
     "H_Shemag_olive",
@@ -214,7 +214,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/germany.sqf
+++ b/Missionframework/presets/resistance/germany.sqf
@@ -2,7 +2,7 @@
     File: custom.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-05-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -17,7 +17,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "I_G_Soldier_AR_F",
     "I_G_engineer_F",
     "I_G_officer_F",
@@ -29,7 +29,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [];
+KPLIB_r_vehicles = [];
 
 /* Guerilla Equipment
 There are 3 tiers for every category. If the strength of the guerillas will increase, they'll have higher tier equipment. */
@@ -37,19 +37,19 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["gm_mp2a1_blk","gm_32Rnd_9x19mm_B_DM51_mp2_blk",4,"",""],
     ["gm_mp2a1_blk","gm_32Rnd_9x19mm_B_DM51_mp2_blk",4,"",""],
     ["gm_mpiaks74n_prp","gm_30Rnd_545x39mm_B_7N6_ak74_prp",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["gm_mpiaks74n_prp","gm_30Rnd_545x39mm_B_7N6_ak74_prp",4,"",""],
     ["gm_mpiak74n_prp","gm_30Rnd_545x39mm_B_7N6_ak74_prp",4,"",""],
     ["gm_mpiak74n_prp","gm_30Rnd_545x39mm_B_7N6_ak74_prp",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["gm_mpiak74n_prp","gm_30Rnd_545x39mm_B_7N6_ak74_prp",4,"",""],
     ["gm_g3a3_blk","gm_20Rnd_762x51mm_B_T_DM21_g3_blk",4,"",""],
     ["gm_g3a3_blk","gm_20Rnd_762x51mm_B_T_DM21_g3_blk",4,"",""],
@@ -58,7 +58,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "gm_gc_civ_uniform_man_01_80_blu",
     "gm_gc_civ_uniform_man_02_80_brn",
     "gm_ge_civ_uniform_blouse_80_gry",
@@ -66,7 +66,7 @@ KPLIB_guerilla_uniforms_1 = [
     "U_C_Mechanic_01_F"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "gm_gc_civ_uniform_man_01_80_blu",
     "gm_gc_civ_uniform_man_02_80_brn",
     "gm_ge_civ_uniform_blouse_80_gry",
@@ -76,7 +76,7 @@ KPLIB_guerilla_uniforms_2 = [
     "U_C_WorkerCoveralls"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "gm_gc_civ_uniform_man_01_80_blu",
     "gm_gc_civ_uniform_man_02_80_brn",
     "gm_ge_civ_uniform_blouse_80_gry",
@@ -93,7 +93,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -103,7 +103,7 @@ KPLIB_guerilla_vests_1 = [
     "V_BandollierB_blk"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -113,7 +113,7 @@ KPLIB_guerilla_vests_2 = [
     "gm_ge_bgs_vest_80_rifleman"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -122,7 +122,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -135,7 +135,7 @@ KPLIB_guerilla_headgear_1 = [
     "H_Hat_Safari_sand_F"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "",
     "",
     "",
@@ -154,7 +154,7 @@ KPLIB_guerilla_headgear_2 = [
     "H_Bandanna_khk"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "",
     "",
     "",
@@ -177,7 +177,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/middle_eastern.sqf
+++ b/Missionframework/presets/resistance/middle_eastern.sqf
@@ -2,7 +2,7 @@
     File: middle_eastern.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2017-12-09
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -19,7 +19,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "LOP_AM_Infantry_SL",
     "LOP_AM_Infantry_Rifleman",
     "LOP_AM_Infantry_Rifleman_2",
@@ -31,7 +31,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "LOP_AM_UAZ_DshKM"
 ];
 
@@ -41,13 +41,13 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["rhs_weap_ak74","rhs_30rnd_545x39_AK",4,"",""],
     ["rhs_weap_aks74u","rhs_30rnd_545x39_AK",4,"",""],
     ["LOP_Weap_LeeEnfield","LOP_10rnd_77mm_mag",3,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["rhs_weap_ak74","rhs_30rnd_545x39_AK",4,"",""],
     ["rhs_weap_akm","rhs_30rnd_762x39mm",4,"",""],
     ["rhs_weap_akms","rhs_30rnd_762x39mm",4,"",""],
@@ -56,7 +56,7 @@ KPLIB_guerilla_weapons_2 = [
     ["LOP_Weap_LeeEnfield_railed","LOP_10rnd_77mm_mag",3,"optic_ACO_grn",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["rhs_weap_ak103","rhs_30rnd_762x39mm",4,"",""],
     ["rhs_weap_ak104","rhs_30rnd_762x39mm",4,"",""],
     ["rhs_weap_ak105","rhs_30rnd_545x39_AK",4,"rhs_acc_ekp1",""],
@@ -66,7 +66,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "LOP_U_TAK_Civ_Fatigue_01",
     "LOP_U_TAK_Civ_Fatigue_02",
     "LOP_U_TAK_Civ_Fatigue_04",
@@ -84,7 +84,7 @@ KPLIB_guerilla_uniforms_1 = [
     "LOP_U_TAK_Civ_Fatigue_16"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "LOP_U_TAK_Civ_Fatigue_01",
     "LOP_U_TAK_Civ_Fatigue_02",
     "LOP_U_TAK_Civ_Fatigue_04",
@@ -102,7 +102,7 @@ KPLIB_guerilla_uniforms_2 = [
     "LOP_U_TAK_Civ_Fatigue_16"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "LOP_U_TAK_Civ_Fatigue_01",
     "LOP_U_TAK_Civ_Fatigue_02",
     "LOP_U_TAK_Civ_Fatigue_04",
@@ -121,11 +121,11 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     ""
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "",
     "V_LegStrapBag_black_F",
     "V_LegStrapBag_coyote_F",
@@ -133,7 +133,7 @@ KPLIB_guerilla_vests_2 = [
     "LOP_6sh46"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "",
     "V_LegStrapBag_black_F",
     "V_LegStrapBag_coyote_F",
@@ -145,7 +145,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "H_HeadBandage_clean_F",
@@ -160,7 +160,7 @@ KPLIB_guerilla_headgear_1 = [
     "H_Bandanna_camo"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "",
     "H_HeadBandage_clean_F",
     "H_HeadBandage_stained_F",
@@ -175,7 +175,7 @@ KPLIB_guerilla_headgear_2 = [
     "LOP_H_Turban_mask"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "LOP_H_Turban",
     "LOP_H_Turban_mask",
     "H_Shemag_olive",
@@ -191,6 +191,6 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     ""
 ];

--- a/Missionframework/presets/resistance/racs.sqf
+++ b/Missionframework/presets/resistance/racs.sqf
@@ -2,7 +2,7 @@
     File: racs.sqf
     Author: PSYKO-nz - https://github.com/PSYKO-nz
     Date: 2018-02-19
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -17,7 +17,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "LOP_RACS_Infantry_MG",
     "LOP_RACS_Infantry_Engineer",
     "LOP_RACS_Infantry_TL",
@@ -29,7 +29,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "LOP_RACS_Landrover_M2",
     "LOP_RACS_Offroad_M2"
 ];
@@ -40,7 +40,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["rhs_weap_Izh","rhsgref_1Rnd_00Buck",20,"",""],
     ["rhs_weap_m38","rhsgref_5rnd_762x54_m38",6,"",""],
     ["rhs_weap_m38_rail","rhsgref_5rnd_762x54_m38",6,"",""],
@@ -49,7 +49,7 @@ KPLIB_guerilla_weapons_1 = [
     ["rhs_weap_makarov_pm","rhs_mag_9x18_8_57N181S",5,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["rhs_weap_ak74","rhs_30rnd_545x39_AK",3,"",""],
     ["rhs_weap_akm","rhs_30rnd_762x39mm",3,"",""],
     ["rhs_weap_akms","rhs_30rnd_762x39mm",3,"",""],
@@ -58,7 +58,7 @@ KPLIB_guerilla_weapons_2 = [
     ["rhs_weap_svds","rhs_10rnd_762x54mmR_7N1",3,"rhs_acc_pso1m2",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["rhs_weap_ak103","rhs_30rnd_762x39mm",4,"rhs_acc_pkas",""],
     ["rhs_weap_ak104","rhs_30rnd_762x39mm",4,"rhs_acc_ekp8_02",""],
     ["rhs_weap_ak105","rhs_30rnd_545x39_AK",4,"rhs_acc_pkas",""],
@@ -70,23 +70,23 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "LOP_U_RACS_Fatigue_01",
     "LOP_U_RACS_Fatigue_01_slv"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "LOP_U_RACS_Fatigue_01",
     "LOP_U_RACS_Fatigue_01_slv"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "LOP_U_RACS_Fatigue_01",
     "LOP_U_RACS_Fatigue_01_slv"
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -105,7 +105,7 @@ KPLIB_guerilla_vests_1 = [
     "rhs_6sh46"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_Chestrig_rgr",
     "V_Chestrig_khk",
     "V_Chestrig_oli",
@@ -122,7 +122,7 @@ KPLIB_guerilla_vests_2 = [
     "V_TacChestrig_oli_F"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_TacVest_brn",
     "V_TacVest_khk",
     "V_TacVest_oli",
@@ -139,7 +139,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -150,7 +150,7 @@ KPLIB_guerilla_headgear_1 = [
 
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "H_Bandanna_blu",
     "H_Bandanna_sand",
     "H_Bandanna_gry",
@@ -170,7 +170,7 @@ KPLIB_guerilla_headgear_2 = [
     "LOP_H_6B27M_ess_RACS"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "H_ShemagOpen_khk",
     "H_ShemagOpen_tan",
     "H_Shemag_olive",
@@ -193,7 +193,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/rhs_gref.sqf
+++ b/Missionframework/presets/resistance/rhs_gref.sqf
@@ -2,7 +2,7 @@
     File: rhs_gref.sqf
     Author: FatRefrigerator - https://github.com/FatRefrigerator
     Date: 2017-10-11
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -18,7 +18,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "I_G_Soldier_AR_F",
     "I_G_engineer_F",
     "I_G_officer_F",
@@ -30,7 +30,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [
+KPLIB_r_vehicles = [
     "rhsgref_ins_g_uaz_dshkm_chdkz"
 ];
 
@@ -40,7 +40,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["rhs_weap_Izh","rhsgref_1Rnd_00Buck",20,"",""],
     ["rhs_weap_m38","rhsgref_5rnd_762x54_m38",6,"",""],
     ["rhs_weap_m38_rail","rhsgref_5rnd_762x54_m38",6,"",""],
@@ -49,7 +49,7 @@ KPLIB_guerilla_weapons_1 = [
     ["rhs_weap_makarov_pm","rhs_mag_9x18_8_57N181S",5,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["rhs_weap_ak74","rhs_30rnd_545x39_AK",3,"",""],
     ["rhs_weap_akm","rhs_30rnd_762x39mm",3,"",""],
     ["rhs_weap_akms","rhs_30rnd_762x39mm",3,"",""],
@@ -58,7 +58,7 @@ KPLIB_guerilla_weapons_2 = [
     ["rhs_weap_svds","rhs_10rnd_762x54mmR_7N1",3,"rhs_acc_pso1m2",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["rhs_weap_ak103","rhs_30rnd_762x39mm",4,"rhs_acc_pkas",""],
     ["rhs_weap_ak104","rhs_30rnd_762x39mm",4,"rhs_acc_ekp8_02",""],
     ["rhs_weap_ak105","rhs_30rnd_545x39_AK",4,"rhs_acc_pkas",""],
@@ -70,7 +70,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "U_I_C_Soldier_Bandit_1_F",
     "U_I_C_Soldier_Bandit_2_F",
     "U_I_C_Soldier_Bandit_3_F",
@@ -83,7 +83,7 @@ KPLIB_guerilla_uniforms_1 = [
     "U_BG_Guerilla2_3"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "U_BG_Guerrilla_6_1",
     "U_BG_Guerilla1_1",
     "U_I_C_Soldier_Para_1_F",
@@ -97,7 +97,7 @@ KPLIB_guerilla_uniforms_2 = [
     "U_I_G_resistanceLeader_F"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "rhsgref_uniform_reed",
     "rhsgref_uniform_woodland_olive",
     "rhsgref_uniform_flecktarn",
@@ -106,7 +106,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "V_LegStrapBag_coyote_F",
     "V_LegStrapBag_olive_F",
     "V_LegStrapBag_black_F",
@@ -125,7 +125,7 @@ KPLIB_guerilla_vests_1 = [
     "rhs_6sh46"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "V_Chestrig_rgr",
     "V_Chestrig_khk",
     "V_Chestrig_oli",
@@ -142,7 +142,7 @@ KPLIB_guerilla_vests_2 = [
     "V_TacChestrig_oli_F"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "V_TacVest_brn",
     "V_TacVest_khk",
     "V_TacVest_oli",
@@ -159,7 +159,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -180,7 +180,7 @@ KPLIB_guerilla_headgear_1 = [
     "H_Cap_blk"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "H_Bandanna_blu",
     "H_Bandanna_sand",
     "H_Bandanna_gry",
@@ -194,7 +194,7 @@ KPLIB_guerilla_headgear_2 = [
     "rhsgref_fieldcap_ttsko_urban"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "H_ShemagOpen_khk",
     "H_ShemagOpen_tan",
     "H_Shemag_olive",
@@ -211,7 +211,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/presets/resistance/unsung.sqf
+++ b/Missionframework/presets/resistance/unsung.sqf
@@ -2,7 +2,7 @@
     File: unsung.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2019-07-25
-    Last Update: 2020-05-18
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -17,7 +17,7 @@
 
 /* Classnames of the guerilla faction which is friendly or hostile, depending on the civil reputation
 Standard loadout of the units will be replaced with a scripted one, which depends on the guerilla strength, after spawn */
-KPLIB_guerilla_units = [
+KPLIB_r_units = [
     "uns_men_ARVNci_HMG",
     "uns_men_ARVNci_S2",
     "uns_men_ARVNci_SL",
@@ -29,7 +29,7 @@ KPLIB_guerilla_units = [
 ];
 
 // Armed vehicles
-KPLIB_guerilla_vehicles = [];
+KPLIB_r_vehicles = [];
 
 /* Guerilla Equipment
 There are 3 tiers for every category. If the strength of the guerillas will increase, they'll have higher tier equipment. */
@@ -37,7 +37,7 @@ There are 3 tiers for every category. If the strength of the guerillas will incr
 /* Weapons - You've to add the weapons as array like
 ["Weaponclassname","Magazineclassname","magazine amount","optic","tripod"]
 You can leave optic and tripod empty with "" */
-KPLIB_guerilla_weapons_1 = [
+KPLIB_r_weapons_1 = [
     ["uns_ak47","uns_ak47mag",4,"",""],
     ["uns_PPS52","uns_k50mag",4,"",""],
     ["uns_owen","uns_owenmag",4,"",""],
@@ -46,7 +46,7 @@ KPLIB_guerilla_weapons_1 = [
     ["uns_m1carbine","uns_m1carbinemag",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_2 = [
+KPLIB_r_weapons_2 = [
     ["uns_m2carbine","uns_m2carbinemag",4,"",""],
     ["uns_akm","uns_ak47mag",4,"",""],
     ["uns_DP28_base","uns_47Rnd_DP28",4,"",""],
@@ -55,7 +55,7 @@ KPLIB_guerilla_weapons_2 = [
     ["uns_mas36","uns_mas36mag",4,"",""]
 ];
 
-KPLIB_guerilla_weapons_3 = [
+KPLIB_r_weapons_3 = [
     ["uns_akm_drum","uns_75Rnd_akdr",4,"",""],
     ["uns_sa58p","uns_sa58mag",4,"",""],
     ["uns_PK","uns_100Rnd_762x54_PK",1,"",""],
@@ -68,7 +68,7 @@ KPLIB_guerilla_weapons_3 = [
 ];
 
 // Uniforms
-KPLIB_guerilla_uniforms_1 = [
+KPLIB_r_uniforms_1 = [
     "U_C_Man_casual_4_F",
     "U_C_Man_casual_5_F",
     "U_C_Man_casual_6_F",
@@ -81,7 +81,7 @@ KPLIB_guerilla_uniforms_1 = [
     "UNS_VC_U"
 ];
 
-KPLIB_guerilla_uniforms_2 = [
+KPLIB_r_uniforms_2 = [
     "U_BG_Guerilla2_1",
     "U_BG_Guerilla2_3",
     "U_BG_Guerilla3_1",
@@ -94,7 +94,7 @@ KPLIB_guerilla_uniforms_2 = [
     "U_I_C_Soldier_Para_5_F"
 ];
 
-KPLIB_guerilla_uniforms_3 = [
+KPLIB_r_uniforms_3 = [
     "U_BG_Guerilla1_1",
     "U_BG_Guerilla1_2_F",
     "U_BG_leader",
@@ -108,7 +108,7 @@ KPLIB_guerilla_uniforms_3 = [
 ];
 
 // Vests
-KPLIB_guerilla_vests_1 = [
+KPLIB_r_vests_1 = [
     "UNS_VC_B1",
     "UNS_VC_S2",
     "V_BandollierB_blk",
@@ -125,7 +125,7 @@ KPLIB_guerilla_vests_1 = [
     "V_Pocketed_olive_F"
 ];
 
-KPLIB_guerilla_vests_2 = [
+KPLIB_r_vests_2 = [
     "UNS_ANZAC_VEST_C",
     "UNS_ANZAC_VEST",
     "UNS_M1956_M14",
@@ -145,7 +145,7 @@ KPLIB_guerilla_vests_2 = [
     "V_HarnessOGL_gry"
 ];
 
-KPLIB_guerilla_vests_3 = [
+KPLIB_r_vests_3 = [
     "UNS_M1956_M1",
     "UNS_M1956_M2",
     "UNS_M1956_M3",
@@ -163,7 +163,7 @@ KPLIB_guerilla_vests_3 = [
 ];
 
 // Headgear
-KPLIB_guerilla_headgear_1 = [
+KPLIB_r_headgear_1 = [
     "",
     "",
     "",
@@ -173,7 +173,7 @@ KPLIB_guerilla_headgear_1 = [
     "UNS_Conehat_VC"
 ];
 
-KPLIB_guerilla_headgear_2 = [
+KPLIB_r_headgear_2 = [
     "H_Bandanna_khk",
     "UNS_Boonie_VC",
     "UNS_Headband_BK",
@@ -188,7 +188,7 @@ KPLIB_guerilla_headgear_2 = [
     "uns_vc_headband_blue"
 ];
 
-KPLIB_guerilla_headgear_3 = [
+KPLIB_r_headgear_3 = [
     "UNS_Boonie_6",
     "UNS_Boonie_ERDL",
     "UNS_Boonie_ERDL3",
@@ -206,7 +206,7 @@ KPLIB_guerilla_headgear_3 = [
 ];
 
 // Facegear. Applies for tier 2 and 3.
-KPLIB_guerilla_facegear = [
+KPLIB_r_facegear = [
     "",
     "",
     "",

--- a/Missionframework/scripts/client/actions/do_recycle.sqf
+++ b/Missionframework/scripts/client/actions/do_recycle.sqf
@@ -12,7 +12,7 @@ private _ammoMulti = 0.5;
 private _fuelMulti = 0.5;
 
 if !(
-    ((toLower _type) in KPLIB_b_buildings_classes) ||
+    ((toLower _type) in KPLIB_b_deco_classes) ||
     ((toLower _type) in KPLIB_storageBuildings) ||
     ((toLower _type) in KPLIB_upgradeBuildings) ||
     (_type in KPLIB_ace_crates) ||
@@ -61,7 +61,7 @@ if ((toLower _type) in KPLIB_o_allVeh_classes) then {
         _price_f = round (150 * _fuelMulti);
     };
 } else {
-    private _objectinfo = ((light_vehicles + heavy_vehicles + air_vehicles + static_vehicles + support_vehicles + buildings) select {_type == (_x select 0)}) select 0;
+    private _objectinfo = ((KPLIB_b_vehLight + KPLIB_b_vehHeavy + KPLIB_b_vehAir + KPLIB_b_vehStatic + KPLIB_b_vehSupport + KPLIB_b_objectsDeco) select {_type == (_x select 0)}) select 0;
     _price_s = round ((_objectinfo select 1) * KPLIB_recycling_percentage * _suppMulti);
     _price_a = round ((_objectinfo select 2) * KPLIB_recycling_percentage * _ammoMulti);
     _price_f = round ((_objectinfo select 3) * KPLIB_recycling_percentage * _fuelMulti);
@@ -80,17 +80,17 @@ waitUntil {sleep 0.1; !dialog || !alive player || dorecycle != 0};
 if (dialog) then {closeDialog 0};
 
 if (dorecycle == 1 && !(isnull _vehToRecycle) && alive _vehToRecycle) then {
-    if (!(KPLIB_recycle_building_near) && ((_price_s + _price_a + _price_f) > 0)) exitWith {hint localize "STR_NORECBUILDING_ERROR";};
+    if (!(KPLIB_b_logiStation_near) && ((_price_s + _price_a + _price_f) > 0)) exitWith {hint localize "STR_NORECBUILDING_ERROR";};
 
     private _storage_areas = (([] call KPLIB_fnc_getNearestFob) nearobjects (KPLIB_fob_range * 1.2)) select {(_x getVariable ["KPLIB_storage_type",-1]) == 0};
     private _crateSum = (ceil (_price_s / 100)) + (ceil (_price_a / 100)) + (ceil (_price_f / 100));
     private _spaceSum = 0;
 
     {
-        if (typeOf _x == KPLIB_large_storage_building) then {
+        if (typeOf _x == KPLIB_b_largeStorage) then {
             _spaceSum = _spaceSum + (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
         };
-        if (typeOf _x == KPLIB_small_storage_building) then {
+        if (typeOf _x == KPLIB_b_smallStorage) then {
             _spaceSum = _spaceSum + (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
         };
     } forEach _storage_areas;

--- a/Missionframework/scripts/client/actions/do_repackage_fob.sqf
+++ b/Missionframework/scripts/client/actions/do_repackage_fob.sqf
@@ -17,7 +17,7 @@ if (dorepackage > 0) then {
         publicVariable "KPLIB_clearances";
     };
 
-    {deleteVehicle _x} forEach (((getPos player) nearobjects [FOB_typename, 250]) select {getObjectType _x >= 8});
+    {deleteVehicle _x} forEach (((getPos player) nearobjects [KPLIB_b_fobBuilding, 250]) select {getObjectType _x >= 8});
 
     sleep 0.5;
 
@@ -28,12 +28,12 @@ if (dorepackage > 0) then {
     };
 
     if (dorepackage == 1) then {
-        private _fobbox = FOB_box_typename createVehicle _spawnpos;
+        private _fobbox = KPLIB_b_fobBox createVehicle _spawnpos;
         [_fobbox] call KPLIB_fnc_addObjectInit;
     };
 
     if (dorepackage == 2) then {
-        private _fobTruck = FOB_truck_typename createVehicle _spawnpos;
+        private _fobTruck = KPLIB_b_fobTruck createVehicle _spawnpos;
         [_fobTruck] call KPLIB_fnc_addObjectInit;
     };
     hint localize "STR_FOB_REPACKAGE_HINT";

--- a/Missionframework/scripts/client/actions/recycle_manager.sqf
+++ b/Missionframework/scripts/client/actions/recycle_manager.sqf
@@ -20,7 +20,7 @@ while {true} do {
     if ([4] call KPLIB_fnc_hasPermission) then {
         private _detected_vehicles = (getPos player) nearObjects veh_action_detect_distance select {
             (((toLower (typeof _x)) in _recycleable_classnames && (({alive _x} count (crew _x)) == 0 || unitIsUAV _x) && (locked _x == 0 || locked _x == 1)) ||
-            (toLower (typeOf _x)) in KPLIB_b_buildings_classes ||
+            (toLower (typeOf _x)) in KPLIB_b_deco_classes ||
             (((toLower (typeOf _x)) in KPLIB_storageBuildings) && ((_x getVariable ["KPLIB_storage_type",-1]) == 0)) ||
             (toLower (typeOf _x)) in KPLIB_upgradeBuildings ||
             (typeOf _x) in KPLIB_ace_crates) &&

--- a/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
+++ b/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
@@ -85,11 +85,11 @@ while {true} do {
             _area_load = count (attachedObjects _x);
 
             if (!(_next_area in _managed_areas) && (_area_load > 0)) then {
-                    _action_id = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_UNSTORE_SUPPLY" + "</t>",{[KPLIB_supply_crate, (_this select 0), true] call KPLIB_fnc_crateFromStorage;},"",-504,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
+                    _action_id = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_UNSTORE_SUPPLY" + "</t>",{[KPLIB_b_crateSupply, (_this select 0), true] call KPLIB_fnc_crateFromStorage;},"",-504,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
                     _next_area setVariable ["KP_supply_unstore_action", _action_id, false];
-                    _action_id2 = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_UNSTORE_AMMO" + "</t>",{[KPLIB_ammo_crate, (_this select 0), true] call KPLIB_fnc_crateFromStorage;},"",-505,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
+                    _action_id2 = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_UNSTORE_AMMO" + "</t>",{[KPLIB_b_crateAmmo, (_this select 0), true] call KPLIB_fnc_crateFromStorage;},"",-505,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
                     _next_area setVariable ["KP_ammo_unstore_action", _action_id2, false];
-                    _action_id3 = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_UNSTORE_FUEL" + "</t>",{[KPLIB_fuel_crate, (_this select 0), true] call KPLIB_fnc_crateFromStorage;},"",-506,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
+                    _action_id3 = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_UNSTORE_FUEL" + "</t>",{[KPLIB_b_crateFuel, (_this select 0), true] call KPLIB_fnc_crateFromStorage;},"",-506,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
                     _next_area setVariable ["KP_fuel_unstore_action", _action_id3, false];
                     _action_id4 = _next_area addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_SORT_STORAGE" + "</t>",{[(_this select 0)] call KPLIB_fnc_sortStorage;},"",-507,true,true,"","build_confirmed == 0 && (_this distance _target < 12) && (vehicle player == player)"];
                     _next_area setVariable ["KP_storage_sort_action", _action_id4, false];

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -32,7 +32,7 @@ while { true } do {
     build_invalid = 0;
     _classname = "";
     if ( buildtype == 99 ) then {
-        _classname = FOB_typename;
+        _classname = KPLIB_b_fobBuilding;
     } else {
         _classname = ((KPLIB_buildList select buildtype) select buildindex) select 0;
         _price_s = ((KPLIB_buildList select buildtype) select buildindex) select 1;
@@ -57,13 +57,13 @@ while { true } do {
         if ( buildtype == 8 ) then {
             _pos = [(getpos player select 0) + 1,(getpos player select 1) + 1, 0];
             _grp = createGroup KPLIB_side_friendly;
-            _grp setGroupId [format ["%1 %2",squads_names select buildindex, groupId _grp]];
+            _grp setGroupId [format ["%1 %2",KPLIB_b_squadNames select buildindex, groupId _grp]];
             _idx = 0;
             {
                 _unitrank = "private";
                 if(_idx == 0) then { _unitrank = "sergeant"; };
                 if(_idx == 1) then { _unitrank = "corporal"; };
-                if (_classname isEqualTo blufor_squad_para) then {
+                if (_classname isEqualTo KPLIB_b_squadPara) then {
                     _x createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}]; removeBackpackGlobal this; this addBackpackGlobal ""B_parachute""", 0.5, _unitrank];
                 } else {
                     _x createUnit [_pos, _grp,"this addMPEventHandler [""MPKilled"", {_this spawn kill_manager}];", 0.5, _unitrank];
@@ -89,7 +89,7 @@ while { true } do {
             if (buildtype == 6 ) then {
                 _idactplacebis = player addAction ["<t color='#B0FF00'>" + localize "STR_PLACEMENT_BIS" + "</t> <img size='2' image='res\ui_confirm.paa'/>",{build_confirmed = 2; repeatbuild = true; hint localize "STR_CONFIRM_HINT";},"",-785,false,false,"","build_invalid == 0 && build_confirmed == 1"];
             };
-            if (buildtype == 6 || buildtype == 99  || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KPLIB_recycle_building || _classname isEqualTo KPLIB_air_vehicle_building) then {
+            if (buildtype == 6 || buildtype == 99  || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KPLIB_b_logiStation || _classname isEqualTo KPLIB_b_airControl) then {
                 _idactsnap = player addAction ["<t color='#B0FF00'>" + localize "STR_GRID" + "</t>",{gridmode = gridmode + 1;},"",-735,false,false,"","build_confirmed == 1"];
                 _idactvector = player addAction ["<t color='#B0FF00'>" + localize "STR_VECACTION" + "</t>",{KP_vector = !KP_vector;},"",-800,false,false,"","build_confirmed == 1"];
             };
@@ -126,7 +126,7 @@ while { true } do {
                 };
                 _actualdir = ((getdir player) + build_rotation);
                 if ( _classname == "Land_Cargo_Patrol_V1_F" || _classname == "Land_PortableLight_single_F" ) then { _actualdir = _actualdir + 180 };
-                if ( _classname == FOB_typename ) then { _actualdir = _actualdir + 270 };
+                if ( _classname == KPLIB_b_fobBuilding ) then { _actualdir = _actualdir + 270 };
 
                 while { _actualdir > 360 } do { _actualdir = _actualdir - 360 };
                 while { _actualdir < 0 } do { _actualdir = _actualdir + 360 };
@@ -156,12 +156,12 @@ while { true } do {
                 _truepos = [_truepos select 0, _truepos select 1, (_truepos select 2) +  build_elevation];
 
                 _near_objects = (_truepos nearobjects ["AllVehicles", _dist]) ;
-                _near_objects = _near_objects + (_truepos nearobjects [FOB_box_typename, _dist]);
-                _near_objects = _near_objects + (_truepos nearobjects [Arsenal_typename, _dist]);
+                _near_objects = _near_objects + (_truepos nearobjects [KPLIB_b_fobBox, _dist]);
+                _near_objects = _near_objects + (_truepos nearobjects [KPLIB_b_arsenal, _dist]);
 
                 _near_objects_25 = (_truepos nearobjects ["AllVehicles", 50]) ;
-                _near_objects_25 = _near_objects_25 + (_truepos nearobjects [FOB_box_typename, 50]);
-                _near_objects_25 = _near_objects_25 + (_truepos nearobjects [Arsenal_typename, 50]);
+                _near_objects_25 = _near_objects_25 + (_truepos nearobjects [KPLIB_b_fobBox, 50]);
+                _near_objects_25 = _near_objects_25 + (_truepos nearobjects [KPLIB_b_arsenal, 50]);
 
                 if(	buildtype != 6 ) then {
                     _near_objects = _near_objects + (_truepos nearobjects ["Static", _dist]);
@@ -171,7 +171,7 @@ while { true } do {
                 private _remove_objects = [];
                 {
                     private _typeOfX = typeOf _x;
-                    if ((_x isKindOf "Animal") || (_typeOfX in KPLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((toLower (typeOf _vehicle)) in KPLIB_b_static_classes)) then {
+                    if ((_x isKindOf "Animal") || (_typeOfX in KPLIB_b_collisionIgnoreObjects) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((toLower (typeOf _vehicle)) in KPLIB_b_static_classes)) then {
                         _remove_objects pushback _x;
                     };
                 } foreach _near_objects;
@@ -179,7 +179,7 @@ while { true } do {
                 private _remove_objects_25 = [];
                 {
                     private _typeOfX = typeOf _x;
-                    if ((_x isKindOf "Animal") || (_typeOfX in KPLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((toLower (typeOf _vehicle)) in KPLIB_b_static_classes)) then {
+                    if ((_x isKindOf "Animal") || (_typeOfX in KPLIB_b_collisionIgnoreObjects) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((toLower (typeOf _vehicle)) in KPLIB_b_static_classes)) then {
                         _remove_objects_25 pushback _x;
                     };
                 } foreach _near_objects_25;
@@ -214,7 +214,7 @@ while { true } do {
                             _vehicle setpos _truepos;
                         };
                     };
-                    if (buildtype == 6 || buildtype == 99 || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KPLIB_recycle_building || _classname isEqualTo KPLIB_air_vehicle_building) then {
+                    if (buildtype == 6 || buildtype == 99 || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KPLIB_b_logiStation || _classname isEqualTo KPLIB_b_airControl) then {
                         if (KP_vector) then {
                             _vehicle setVectorUp [0,0,1];
                         } else {
@@ -278,10 +278,10 @@ while { true } do {
                 _spaceSum = 0;
 
                 {
-                    if (typeOf _x == KPLIB_large_storage_building) then {
+                    if (typeOf _x == KPLIB_b_largeStorage) then {
                         _spaceSum = _spaceSum + (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
                     };
-                    if (typeOf _x == KPLIB_small_storage_building) then {
+                    if (typeOf _x == KPLIB_b_smallStorage) then {
                         _spaceSum = _spaceSum + (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
                     };
                 } forEach _storage_areas;
@@ -313,7 +313,7 @@ while { true } do {
 
                 [_vehicle] call KPLIB_fnc_clearCargo;
 
-                if (buildtype == 6 || buildtype == 99 || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KPLIB_recycle_building || _classname isEqualTo KPLIB_air_vehicle_building) then {
+                if (buildtype == 6 || buildtype == 99 || (toLower _classname) in KPLIB_storageBuildings || _classname isEqualTo KPLIB_b_logiStation || _classname isEqualTo KPLIB_b_airControl) then {
                     if (KP_vector) then {
                         _vehicle setVectorUp [0,0,1];
                     } else {

--- a/Missionframework/scripts/client/build/do_sector_build.sqf
+++ b/Missionframework/scripts/client/build/do_sector_build.sqf
@@ -1,6 +1,6 @@
 private ["_vector", "_idactcancel", "_idactplace", "_idactvector", "_ghost_spot", "_truedir", "_dist", "_truepos", "_sectorpos", "_building"];
 
-if (((_this select 3) select 0) == KPLIB_small_storage_building) then {
+if (((_this select 3) select 0) == KPLIB_b_smallStorage) then {
 
     _truepos = [];
 

--- a/Missionframework/scripts/client/build/open_build_menu.sqf
+++ b/Missionframework/scripts/client/build/open_build_menu.sqf
@@ -52,17 +52,17 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
                 _entrytext = getText (_cfg >> _classnamevar >> "displayName");
 
                 switch (_classnamevar) do {
-                    case FOB_box_typename: {_entrytext = localize "STR_FOBBOX";};
-                    case Arsenal_typename: {if (KPLIB_mobilearsenal) then {_entrytext = localize "STR_ARSENAL_BOX";};};
-                    case Respawn_truck_typename: {if (KPLIB_mobilerespawn) then {_entrytext = localize "STR_RESPAWN_TRUCK";};};
-                    case FOB_truck_typename: {_entrytext = localize "STR_FOBTRUCK";};
+                    case KPLIB_b_fobBox: {_entrytext = localize "STR_FOBBOX";};
+                    case KPLIB_b_arsenal: {if (KPLIB_mobilearsenal) then {_entrytext = localize "STR_ARSENAL_BOX";};};
+                    case KPLIB_b_mobileRespawn: {if (KPLIB_mobilerespawn) then {_entrytext = localize "STR_RESPAWN_TRUCK";};};
+                    case KPLIB_b_fobTruck: {_entrytext = localize "STR_FOBTRUCK";};
                     case "Flag_White_F": {_entrytext = localize "STR_INDIV_FLAG";};
-                    case KPLIB_small_storage_building: {_entrytext = localize "STR_SMALL_STORAGE";};
-                    case KPLIB_large_storage_building: {_entrytext = localize "STR_LARGE_STORAGE";};
-                    case KPLIB_recycle_building: {_entrytext = localize "STR_RECYCLE_BUILDING";};
-                    case KPLIB_air_vehicle_building: {_entrytext = localize "STR_HELI_BUILDING";};
-                    case KPLIB_heli_slot_building: {_entrytext = localize "STR_HELI_SLOT";};
-                    case KPLIB_plane_slot_building: {_entrytext = localize "STR_PLANE_SLOT";};
+                    case KPLIB_b_smallStorage: {_entrytext = localize "STR_SMALL_STORAGE";};
+                    case KPLIB_b_largeStorage: {_entrytext = localize "STR_LARGE_STORAGE";};
+                    case KPLIB_b_logiStation: {_entrytext = localize "STR_RECYCLE_BUILDING";};
+                    case KPLIB_b_airControl: {_entrytext = localize "STR_HELI_BUILDING";};
+                    case KPLIB_b_slotHeli: {_entrytext = localize "STR_HELI_SLOT";};
+                    case KPLIB_b_slotPlane: {_entrytext = localize "STR_PLANE_SLOT";};
                     default {};
                 };
 
@@ -74,8 +74,8 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
                 };
                 lnbSetPicture  [110, [((lnbSize 110) select 0) - 1, 0],_icon];
             } else {
-                if ( ((lnbSize  110) select 0) <= count squads_names ) then {
-                    _squadname = squads_names select ((lnbSize  110) select 0);
+                if ( ((lnbSize  110) select 0) <= count KPLIB_b_squadNames ) then {
+                    _squadname = KPLIB_b_squadNames select ((lnbSize  110) select 0);
                 } else {
                     _squadname = "";
                 };
@@ -128,14 +128,14 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
             ((_build_item select 3 == 0 ) || ((_build_item select 3) <= ((_actual_fob select 0) select 3)))
         ) then {
             if ((toLower (_build_item select 0)) in KPLIB_b_air_classes && !([_build_item select 0] call KPLIB_fnc_isClassUAV)) then {
-                if (KPLIB_air_vehicle_building_near &&
+                if (KPLIB_b_airControl_near &&
                     ((((_build_item select 0) isKindOf "Helicopter") && (KPLIB_heli_count < KPLIB_heli_slots)) ||
                     (((_build_item select 0) isKindOf "Plane") && (KPLIB_plane_count < KPLIB_plane_slots)))
                 ) then {
                     _affordable = true;
                 };
             } else {
-                if (!((toLower (_build_item select 0)) in KPLIB_airSlots) || (((toLower (_build_item select 0)) in KPLIB_airSlots) && KPLIB_air_vehicle_building_near)) then {
+                if (!((toLower (_build_item select 0)) in KPLIB_airSlots) || (((toLower (_build_item select 0)) in KPLIB_airSlots) && KPLIB_b_airControl_near)) then {
                     _affordable = true;
                 };
             };

--- a/Missionframework/scripts/client/commander/open_logistic.sqf
+++ b/Missionframework/scripts/client/commander/open_logistic.sqf
@@ -13,7 +13,7 @@ _nearfob = [] call KPLIB_fnc_getNearestFob;
 _logi_destinations = [];
 
 {
-    _logi_destinations pushBack [(format ["FOB %1", military_alphabet select _forEachIndex]), (_x select 0), (_x select 1), (_x select 2), (_x select 3)];
+    _logi_destinations pushBack [(format ["FOB %1", KPLIB_militaryAlphabet select _forEachIndex]), (_x select 0), (_x select 1), (_x select 2), (_x select 3)];
 } forEach KPLIB_fob_resources;
 
 {

--- a/Missionframework/scripts/client/commander/open_production.sqf
+++ b/Missionframework/scripts/client/commander/open_production.sqf
@@ -64,7 +64,7 @@ while {dialog && (alive player)} do {
     ctrlSetText [75804, _sectorType];
 
     if ((count (_selectedSector select 3)) > 0) then {
-        _storage = ((nearestObjects [((_selectedSector select 3) select 0), [KPLIB_small_storage_building], 25]) select 0);
+        _storage = ((nearestObjects [((_selectedSector select 3) select 0), [KPLIB_b_smallStorage], 25]) select 0);
         _crateCount = count (attachedObjects _storage);
         _crateMax = count (KPLIB_small_storage_positions);
 

--- a/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
+++ b/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
@@ -6,8 +6,8 @@ _cfg = configFile >> "cfgVehicles";
 _vehtomark = [];
 
 _support_to_skip = [
-    KPLIB_recycle_building,
-    KPLIB_air_vehicle_building,
+    KPLIB_b_logiStation,
+    KPLIB_b_airControl,
     "B_Slingload_01_Repair_F",
     "B_Slingload_01_Fuel_F",
     "B_Slingload_01_Ammo_F"

--- a/Missionframework/scripts/client/markers/fob_markers.sqf
+++ b/Missionframework/scripts/client/markers/fob_markers.sqf
@@ -17,7 +17,7 @@ while {true} do {
             _marker setMarkerTypeLocal "b_hq";
             _marker setMarkerSizeLocal [1.5, 1.5];
             _marker setMarkerPosLocal (KPLIB_sectors_fob select _idx);
-            _marker setMarkerTextLocal format ["FOB %1",military_alphabet select _idx];
+            _marker setMarkerTextLocal format ["FOB %1",KPLIB_militaryAlphabet select _idx];
             _marker setMarkerColorLocal "ColorYellow";
             _markers pushback _marker;
         };

--- a/Missionframework/scripts/client/misc/playerNamespace.sqf
+++ b/Missionframework/scripts/client/misc/playerNamespace.sqf
@@ -2,7 +2,7 @@
     File: playerNamespace.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-12
-    Last Update: 2020-05-17
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -44,12 +44,12 @@ while {true} do {
 
     // Is near an arsenal object
     if (KPLIB_mobilearsenal) then {
-        player setVariable ["KPLIB_isNearArsenal", !(((player nearObjects [Arsenal_typename, 5]) select {getObjectType _x >= 8}) isEqualTo [])];
+        player setVariable ["KPLIB_isNearArsenal", !(((player nearObjects [KPLIB_b_arsenal, 5]) select {getObjectType _x >= 8}) isEqualTo [])];
     };
 
     // Is near a mobile respawn
     if (KPLIB_mobilerespawn) then {
-        player setVariable ["KPLIB_isNearMobRespawn", !((player nearEntities [[Respawn_truck_typename, huron_typename], 10]) isEqualTo [])];
+        player setVariable ["KPLIB_isNearMobRespawn", !((player nearEntities [[KPLIB_b_mobileRespawn, KPLIB_b_potato01], 10]) isEqualTo [])];
     };
 
     // Is near startbase

--- a/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
+++ b/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
@@ -17,7 +17,7 @@ _unit enableAI "MOVE";
 sleep 2;
 [_unit, ""] remoteExecCall ["switchMove"];
 
-if ( typeof _unit == pilot_classname ) exitWith {};
+if ( typeof _unit == KPLIB_b_heliPilotUnit ) exitWith {};
 
 waitUntil { sleep 5;
 

--- a/Missionframework/scripts/client/spawn/redeploy_manager.sqf
+++ b/Missionframework/scripts/client/spawn/redeploy_manager.sqf
@@ -83,7 +83,7 @@ while {true} do {
         choiceslist = [[_basenamestr, getposATL startbase]];
 
         for [{_idx=0},{_idx < count KPLIB_sectors_fob},{_idx=_idx+1}] do {
-            choiceslist = choiceslist + [[format ["FOB %1 - %2", (military_alphabet select _idx),mapGridPosition (KPLIB_sectors_fob select _idx)],KPLIB_sectors_fob select _idx]];
+            choiceslist = choiceslist + [[format ["FOB %1 - %2", (KPLIB_militaryAlphabet select _idx),mapGridPosition (KPLIB_sectors_fob select _idx)],KPLIB_sectors_fob select _idx]];
         };
 
         if (KPLIB_mobilerespawn) then {

--- a/Missionframework/scripts/client/tutorial/fn_tutorial.fsm
+++ b/Missionframework/scripts/client/tutorial/fn_tutorial.fsm
@@ -519,7 +519,7 @@ class FSM
                          "    allPlayers," \n
                          "    [""KPLIB_Tasks_Tutorial_Fob_01a"", ""KPLIB_Tasks_Tutorial_Fob""]," \n
                          "    """"," \n
-                         "    [(base_boxspawn nearObjects [FOB_box_typename, 10]) select 0, true]," \n
+                         "    [(base_boxspawn nearObjects [KPLIB_b_fobBox, 10]) select 0, true]," \n
                          "    ""ASSIGNED""," \n
                          "    0," \n
                          "    true," \n
@@ -553,7 +553,7 @@ class FSM
                          "    allPlayers," \n
                          "    [""KPLIB_Tasks_Tutorial_Fob_01b"", ""KPLIB_Tasks_Tutorial_Fob""]," \n
                          "    """"," \n
-                         "    [(base_boxspawn nearObjects [FOB_box_typename, 10]) select 0, true]," \n
+                         "    [(base_boxspawn nearObjects [KPLIB_b_fobBox, 10]) select 0, true]," \n
                          "    ""ASSIGNED""," \n
                          "    0," \n
                          "    true," \n

--- a/Missionframework/scripts/client/ui/cinematic_camera.sqf
+++ b/Missionframework/scripts/client/ui/cinematic_camera.sqf
@@ -258,7 +258,7 @@ while { cinematic_camera_started } do {
                     } else {
                         _nearfobs = KPLIB_sectors_fob select {_x distance _position < 300};
                         if ( count _nearfobs > 0 ) then {
-                            _nearest_sector = format [ "FOB %1", military_alphabet select ( KPLIB_sectors_fob find ( _nearfobs select 0 ) ) ];
+                            _nearest_sector = format [ "FOB %1", KPLIB_militaryAlphabet select ( KPLIB_sectors_fob find ( _nearfobs select 0 ) ) ];
                         };
                     };
                 };

--- a/Missionframework/scripts/client/ui/end_screen.sqf
+++ b/Missionframework/scripts/client/ui/end_screen.sqf
@@ -34,7 +34,7 @@ params [
     "_stats_secondary_objectives",
     "_stats_sectors_liberated",
     "_stats_sectors_lost",
-    "_stats_spartan_respawns",
+    "_stats_potato_respawns",
     "_stats_supplies_produced",
     "_stats_supplies_spent",
     "_stats_vehicles_recycled",
@@ -141,7 +141,7 @@ if (dialog) then {sleep 3};
 [692, format [localize "STR_STATS_REINFORCEMENTS", _stats_reinforcements_called]] call _addReportLine;
 [693, format [localize "STR_STATS_COMBATREADINESS", round _stats_readiness_earned]] call _addReportLine;
 [694, format [localize "STR_STATS_IEDS", _stats_ieds_detonated]] call _addReportLine;
-[695, format [localize "STR_STATS_POTATO", _stats_spartan_respawns]] call _addReportLine;
+[695, format [localize "STR_STATS_POTATO", _stats_potato_respawns]] call _addReportLine;
 [696, format [localize "STR_STATS_RABBITS", _stats_rabbits_killed], true] call _addReportLine;
 [] call _cleanPage;
 

--- a/Missionframework/scripts/client/ui/ui_manager.sqf
+++ b/Missionframework/scripts/client/ui/ui_manager.sqf
@@ -14,8 +14,8 @@ KPLIB_ui_notif = "";
 KPLIB_supplies = 0;
 KPLIB_ammo = 0;
 KPLIB_fuel = 0;
-KPLIB_air_vehicle_building_near = false;
-KPLIB_recycle_building_near = false;
+KPLIB_b_airControl_near = false;
+KPLIB_b_logiStation_near = false;
 
 waitUntil { !isNil "synchro_done" };
 waitUntil { synchro_done };
@@ -74,15 +74,15 @@ while {true} do {
             KPLIB_fuel = _fuel;
         };
         // TODO this is used by build scripts, move to relevant places
-        KPLIB_air_vehicle_building_near = _hasAir;
-        KPLIB_recycle_building_near = _hasRecycling;
+        KPLIB_b_airControl_near = _hasAir;
+        KPLIB_b_logiStation_near = _hasRecycling;
     } else {
         _showResources = false;
         KPLIB_supplies = 0;
         KPLIB_ammo = 0;
         KPLIB_fuel = 0;
-        KPLIB_air_vehicle_building_near = false;
-        KPLIB_recycle_building_near = false;
+        KPLIB_b_airControl_near = false;
+        KPLIB_b_logiStation_near = false;
     };
 
     if (_overlayVisible) then {

--- a/Missionframework/scripts/server/ai/prisonner_ai.sqf
+++ b/Missionframework/scripts/server/ai/prisonner_ai.sqf
@@ -11,7 +11,7 @@ if ((_unit isKindOf "Man") && (alive _unit) && (side group _unit == KPLIB_side_e
     if (alive _unit) then {
 
         removeAllWeapons _unit;
-        if (typeof _unit != pilot_classname) then {
+        if (typeof _unit != KPLIB_b_heliPilotUnit) then {
             removeHeadgear _unit;
         };
         removeBackpack _unit;

--- a/Missionframework/scripts/server/asymmetric/convoy/logistic_convoy_ambush.sqf
+++ b/Missionframework/scripts/server/asymmetric/convoy/logistic_convoy_ambush.sqf
@@ -24,7 +24,7 @@ KPLIB_convoy_ambush_inProgress = true;
 
 private _vehicleArray = [];
 for "_i" from 1 to (_convoy select 1) do {
-    private _veh = createVehicle [KPLIB_truck_classname, getPos _roadObj, [], 50, "NONE"];
+    private _veh = createVehicle [KPLIB_b_logiTruck, getPos _roadObj, [], 50, "NONE"];
     _veh setDir (getDir _roadObj);
     {
         private _damage = random 0.6;
@@ -38,7 +38,7 @@ for "_i" from 1 to (_convoy select 1) do {
     } forEach ((getAllHitPointsDamage _veh) select 0);
     _vehicleArray pushBack _veh;
 
-    private _driver = createVehicle [crewman_classname, getPos _veh, [], 12, "NONE"];
+    private _driver = createVehicle [KPLIB_b_crewUnit, getPos _veh, [], 12, "NONE"];
     _driver setDamage 1;
 };
 if (KPLIB_asymmetric_debug > 0) then {[format ["Logistic convoy %1 ambush: truck spawning done", (_convoy select 0)], "ASYMMETRIC"] call KPLIB_fnc_log;};
@@ -54,7 +54,7 @@ while {_supplies > 0} do {
         _amount = _supplies;
     };
     _supplies = _supplies - _amount;
-    private _crate = [KPLIB_supply_crate, _amount, getPos _roadObj] call KPLIB_fnc_createCrate;
+    private _crate = [KPLIB_b_crateSupply, _amount, getPos _roadObj] call KPLIB_fnc_createCrate;
     _crate setPos (_crate getPos [random 60, random 360]);
     _crateArray pushBack [_crate];
 };
@@ -65,7 +65,7 @@ while {_ammo > 0} do {
         _amount = _ammo;
     };
     _ammo = _ammo - _amount;
-    private _crate = [KPLIB_ammo_crate, _amount, getPos _roadObj] call KPLIB_fnc_createCrate;
+    private _crate = [KPLIB_b_crateAmmo, _amount, getPos _roadObj] call KPLIB_fnc_createCrate;
     _crate setPos (_crate getPos [random 60, random 360]);
     _crateArray pushBack [_crate];
 };
@@ -76,7 +76,7 @@ while {_fuel > 0} do {
         _amount = _fuel;
     };
     _fuel = _fuel - _amount;
-    private _crate = [KPLIB_fuel_crate, _amount, getPos _roadObj] call KPLIB_fnc_createCrate;
+    private _crate = [KPLIB_b_crateFuel, _amount, getPos _roadObj] call KPLIB_fnc_createCrate;
     _crate setPos (_crate getPos [random 60, random 360]);
     _crateArray pushBack [_crate];
 };
@@ -125,7 +125,7 @@ if ((_waitingTime <= 0) && (({alive _x} count (units _grp)) > 0)) then {
         };
     } forEach (units _grp);
     {
-        if ((typeOf (_x select 0)) == KPLIB_ammo_crate) then {
+        if ((typeOf (_x select 0)) == KPLIB_b_crateAmmo) then {
             _gain = _gain + 3;
         } else {
             _gain = _gain + 2;

--- a/Missionframework/scripts/server/asymmetric/random/sector_guerilla.sqf
+++ b/Missionframework/scripts/server/asymmetric/random/sector_guerilla.sqf
@@ -76,8 +76,8 @@ _spawnedGroups pushBack _grp;
 
 sleep 30;
 
-if (((random 100) <= 25) && !(KPLIB_guerilla_vehicles isEqualTo [])) then {
-    private _vehicle = (selectRandom KPLIB_guerilla_vehicles) createVehicle _startpos;
+if (((random 100) <= 25) && !(KPLIB_r_vehicles isEqualTo [])) then {
+    private _vehicle = (selectRandom KPLIB_r_vehicles) createVehicle _startpos;
     [_vehicle] call KPLIB_fnc_allowCrewInImmobile;
 
     private _grp = [_startpos, 2] call KPLIB_fnc_spawnGuerillaGroup;

--- a/Missionframework/scripts/server/base/huron_manager.sqf
+++ b/Missionframework/scripts/server/base/huron_manager.sqf
@@ -1,40 +1,40 @@
 waitUntil {!isNil "save_is_loaded"};
 waitUntil {save_is_loaded};
 
-huron = objNull;
+KPLIB_potato01 = objNull;
 
-// Detect possible huron from loaded save data
-private _savedHuron = vehicles select {(toLower (typeOf _x)) isEqualTo (toLower huron_typename)};
-if !(_savedHuron isEqualTo []) then {
-    huron = _savedHuron select 0;
+// Detect possible Potato 01 from loaded save data
+private _savedPotato = vehicles select {(toLower (typeOf _x)) isEqualTo (toLower KPLIB_b_potato01)};
+if !(_savedPotato isEqualTo []) then {
+    KPLIB_potato01 = _savedPotato select 0;
 };
 
 while {true} do {
     // Spawn new huron if not loaded or destroyed
     if !(alive huron) then {
-        huron = huron_typename createVehicle [(getposATL huronspawn) select 0, (getposATL huronspawn) select 1, ((getposATL huronspawn) select 2) + 0.2];
-        huron enableSimulationGlobal false;
-        huron allowdamage false;
-        huron setDir (getDir huronspawn);
-        huron setPosATL (getposATL huronspawn);
-        huron setDamage 0;
+        KPLIB_potato01 = KPLIB_b_potato01 createVehicle [(getposATL huronspawn) select 0, (getposATL huronspawn) select 1, ((getposATL huronspawn) select 2) + 0.2];
+        KPLIB_potato01 enableSimulationGlobal false;
+        KPLIB_potato01 allowdamage false;
+        KPLIB_potato01 setDir (getDir huronspawn);
+        KPLIB_potato01 setPosATL (getposATL huronspawn);
+        KPLIB_potato01 setDamage 0;
         sleep 0.5;
-        huron enableSimulationGlobal true;
-        huron setDamage 0;
-        huron allowdamage true;
-        [huron] call KPLIB_fnc_addObjectInit;
+        KPLIB_potato01 enableSimulationGlobal true;
+        KPLIB_potato01 setDamage 0;
+        KPLIB_potato01 allowdamage true;
+        [KPLIB_potato01] call KPLIB_fnc_addObjectInit;
     };
-    [huron] call KPLIB_fnc_clearCargo;
-    huron setVariable ["ace_medical_isMedicalVehicle", true, true];
-    publicVariable "huron";
+    [KPLIB_potato01] call KPLIB_fnc_clearCargo;
+    KPLIB_potato01 setVariable ["ace_medical_isMedicalVehicle", true, true];
+    publicVariable "KPLIB_potato01";
 
     // Wait until huron is destroyed to respawn it
-    waitUntil {sleep 5; !alive huron};
-    stats_spartan_respawns = stats_spartan_respawns + 1;
+    waitUntil {sleep 5; !alive KPLIB_potato01};
+    stats_potato_respawns = stats_potato_respawns + 1;
     sleep 10;
 
     // Delete wreck, if near startbase
-    if (huron distance startbase < 500) then {
-        deletevehicle huron;
+    if (KPLIB_potato01 distance startbase < 500) then {
+        deletevehicle KPLIB_potato01;
     };
 };

--- a/Missionframework/scripts/server/base/startgame.sqf
+++ b/Missionframework/scripts/server/base/startgame.sqf
@@ -19,7 +19,7 @@ if (KPLIB_sectors_fob isEqualTo []) then {
         // Spawn FOB box and wait until the first FOB was built
         private _fobbox = objNull;
         while {KPLIB_sectors_fob isEqualTo []} do {
-            _fobbox = ([FOB_box_typename, FOB_truck_typename] select KPLIB_fob_vehicle) createVehicle (getposATL base_boxspawn);
+            _fobbox = ([KPLIB_b_fobBox, KPLIB_b_fobTruck] select KPLIB_fob_vehicle) createVehicle (getposATL base_boxspawn);
             _fobbox setdir getDir base_boxspawn;
             _fobbox setposATL (getposATL base_boxspawn);
             [_fobbox, true] call KPLIB_fnc_clearCargo;

--- a/Missionframework/scripts/server/base/startvehicle_spawn.sqf
+++ b/Missionframework/scripts/server/base/startvehicle_spawn.sqf
@@ -12,7 +12,7 @@
 
     E.g. the variables of the grasscutter placeholder objects for the
     little birds are named "littlebird_0", "littlebird_1", etc.
-    while the variable from the preset is KPLIB_little_bird_classname.
+    while the variable from the preset is KPLIB_b_addHeli.
     This leads to the entry below.
 
     You can also remove unwanted start vehicles by deleting the corresponding line
@@ -46,6 +46,6 @@ private _veh = objNull;
         [_veh] call KPLIB_fnc_addObjectInit;
     };
 } forEach [
-    ["littlebird_", KPLIB_little_bird_classname],
-    ["boat_", KPLIB_boat_classname]
+    ["littlebird_", KPLIB_b_addHeli],
+    ["boat_", KPLIB_b_addBoat]
 ];

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -20,7 +20,7 @@ while {true} do {
         private _house = (nearestObjects [[((markerPos _sector select 0) - 100 + (random 200)), ((markerPos _sector select 1) - 100 + (random 200))],["House", "Building"], 100]) select 0;
 
         private _grp = createGroup [KPLIB_side_civilian, true];
-        private _informant = [selectRandom civilians, markerPos _sector, _grp] call KPLIB_fnc_createManagedUnit;
+        private _informant = [selectRandom KPLIB_c_units, markerPos _sector, _grp] call KPLIB_fnc_createManagedUnit;
         private _waiting_time = KPLIB_civinfo_duration;
 
         _informant setPos (selectRandom (_house buildingPos -1));

--- a/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
+++ b/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
@@ -14,7 +14,7 @@ for "_i" from 1 to _count do {
     while {(surfaceIsWater _pos) || ((count ([_pos, 30] call KPLIB_fnc_getNearbyPlayers)) > 0)} do {
         _pos = (markerPos _sector) getPos [(50 + (random 200)), (random 360)];
     };
-    private _civ = [selectRandom civilians, _pos, _grp] call KPLIB_fnc_createManagedUnit;
+    private _civ = [selectRandom KPLIB_c_units, _pos, _grp] call KPLIB_fnc_createManagedUnit;
     _civ setDir (random 360);
     {_civ disableAI _x} forEach ["ANIM", "TARGET", "AUTOTARGET", "MOVE"];
     removeAllItems _civ;

--- a/Missionframework/scripts/server/game/check_victory_conditions.sqf
+++ b/Missionframework/scripts/server/game/check_victory_conditions.sqf
@@ -43,7 +43,7 @@ if ([] call KPLIB_victoryCheck && KPLIB_endgame != 1) then {
     publicstats pushback stats_secondary_objectives;
     publicstats pushback stats_sectors_liberated;
     publicstats pushback stats_sectors_lost;
-    publicstats pushback stats_spartan_respawns;
+    publicstats pushback stats_potato_respawns;
     publicstats pushback stats_supplies_produced;
     publicstats pushback stats_supplies_spent;
     publicstats pushback stats_vehicles_recycled;
@@ -95,7 +95,7 @@ if ([] call KPLIB_victoryCheck && KPLIB_endgame != 1) then {
     [format ["Hostile reinforcements called: %1", stats_reinforcements_called], "MISSION END"] call KPLIB_fnc_log;
     [format ["Total combat readiness raised: %1", round stats_readiness_earned], "MISSION END"] call KPLIB_fnc_log;
     [format ["IEDs detonated: %1", stats_ieds_detonated], "MISSION END"] call KPLIB_fnc_log;
-    [format ["Number of Potato 01 losses: %1", stats_spartan_respawns], "MISSION END"] call KPLIB_fnc_log;
+    [format ["Number of Potato 01 losses: %1", stats_potato_respawns], "MISSION END"] call KPLIB_fnc_log;
     [format ["Rabbits killed: %1", _rabbits], "MISSION END"] call KPLIB_fnc_log;
     ["------------------------------------", "MISSION END"] call KPLIB_fnc_log;
 

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -33,7 +33,7 @@ if (hasInterface) then {
 };
 
 // All classnames of objects which should be saved
-KPLIB_classnamesToSave = [toLower FOB_typename, toLower huron_typename];
+KPLIB_classnamesToSave = [toLower KPLIB_b_fobBuilding, toLower KPLIB_b_potato01];
 
 /*
     --- Locals ---
@@ -44,7 +44,7 @@ private _aiGroups = [];
 // Current campaign date and time
 private _dateTime = [];
 // Vehicles which shouldn't be handled in the kill manager
-private _noKillHandler = [toLower FOB_typename, toLower huron_typename];
+private _noKillHandler = [toLower KPLIB_b_fobBuilding, toLower KPLIB_b_potato01];
 // All objects which should be loaded/saved
 private _objectsToSave = [];
 // All storages which are handled for resource persistence
@@ -97,13 +97,13 @@ resources_intel = 0;
 save_is_loaded = false;
 
 // Add all buildings for saving and kill manager ignore
-_noKillHandler append KPLIB_b_buildings_classes;
-KPLIB_classnamesToSave append KPLIB_b_buildings_classes;
+_noKillHandler append KPLIB_b_deco_classes;
+KPLIB_classnamesToSave append KPLIB_b_deco_classes;
 KPLIB_classnamesToSave append KPLIB_b_allVeh_classes;
 
 // Add opfor and civilian vehicles for saving
 KPLIB_classnamesToSave append KPLIB_o_allVeh_classes;
-KPLIB_classnamesToSave append civilian_vehicles;
+KPLIB_classnamesToSave append KPLIB_c_vehicles;
 
 // Remove duplicates
 KPLIB_classnamesToSave = KPLIB_classnamesToSave arrayIntersect KPLIB_classnamesToSave;
@@ -147,7 +147,7 @@ stats_resistance_teamkills_by_players = 0;
 stats_secondary_objectives = 0;
 stats_sectors_liberated = 0;
 stats_sectors_lost = 0;
-stats_spartan_respawns = 0;
+stats_potato_respawns = 0;
 stats_supplies_produced = 0;
 stats_supplies_spent = 0;
 stats_vehicles_recycled = 0;
@@ -227,7 +227,7 @@ if (!isNil "_saveData") then {
         stats_secondary_objectives                  = _stats select 32;
         stats_sectors_liberated                     = _stats select 33;
         stats_sectors_lost                          = _stats select 34;
-        stats_spartan_respawns                      = _stats select 35;
+        stats_potato_respawns                      = _stats select 35;
         stats_supplies_produced                     = _stats select 36;
         stats_supplies_spent                        = _stats select 37;
         stats_vehicles_recycled                     = _stats select 38;
@@ -266,7 +266,7 @@ if (!isNil "_saveData") then {
         stats_civilians_killed_by_players           = _stats select 10;
         stats_sectors_liberated                     = _stats select 11;
         stats_playtime                              = _stats select 12;
-        stats_spartan_respawns                      = _stats select 13;
+        stats_potato_respawns                      = _stats select 13;
         stats_secondary_objectives                  = _stats select 14;
         stats_hostile_battlegroups                  = _stats select 15;
         stats_ieds_detonated                        = _stats select 16;
@@ -321,13 +321,13 @@ if (!isNil "_saveData") then {
         // This will be removed if we reach a 0.96.7 due to more released Arma 3 DLCs until we finish 0.97.0
         if !(((_saveData select 0) select 0) isEqualType 0) then {
             // Pre 0.96.5 compatibility with repair building, as it was replaced by default with a different classname
-            if ((KPLIB_recycle_building != "Land_CarService_F") && (_class == "Land_CarService_F")) then {
-                _class = KPLIB_recycle_building;
+            if ((KPLIB_b_logiStation != "Land_CarService_F") && (_class == "Land_CarService_F")) then {
+                _class = KPLIB_b_logiStation;
             };
 
             // Pre 0.96.5 compatibility with air building, as it was replaced by default with a different classname
-            if ((KPLIB_air_vehicle_building != "Land_Radar_Small_F") && (_class == "Land_Radar_Small_F")) then {
-                _class = KPLIB_air_vehicle_building;
+            if ((KPLIB_b_airControl != "Land_Radar_Small_F") && (_class == "Land_Radar_Small_F")) then {
+                _class = KPLIB_b_airControl;
             };
         };
 
@@ -360,7 +360,7 @@ if (!isNil "_saveData") then {
             };
 
             // Set civilian vehicle as seized
-            if (_class in civilian_vehicles) then {
+            if (_class in KPLIB_c_vehicles) then {
                 _object setVariable ["KPLIB_seized", true, true];
             };
 
@@ -439,7 +439,7 @@ if (!isNil "_saveData") then {
             _storage params ["_pos", "_dir", "_vecUp"];
 
             // Create object without damage handling and simulation
-            _object = createVehicle [KPLIB_small_storage_building, _pos, [], 0, "CAN_COLLIDE"];
+            _object = createVehicle [KPLIB_b_smallStorage, _pos, [], 0, "CAN_COLLIDE"];
             _object enableSimulationGlobal false;
             _object allowdamage false;
 
@@ -507,14 +507,14 @@ publicVariable "KPLIB_sectors_fob";
 publicVariable "KPLIB_clearances";
 
 // Check for deleted military sectors or deleted classnames in the locked vehicles array
-KPLIB_vehicle_to_military_base_links = KPLIB_vehicle_to_military_base_links select {((_x select 0) in elite_vehicles) && ((_x select 1) in KPLIB_sectors_military)};
+KPLIB_vehicle_to_military_base_links = KPLIB_vehicle_to_military_base_links select {((_x select 0) in KPLIB_b_vehToUnlock) && ((_x select 1) in KPLIB_sectors_military)};
 
 // Remove links for vehicles of possibly removed mods
 KPLIB_vehicle_to_military_base_links = KPLIB_vehicle_to_military_base_links select {[_x select 0] call KPLIB_fnc_checkClass};
 
 // Check for additions in the locked vehicles array
 private _lockedVehCount = count KPLIB_vehicle_to_military_base_links;
-if ((_lockedVehCount < (count KPLIB_sectors_military)) && (_lockedVehCount < (count elite_vehicles))) then {
+if ((_lockedVehCount < (count KPLIB_sectors_military)) && (_lockedVehCount < (count KPLIB_b_vehToUnlock))) then {
     private _assignedVehicles = [];
     private _assignedBases = [];
     private _nextVehicle = "";
@@ -526,8 +526,8 @@ if ((_lockedVehCount < (count KPLIB_sectors_military)) && (_lockedVehCount < (co
     } forEach KPLIB_vehicle_to_military_base_links;
 
     // Add new entries, when there are elite vehicles and military sectors are not yet assigned
-    while {((count _assignedVehicles) < (count elite_vehicles)) && ((count _assignedBases) < (count KPLIB_sectors_military))} do {
-        _nextVehicle = selectRandom (elite_vehicles - _assignedVehicles);
+    while {((count _assignedVehicles) < (count KPLIB_b_vehToUnlock)) && ((count _assignedBases) < (count KPLIB_sectors_military))} do {
+        _nextVehicle = selectRandom (KPLIB_b_vehToUnlock - _assignedVehicles);
         _nextBase = selectRandom (KPLIB_sectors_military - _assignedBases);
         _assignedVehicles pushBack _nextVehicle;
         _assignedBases pushBack _nextBase;

--- a/Missionframework/scripts/server/game/zeus_synchro.sqf
+++ b/Missionframework/scripts/server/game/zeus_synchro.sqf
@@ -1,7 +1,7 @@
-waitUntil {!isNil "huron_typename"};
+waitUntil {!isNil "KPLIB_b_potato01"};
 
 // Classnames of objects which should be added as editable for Zeus
-private _vehicleClassnames = [toLower huron_typename];
+private _vehicleClassnames = [toLower KPLIB_b_potato01];
 {
     _vehicleClassnames append _x;
 } forEach [

--- a/Missionframework/scripts/server/patrols/manage_one_civilian_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_civilian_patrol.sqf
@@ -26,7 +26,7 @@ while { KPLIB_endgame == 0 } do {
         if ( random 100 < 33) then {
             _civnumber = 1 + (floor (random 2));
             while { count units _grp < _civnumber } do {
-                [selectRandom civilians, markerPos _spawnsector, _grp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
+                [selectRandom KPLIB_c_units, markerPos _spawnsector, _grp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
             };
             _grpspeed = "LIMITED";
         } else {
@@ -39,8 +39,8 @@ while { KPLIB_endgame == 0 } do {
 
             _spawnpos = getpos _nearestroad;
 
-            [selectRandom civilians, _spawnpos, _grp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
-            _civveh = (selectRandom civilian_vehicles) createVehicle _spawnpos;
+            [selectRandom KPLIB_c_units, _spawnpos, _grp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
+            _civveh = (selectRandom KPLIB_c_vehicles) createVehicle _spawnpos;
             _civveh setpos _spawnpos;
             _civveh addMPEventHandler ['MPKilled', {_this spawn kill_manager}];
             _civveh addEventHandler ["HandleDamage", { private [ "_damage" ]; if (( side (_this select 3) != KPLIB_side_friendly ) && ( side (_this select 3) != KPLIB_side_enemy )) then { _damage = 0 } else { _damage = _this select 2 }; _damage } ];

--- a/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
@@ -25,7 +25,7 @@ if ((_price_s > _supplies) || (_price_a > _ammo) || (_price_f > _fuel)) exitWith
         private _crateValue = _x getVariable ["KPLIB_crate_value",0];
 
         switch ((typeOf _x)) do {
-            case KPLIB_supply_crate: {
+            case KPLIB_b_crateSupply: {
                 if (_price_s > 0) then {
                     if (_crateValue > _price_s) then {
                         _crateValue = _crateValue - _price_s;
@@ -38,7 +38,7 @@ if ((_price_s > _supplies) || (_price_a > _ammo) || (_price_f > _fuel)) exitWith
                     };
                 };
             };
-            case KPLIB_ammo_crate: {
+            case KPLIB_b_crateAmmo: {
                 if (_price_a > 0) then {
                     if (_crateValue > _price_a) then {
                         _crateValue = _crateValue - _price_a;
@@ -51,7 +51,7 @@ if ((_price_s > _supplies) || (_price_a > _ammo) || (_price_f > _fuel)) exitWith
                     };
                 };
             };
-            case KPLIB_fuel_crate: {
+            case KPLIB_b_crateFuel: {
                 if (_price_f > 0) then {
                     if (_crateValue > _price_f) then {
                         _crateValue = _crateValue - _price_f;

--- a/Missionframework/scripts/server/remotecall/build_fac_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/build_fac_remote_call.sqf
@@ -22,7 +22,7 @@ switch (_fac) do {
             stats_ammo_spent = stats_ammo_spent + _price_a;
             stats_fuel_spent = stats_fuel_spent + _price_f;
 
-            private _storage = nearestObjects [(markerPos (_x select 1)), [KPLIB_small_storage_building], 100];
+            private _storage = nearestObjects [(markerPos (_x select 1)), [KPLIB_b_smallStorage], 100];
             _storage = _storage select {(_x getVariable ["KPLIB_storage_type",-1]) == 1};
             if ((count _storage) == 0) exitWith {};
             _storage = (_storage select 0);
@@ -33,7 +33,7 @@ switch (_fac) do {
                 private _crateValue = _x getVariable ["KPLIB_crate_value",0];
 
                 switch ((typeOf _x)) do {
-                    case KPLIB_supply_crate: {
+                    case KPLIB_b_crateSupply: {
                         if (_price_s > 0) then {
                             if (_crateValue > _price_s) then {
                                 _crateValue = _crateValue - _price_s;
@@ -46,7 +46,7 @@ switch (_fac) do {
                             };
                         };
                     };
-                    case KPLIB_ammo_crate: {
+                    case KPLIB_b_crateAmmo: {
                         if (_price_a > 0) then {
                             if (_crateValue > _price_a) then {
                                 _crateValue = _crateValue - _price_a;
@@ -59,7 +59,7 @@ switch (_fac) do {
                             };
                         };
                     };
-                    case KPLIB_fuel_crate: {
+                    case KPLIB_b_crateFuel: {
                         if (_price_f > 0) then {
                             if (_crateValue > _price_f) then {
                                 _crateValue = _crateValue - _price_f;

--- a/Missionframework/scripts/server/remotecall/build_fob_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/build_fob_remote_call.sqf
@@ -9,7 +9,7 @@ publicVariable "KPLIB_sectors_fob";
 if ( _create_fob_building ) then {
     _fob_pos = [ (_new_fob select 0) + 15, (_new_fob select 1) + 2, 0 ];
     [_fob_pos, 20, true] call KPLIB_fnc_createClearance;
-    _fob_building = FOB_typename createVehicle _fob_pos;
+    _fob_building = KPLIB_b_fobBuilding createVehicle _fob_pos;
     _fob_building setpos _fob_pos;
     _fob_building setVectorUp [0,0,1];
     sleep 1;

--- a/Missionframework/scripts/server/remotecall/build_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/build_remote_call.sqf
@@ -17,7 +17,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
             _crateValue = _x getVariable ["KPLIB_crate_value",0];
 
             switch ((typeOf _x)) do {
-                case KPLIB_supply_crate: {
+                case KPLIB_b_crateSupply: {
                     if (_price_s > 0) then {
                         if (_crateValue > _price_s) then {
                             _crateValue = _crateValue - _price_s;
@@ -30,7 +30,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                         };
                     };
                 };
-                case KPLIB_ammo_crate: {
+                case KPLIB_b_crateAmmo: {
                     if (_price_a > 0) then {
                         if (_crateValue > _price_a) then {
                             _crateValue = _crateValue - _price_a;
@@ -43,7 +43,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                         };
                     };
                 };
-                case KPLIB_fuel_crate: {
+                case KPLIB_b_crateFuel: {
                     if (_price_f > 0) then {
                         if (_crateValue > _price_f) then {
                             _crateValue = _crateValue - _price_f;

--- a/Missionframework/scripts/server/remotecall/cancel_build_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/cancel_build_remote_call.sqf
@@ -5,10 +5,10 @@ params ["_price_s", "_price_a", "_price_f", "_storage_areas"];
 if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
     {
         private _space = 0;
-        if (typeOf _x == KPLIB_large_storage_building) then {
+        if (typeOf _x == KPLIB_b_largeStorage) then {
             _space = (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
         };
-        if (typeOf _x == KPLIB_small_storage_building) then {
+        if (typeOf _x == KPLIB_b_smallStorage) then {
             _space = (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
         };
 
@@ -18,7 +18,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                 _amount = _price_s;
             };
             _price_s = _price_s - _amount;
-            private _crate = [KPLIB_supply_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+            private _crate = [KPLIB_b_crateSupply, _amount, getPos _x] call KPLIB_fnc_createCrate;
             [_crate, _x] call KPLIB_fnc_crateToStorage;
             _space = _space - 1;
         };
@@ -29,7 +29,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                 _amount = _price_a;
             };
             _price_a = _price_a - _amount;
-            private _crate = [KPLIB_ammo_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+            private _crate = [KPLIB_b_crateAmmo, _amount, getPos _x] call KPLIB_fnc_createCrate;
             [_crate, _x] call KPLIB_fnc_crateToStorage;
             _space = _space - 1;
         };
@@ -40,7 +40,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                 _amount = _price_f;
             };
             _price_f = _price_f - _amount;
-            private _crate = [KPLIB_fuel_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+            private _crate = [KPLIB_b_crateFuel, _amount, getPos _x] call KPLIB_fnc_createCrate;
             [_crate, _x] call KPLIB_fnc_crateToStorage;
             _space = _space - 1;
         };

--- a/Missionframework/scripts/server/remotecall/del_logiTruck_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/del_logiTruck_remote_call.sqf
@@ -19,10 +19,10 @@ private _crateSum = (ceil(_price_s / 100)) + (ceil(_price_a / 100)) + (ceil(_pri
 private _spaceSum = 0;
 
 {
-    if (typeOf _x == KPLIB_large_storage_building) then {
+    if (typeOf _x == KPLIB_b_largeStorage) then {
         _spaceSum = _spaceSum + (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
     };
-    if (typeOf _x == KPLIB_small_storage_building) then {
+    if (typeOf _x == KPLIB_b_smallStorage) then {
         _spaceSum = _spaceSum + (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
     };
 } forEach _storage_areas;
@@ -31,10 +31,10 @@ if (_spaceSum < _crateSum) exitWith {(localize "STR_LOGISTIC_NOSPACE") remoteExe
 
 {
     private _space = 0;
-    if (typeOf _x == KPLIB_large_storage_building) then {
+    if (typeOf _x == KPLIB_b_largeStorage) then {
         _space = (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
     };
-    if (typeOf _x == KPLIB_small_storage_building) then {
+    if (typeOf _x == KPLIB_b_smallStorage) then {
         _space = (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
     };
 
@@ -44,7 +44,7 @@ if (_spaceSum < _crateSum) exitWith {(localize "STR_LOGISTIC_NOSPACE") remoteExe
             _amount = _price_s;
         };
         _price_s = _price_s - _amount;
-        private _crate = [KPLIB_supply_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+        private _crate = [KPLIB_b_crateSupply, _amount, getPos _x] call KPLIB_fnc_createCrate;
         [_crate, _x] call KPLIB_fnc_crateToStorage;
         _space = _space - 1;
     };
@@ -55,7 +55,7 @@ if (_spaceSum < _crateSum) exitWith {(localize "STR_LOGISTIC_NOSPACE") remoteExe
             _amount = _price_a;
         };
         _price_a = _price_a - _amount;
-        private _crate = [KPLIB_ammo_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+        private _crate = [KPLIB_b_crateAmmo, _amount, getPos _x] call KPLIB_fnc_createCrate;
         [_crate, _x] call KPLIB_fnc_crateToStorage;
         _space = _space - 1;
     };
@@ -66,7 +66,7 @@ if (_spaceSum < _crateSum) exitWith {(localize "STR_LOGISTIC_NOSPACE") remoteExe
             _amount = _price_f;
         };
         _price_f = _price_f - _amount;
-        private _crate = [KPLIB_fuel_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+        private _crate = [KPLIB_b_crateFuel, _amount, getPos _x] call KPLIB_fnc_createCrate;
         [_crate, _x] call KPLIB_fnc_crateToStorage;
         _space = _space - 1;
     };

--- a/Missionframework/scripts/server/remotecall/recycle_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/recycle_remote_call.sqf
@@ -9,10 +9,10 @@ deleteVehicle _object_recycled;
 if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
     {
         private _space = 0;
-        if (typeOf _x == KPLIB_large_storage_building) then {
+        if (typeOf _x == KPLIB_b_largeStorage) then {
             _space = (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
         };
-        if (typeOf _x == KPLIB_small_storage_building) then {
+        if (typeOf _x == KPLIB_b_smallStorage) then {
             _space = (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
         };
 
@@ -22,7 +22,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                 _amount = _price_s;
             };
             _price_s = _price_s - _amount;
-            private _crate = [KPLIB_supply_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+            private _crate = [KPLIB_b_crateSupply, _amount, getPos _x] call KPLIB_fnc_createCrate;
             [_crate, _x] call KPLIB_fnc_crateToStorage;
             _space = _space - 1;
         };
@@ -33,7 +33,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                 _amount = _price_a;
             };
             _price_a = _price_a - _amount;
-            private _crate = [KPLIB_ammo_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+            private _crate = [KPLIB_b_crateAmmo, _amount, getPos _x] call KPLIB_fnc_createCrate;
             [_crate, _x] call KPLIB_fnc_crateToStorage;
             _space = _space - 1;
         };
@@ -44,7 +44,7 @@ if ((_price_s > 0) || (_price_a > 0) || (_price_f > 0)) then {
                 _amount = _price_f;
             };
             _price_f = _price_f - _amount;
-            private _crate = [KPLIB_fuel_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+            private _crate = [KPLIB_b_crateFuel, _amount, getPos _x] call KPLIB_fnc_createCrate;
             [_crate, _x] call KPLIB_fnc_crateToStorage;
             _space = _space - 1;
         };

--- a/Missionframework/scripts/server/resources/manage_logistics.sqf
+++ b/Missionframework/scripts/server/resources/manage_logistics.sqf
@@ -25,7 +25,7 @@ while {KPLIB_endgame == 0} do {
                     if ((_x select 8) > 1) then {
                         switch (_x select 7) do {case 1: {_locPos = 2; _locRes = 4;}; case 3: {_locPos = 3; _locRes = 5;};};
                         switch (_x select 9) do {case 2: {_x set [9,0];}; case 3: {_x set [9,1];};};
-                        private _storage_areas = nearestObjects [(_x select _locPos), [KPLIB_small_storage_building, KPLIB_large_storage_building], 150];
+                        private _storage_areas = nearestObjects [(_x select _locPos), [KPLIB_b_smallStorage, KPLIB_b_largeStorage], 150];
 
                         if (((_x select 9) == 0) && !((_x select 6) isEqualTo [0,0,0])) then {
 
@@ -35,10 +35,10 @@ while {KPLIB_endgame == 0} do {
                             if (_toProcess > 3) then {_toProcess = 3;};
                             private _spaceSum = 0;
                             {
-                                if (typeOf _x == KPLIB_large_storage_building) then {
+                                if (typeOf _x == KPLIB_b_largeStorage) then {
                                     _spaceSum = _spaceSum + (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
                                 };
-                                if (typeOf _x == KPLIB_small_storage_building) then {
+                                if (typeOf _x == KPLIB_b_smallStorage) then {
                                     _spaceSum = _spaceSum + (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
                                 };
                             } forEach _storage_areas;
@@ -51,10 +51,10 @@ while {KPLIB_endgame == 0} do {
                             while {_processed < _toProcess} do {
                                 {
                                     private _space = 0;
-                                    if (typeOf _x == KPLIB_large_storage_building) then {
+                                    if (typeOf _x == KPLIB_b_largeStorage) then {
                                         _space = (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
                                     };
-                                    if (typeOf _x == KPLIB_small_storage_building) then {
+                                    if (typeOf _x == KPLIB_b_smallStorage) then {
                                         _space = (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
                                     };
 
@@ -68,7 +68,7 @@ while {KPLIB_endgame == 0} do {
                                             (((_tempLogistics select _currentIndex) select 6) select 1),
                                             (((_tempLogistics select _currentIndex) select 6) select 2)]
                                         ];
-                                        private _crate = [KPLIB_supply_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+                                        private _crate = [KPLIB_b_crateSupply, _amount, getPos _x] call KPLIB_fnc_createCrate;
                                         [_crate, _x] call KPLIB_fnc_crateToStorage;
                                         _processed = _processed + 1;
                                         _space = _space - 1;
@@ -85,7 +85,7 @@ while {KPLIB_endgame == 0} do {
                                                 (((_tempLogistics select _currentIndex) select 6) select 1) - _amount,
                                                 (((_tempLogistics select _currentIndex) select 6) select 2)]
                                             ];
-                                        private _crate = [KPLIB_ammo_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+                                        private _crate = [KPLIB_b_crateAmmo, _amount, getPos _x] call KPLIB_fnc_createCrate;
                                         [_crate, _x] call KPLIB_fnc_crateToStorage;
                                         _processed = _processed + 1;
                                         _space = _space - 1;
@@ -102,7 +102,7 @@ while {KPLIB_endgame == 0} do {
                                                 (((_tempLogistics select _currentIndex) select 6) select 1),
                                                 (((_tempLogistics select _currentIndex) select 6) select 2) - _amount]
                                             ];
-                                        private _crate = [KPLIB_fuel_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+                                        private _crate = [KPLIB_b_crateFuel, _amount, getPos _x] call KPLIB_fnc_createCrate;
                                         [_crate, _x] call KPLIB_fnc_crateToStorage;
                                         _processed = _processed + 1;
                                         _space = _space - 1;
@@ -127,9 +127,9 @@ while {KPLIB_endgame == 0} do {
                             {
                                 {
                                     switch ((typeOf _x)) do {
-                                        case KPLIB_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
-                                        case KPLIB_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
-                                        case KPLIB_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                                        case KPLIB_b_crateSupply: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                                        case KPLIB_b_crateAmmo: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                                        case KPLIB_b_crateFuel: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
                                         default {[format ["Invalid object (%1) at storage area", (typeOf _x)], "ERROR"] call KPLIB_fnc_log;};
                                     };
                                 } forEach (attachedObjects _x);
@@ -209,7 +209,7 @@ while {KPLIB_endgame == 0} do {
                                     private _crateValue = _x getVariable ["KPLIB_crate_value",0];
 
                                     switch ((typeOf _x)) do {
-                                        case KPLIB_supply_crate: {
+                                        case KPLIB_b_crateSupply: {
                                             if (_getSupply > 0) then {
                                                 if (_crateValue > _getSupply) then {
                                                     _crateValue = _crateValue - _getSupply;
@@ -222,7 +222,7 @@ while {KPLIB_endgame == 0} do {
                                                 };
                                             };
                                         };
-                                        case KPLIB_ammo_crate: {
+                                        case KPLIB_b_crateAmmo: {
                                             if (_getAmmo > 0) then {
                                                 if (_crateValue > _getAmmo) then {
                                                     _crateValue = _crateValue - _getAmmo;
@@ -235,7 +235,7 @@ while {KPLIB_endgame == 0} do {
                                                 };
                                             };
                                         };
-                                        case KPLIB_fuel_crate: {
+                                        case KPLIB_b_crateFuel: {
                                             if (_getFuel > 0) then {
                                                 if (_crateValue > _getFuel) then {
                                                     _crateValue = _crateValue - _getFuel;
@@ -351,7 +351,7 @@ while {KPLIB_endgame == 0} do {
                     if ((_x select 8) > 1) then {
                         _locPos = switch (_x select 7) do {case 5: {2}; case 6: {3};};
                         _x set [9,0];
-                        private _storage_areas = nearestObjects [(_x select _locPos), [KPLIB_small_storage_building, KPLIB_large_storage_building], 150];
+                        private _storage_areas = nearestObjects [(_x select _locPos), [KPLIB_b_smallStorage, KPLIB_b_largeStorage], 150];
 
                         if ((count (_storage_areas)) == 0) exitWith {_x set [9,2];};
 
@@ -359,10 +359,10 @@ while {KPLIB_endgame == 0} do {
                         if (_toProcess > 3) then {_toProcess = 3;};
                         private _spaceSum = 0;
                         {
-                            if (typeOf _x == KPLIB_large_storage_building) then {
+                            if (typeOf _x == KPLIB_b_largeStorage) then {
                                 _spaceSum = _spaceSum + (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
                             };
-                            if (typeOf _x == KPLIB_small_storage_building) then {
+                            if (typeOf _x == KPLIB_b_smallStorage) then {
                                 _spaceSum = _spaceSum + (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
                             };
                         } forEach _storage_areas;
@@ -375,10 +375,10 @@ while {KPLIB_endgame == 0} do {
                         while {_processed < _toProcess} do {
                             {
                                 private _space = 0;
-                                if (typeOf _x == KPLIB_large_storage_building) then {
+                                if (typeOf _x == KPLIB_b_largeStorage) then {
                                     _space = (count KPLIB_large_storage_positions) - (count (attachedObjects _x));
                                 };
-                                if (typeOf _x == KPLIB_small_storage_building) then {
+                                if (typeOf _x == KPLIB_b_smallStorage) then {
                                     _space = (count KPLIB_small_storage_positions) - (count (attachedObjects _x));
                                 };
 
@@ -392,7 +392,7 @@ while {KPLIB_endgame == 0} do {
                                         (((_tempLogistics select _currentIndex) select 6) select 1),
                                         (((_tempLogistics select _currentIndex) select 6) select 2)]
                                     ];
-                                    private _crate = [KPLIB_supply_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+                                    private _crate = [KPLIB_b_crateSupply, _amount, getPos _x] call KPLIB_fnc_createCrate;
                                     [_crate, _x] call KPLIB_fnc_crateToStorage;
                                     _processed = _processed + 1;
                                     _space = _space - 1;
@@ -409,7 +409,7 @@ while {KPLIB_endgame == 0} do {
                                             (((_tempLogistics select _currentIndex) select 6) select 1) - _amount,
                                             (((_tempLogistics select _currentIndex) select 6) select 2)]
                                         ];
-                                    private _crate = [KPLIB_ammo_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+                                    private _crate = [KPLIB_b_crateAmmo, _amount, getPos _x] call KPLIB_fnc_createCrate;
                                     [_crate, _x] call KPLIB_fnc_crateToStorage;
                                     _processed = _processed + 1;
                                     _space = _space - 1;
@@ -426,7 +426,7 @@ while {KPLIB_endgame == 0} do {
                                             (((_tempLogistics select _currentIndex) select 6) select 1),
                                             (((_tempLogistics select _currentIndex) select 6) select 2) - _amount]
                                         ];
-                                    private _crate = [KPLIB_fuel_crate, _amount, getPos _x] call KPLIB_fnc_createCrate;
+                                    private _crate = [KPLIB_b_crateFuel, _amount, getPos _x] call KPLIB_fnc_createCrate;
                                     [_crate, _x] call KPLIB_fnc_crateToStorage;
                                     _processed = _processed + 1;
                                     _space = _space - 1;

--- a/Missionframework/scripts/server/resources/manage_resources.sqf
+++ b/Missionframework/scripts/server/resources/manage_resources.sqf
@@ -29,7 +29,7 @@ while {KPLIB_endgame == 0} do {
             private _fuelValue = 0;
             private _time = _x select 8;
 
-            private _storage = nearestObjects [(markerPos (_x select 1)), [KPLIB_small_storage_building], 100];
+            private _storage = nearestObjects [(markerPos (_x select 1)), [KPLIB_b_smallStorage], 100];
             _storage = _storage select {(_x getVariable ["KPLIB_storage_type",-1]) == 1};
             if ((count _storage) > 0) then {
                 _storage = (_storage select 0);
@@ -41,11 +41,11 @@ while {KPLIB_endgame == 0} do {
                         _time = KPLIB_production_interval;
 
                         if (((count (attachedObjects _storage)) < 12) && !((_x select 7) == 3)) then {
-                            private _crateType = KPLIB_supply_crate;
+                            private _crateType = KPLIB_b_crateSupply;
                             switch (_x select 7) do {
-                                case 1: {_crateType = KPLIB_ammo_crate; stats_ammo_produced = stats_ammo_produced + 100;};
-                                case 2: {_crateType = KPLIB_fuel_crate; stats_fuel_produced = stats_fuel_produced + 100;};
-                                default {_crateType = KPLIB_supply_crate; stats_supplies_produced = stats_supplies_produced + 100;};
+                                case 1: {_crateType = KPLIB_b_crateAmmo; stats_ammo_produced = stats_ammo_produced + 100;};
+                                case 2: {_crateType = KPLIB_b_crateFuel; stats_fuel_produced = stats_fuel_produced + 100;};
+                                default {_crateType = KPLIB_b_crateSupply; stats_supplies_produced = stats_supplies_produced + 100;};
                             };
 
                             private _crate = [_crateType, 100, getPosATL _storage] call KPLIB_fnc_createCrate;
@@ -58,9 +58,9 @@ while {KPLIB_endgame == 0} do {
 
                 {
                     switch ((typeOf _x)) do {
-                        case KPLIB_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
-                        case KPLIB_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
-                        case KPLIB_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                        case KPLIB_b_crateSupply: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                        case KPLIB_b_crateAmmo: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                        case KPLIB_b_crateFuel: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
                         default {[format ["Invalid object (%1) at storage area", (typeOf _x)], "ERROR"] call KPLIB_fnc_log;};
                     };
                 } forEach (attachedObjects _storage);

--- a/Missionframework/scripts/server/resources/recalculate_resources.sqf
+++ b/Missionframework/scripts/server/resources/recalculate_resources.sqf
@@ -28,11 +28,11 @@ while {true} do {
     {
         private _fob_buildings = _x nearobjects KPLIB_fob_range;
         private _storage_areas = _fob_buildings select {(_x getVariable ["KPLIB_storage_type",-1]) == 0};
-        private _heliSlots = {(typeOf _x) == KPLIB_heli_slot_building;} count _fob_buildings;
-        private _planeSlots = {(typeOf _x) == KPLIB_plane_slot_building;} count _fob_buildings;
-        private _hasAirBuilding = {(typeOf _x) == KPLIB_air_vehicle_building;} count _fob_buildings;
+        private _heliSlots = {(typeOf _x) == KPLIB_b_slotHeli;} count _fob_buildings;
+        private _planeSlots = {(typeOf _x) == KPLIB_b_slotPlane;} count _fob_buildings;
+        private _hasAirBuilding = {(typeOf _x) == KPLIB_b_airControl;} count _fob_buildings;
         if (_hasAirBuilding > 0) then {_hasAirBuilding = true;} else {_hasAirBuilding = false;};
-        private _hasRecBuilding = {(typeOf _x) == KPLIB_recycle_building;} count _fob_buildings;
+        private _hasRecBuilding = {(typeOf _x) == KPLIB_b_logiStation;} count _fob_buildings;
         if (_hasRecBuilding > 0) then {_hasRecBuilding = true;} else {_hasRecBuilding = false;};
 
         private _supplyValue = 0;
@@ -42,9 +42,9 @@ while {true} do {
         {
             {
                 switch ((typeOf _x)) do {
-                    case KPLIB_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
-                    case KPLIB_ammo_crate: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
-                    case KPLIB_fuel_crate: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                    case KPLIB_b_crateSupply: {_supplyValue = _supplyValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                    case KPLIB_b_crateAmmo: {_ammoValue = _ammoValue + (_x getVariable ["KPLIB_crate_value",0]);};
+                    case KPLIB_b_crateFuel: {_fuelValue = _fuelValue + (_x getVariable ["KPLIB_crate_value",0]);};
                     default {[format ["Invalid object (%1) at storage area", (typeOf _x)], "ERROR"] call KPLIB_fnc_log;};
                 };
             } forEach (attachedObjects _x);

--- a/Missionframework/scripts/server/secondary/convoy_hijack.sqf
+++ b/Missionframework/scripts/server/secondary/convoy_hijack.sqf
@@ -31,7 +31,7 @@ private _boxes_loaded = 0;
 while { _boxes_loaded < _boxes_amount } do {
     _boxes_loaded = _boxes_loaded + 1;
     sleep 0.5;
-    private _next_box = [KPLIB_ammo_crate, 100, _spawnpos getPos [15, 135]] call KPLIB_fnc_createCrate;
+    private _next_box = [KPLIB_b_crateAmmo, 100, _spawnpos getPos [15, 135]] call KPLIB_fnc_createCrate;
     sleep 0.5;
     [_next_box, 50] call _load_box_fnc;
 };

--- a/Missionframework/scripts/server/secondary/search_and_rescue.sqf
+++ b/Missionframework/scripts/server/secondary/search_and_rescue.sqf
@@ -18,10 +18,10 @@ _helofire setpos (getpos _helowreck);
 private _pilotsGrp = createGroup [KPLIB_side_enemy, true];
 private _pilotsPos = (getpos _helowreck) getPos [25, random 360];
 
-[pilot_classname, _pilotsPos, _pilotsGrp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
+[KPLIB_b_heliPilotUnit, _pilotsPos, _pilotsGrp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
 sleep 0.2;
 
-[pilot_classname, _pilotsPos getPos [1, random 360], _pilotsGrp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
+[KPLIB_b_heliPilotUnit, _pilotsPos getPos [1, random 360], _pilotsGrp, "PRIVATE", 0.5] call KPLIB_fnc_createManagedUnit;
 sleep 2;
 
 private _pilotUnits = units _pilotsGrp;

--- a/Missionframework/scripts/server/sector/attack_in_progress_fob.sqf
+++ b/Missionframework/scripts/server/sector/attack_in_progress_fob.sqf
@@ -10,7 +10,7 @@ if ( KPLIB_blufor_defenders ) then {
     _grp = creategroup [KPLIB_side_friendly, true];
     {
         [_x, _thispos, _grp] call KPLIB_fnc_createManagedUnit;
-    } foreach blufor_squad_inf;
+    } foreach KPLIB_b_squadInf;
     sleep 3;
     _grp setBehaviour "COMBAT";
 };

--- a/Missionframework/scripts/server/sector/attack_in_progress_sector.sqf
+++ b/Missionframework/scripts/server/sector/attack_in_progress_sector.sqf
@@ -6,9 +6,9 @@ sleep 5;
 _ownership = [ markerpos _sector ] call KPLIB_fnc_getSectorOwnership;
 if ( _ownership != KPLIB_side_enemy ) exitWith {};
 
-_squad_type = blufor_squad_inf_light;
+_squad_type = KPLIB_b_squadLight;
 if ( _sector in KPLIB_sectors_military ) then {
-    _squad_type = blufor_squad_inf;
+    _squad_type = KPLIB_b_squadInf;
 };
 
 if ( KPLIB_blufor_defenders ) then {
@@ -59,9 +59,9 @@ if ( KPLIB_endgame == 0 ) then {
                     {
                         detach _x;
                         deleteVehicle _x;
-                    } forEach (attachedObjects ((nearestObjects [((_x select 3) select 0), [KPLIB_small_storage_building], 10]) select 0));
+                    } forEach (attachedObjects ((nearestObjects [((_x select 3) select 0), [KPLIB_b_smallStorage], 10]) select 0));
 
-                    deleteVehicle ((nearestObjects [((_x select 3) select 0), [KPLIB_small_storage_building], 10]) select 0);
+                    deleteVehicle ((nearestObjects [((_x select 3) select 0), [KPLIB_b_smallStorage], 10]) select 0);
                 };
                 KPLIB_production = KPLIB_production - [_x];
             };

--- a/Missionframework/scripts/server/sector/fn_destroyFob.sqf
+++ b/Missionframework/scripts/server/sector/fn_destroyFob.sqf
@@ -2,7 +2,7 @@
     File: fn_destroyFob.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-28
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -20,8 +20,8 @@ params [
     ["_fobPos", [], [[]]]
 ];
 
-private _buildings = [toLower FOB_typename];
-_buildings append KPLIB_b_buildings_classes;
+private _buildings = [toLower KPLIB_b_fobBuilding];
+_buildings append KPLIB_b_deco_classes;
 
 {
     if ((toLower (typeOf _x)) in _buildings) then {

--- a/Missionframework/scripts/server/sector/fn_spawnSectorCrates.sqf
+++ b/Missionframework/scripts/server/sector/fn_spawnSectorCrates.sqf
@@ -2,7 +2,7 @@
     File: fn_spawnSectorCrates.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-04-28
-    Last Update: 2020-05-10
+    Last Update: 2020-05-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -34,7 +34,7 @@ if !(_sector in KPLIB_sectorCratesSpawned) then {
     for "_i" from 1 to _amount do {
         while {_spawnPos isEqualTo []} do {
             _j = _j + 1;
-            _spawnPos = ((markerPos _sector) getPos [random 50, random 360]) findEmptyPosition [10, 40, KPLIB_ammo_crate];
+            _spawnPos = ((markerPos _sector) getPos [random 50, random 360]) findEmptyPosition [10, 40, KPLIB_b_crateAmmo];
             if (_j isEqualTo 10) exitWith {};
         };
         if !(_spawnPos isEqualTo []) then {

--- a/Missionframework/scripts/shared/kill_manager.sqf
+++ b/Missionframework/scripts/shared/kill_manager.sqf
@@ -145,7 +145,7 @@ if (isServer) then {
             };
         } else {
             // Civilian vehicle casualty
-            if (typeOf _unit in civilian_vehicles) then {
+            if (typeOf _unit in KPLIB_c_vehicles) then {
                 stats_civilian_vehicles_killed = stats_civilian_vehicles_killed + 1;
 
                 // Destroyed by player

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -39,7 +39,7 @@
         Turkish | Updated: pre 0.96.8
             Carbneth                - https://github.com/Carbneth
 
-        Czech | Updated: pre 0.96.8
+        Czech | Updated: 0.96.8
             MJVEVERUSKA             - https://github.com/MJVEVERUSKA
 -->
 <Project name="Liberation">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no |

### Description:
Variable renaming of the preset variables concerning `KPLIB_` prefix and similar tweaks.

### Content:
- [x] Renamed Civilian preset variables
- [x] Renamed Resistance preset variables
- [x] Renamed Player preset variables
- [x] Code adjustments for new variable names