### PR TITLE
[0.96.7a] Radio tower classnames array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added: AAF arsenal preset. Thanks to [lkvk](https://github.com/lkvk)
 * Added: LDF arsenal preset. Thanks to [lkvk](https://github.com/lkvk)
 * Added: Mission parameter for direct arsenal access without KPLIB Loadout Dialog.
+* Added: Config value for radio tower classnames.
 * Removed: T-14 from RHS AFRF preset.
 * Tweaked: "FOB " removed from resource overlay, so it's just e.g. "ALPHA" again.
 * Fixed: Sector monitor got stuck after sector cap was reached until restarting the server.

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -2,7 +2,7 @@
     File: fn_getSaveData.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-03-29
-    Last Update: 2020-08-05
+    Last Update: 2020-08-25
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -203,5 +203,6 @@ private _weights = [
     KP_liberation_production_markers,
     resources_intel,
     _allMines,
-    _allCrates
+    _allCrates,
+    KPLIB_sectorTowers
 ] // return

--- a/Missionframework/kp_liberation_config.sqf
+++ b/Missionframework/kp_liberation_config.sqf
@@ -167,7 +167,7 @@ KP_liberation_preset_civilians = 0;
 7  = Unsung US arsenal preset
 8  = SFP arsenal preset
 9  = BWMod arsenal preset
-10 = NATO MTP arsenal preset 
+10 = NATO MTP arsenal preset
 11 = NATO Tropic arsenal preset
 12 = NATO Woodland arsenal preset
 13 = CSAT Hex arsenal preset
@@ -270,6 +270,12 @@ KP_liberation_commander_actions = [
 Same format as for the commander actions. */
 KP_liberation_suppMod_whitelist = [
 
+];
+
+/* Array of radio tower classnames to place at radio tower sectors.
+If more than one is added, it'll be selected random for each sector on campaign start. */
+KPLIB_radioTowerClassnames = [
+    "Land_Communication_F"
 ];
 
 /* - Default arsenal blacklist method.

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -91,6 +91,8 @@ KP_liberation_logistics = [];
 KP_liberation_production = [];
 // Factory markers to display the current available facilities
 KP_liberation_production_markers = [];
+// Radio tower classnames per radio tower sector
+KPLIB_sectorTowers = [];
 // Global Intel resource
 resources_intel = 0;
 // State if the save is fully loaded
@@ -191,6 +193,7 @@ if (!isNil "_saveData") then {
         resources_intel                             = _saveData select 18;
         _allMines                                   = _saveData param [19, []];
         _allCrates                                  = _saveData param [20, []];
+        KPLIB_sectorTowers                          = _saveData param [21, []];
 
         stats_ammo_produced                         = _stats select  0;
         stats_ammo_spent                            = _stats select  1;

--- a/Missionframework/scripts/server/game/spawn_radio_towers.sqf
+++ b/Missionframework/scripts/server/game/spawn_radio_towers.sqf
@@ -12,7 +12,7 @@ private _tower = objNull;
         _classname = selectRandom KPLIB_radioTowerClassnames;
         KPLIB_sectorTowers pushBack [_sector, _classname];
     } else {
-        _classname = _saved select 1;
+        _classname = (_saved select 0) select 1;
     };
     _tower = _classname createVehicle (markerpos _x);
     _tower setPos (markerpos _x);

--- a/Missionframework/scripts/server/game/spawn_radio_towers.sqf
+++ b/Missionframework/scripts/server/game/spawn_radio_towers.sqf
@@ -1,8 +1,21 @@
 uiSleep 3;
 
+private _sector = "";
+private _saved = [];
+private _classname = "";
+private _tower = objNull;
+
 {
-    _nextower = "Land_Communication_F" createVehicle (markerpos _x);
-    _nextower setpos (markerpos _x);
-    _nextower setVectorUp [0,0,1];
-    _nextower addEventHandler ["HandleDamage", { 0 }];
-} foreach sectors_tower;
+    _sector = _x;
+    _saved = KPLIB_sectorTowers select {(_x select 0) isEqualTo _sector};
+    if (_saved isEqualTo []) then {
+        _classname = selectRandom KPLIB_radioTowerClassnames;
+        KPLIB_sectorTowers pushBack [_sector, _classname];
+    } else {
+        _classname = _saved select 1;
+    };
+    _tower = _classname createVehicle (markerpos _x);
+    _tower setPos (markerpos _x);
+    _tower setVectorUp [0, 0, 1];
+    _tower addEventHandler ["HandleDamage", {0}];
+} forEach sectors_tower;


### PR DESCRIPTION
Closes #812

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |

### Description:
Adds an array to the config file to set the radio tower classnames which spawn at the radio tower sectors.
This is selected random on campaign start and is afterwards persistent during the campaign.