### PR TITLE
[0.96.7a] GM Preset Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Added: AAF arsenal preset. Thanks to [lkvk](https://github.com/lkvk)
 * Added: LDF arsenal preset. Thanks to [lkvk](https://github.com/lkvk)
 * Added: Mission parameter for direct arsenal access without KPLIB Loadout Dialog.
+* Added: Helicopters from GM Update to GM faction presets.
+* Added: ACE, TFAR and ACRE items to GM West and East arsenal presets.
 * Removed: T-14 from RHS AFRF preset.
 * Tweaked: "FOB " removed from resource overlay, so it's just e.g. "ALPHA" again.
 * Fixed: Sector monitor got stuck after sector cap was reached until restarting the server.

--- a/Missionframework/arsenal_presets/gm_east.sqf
+++ b/Missionframework/arsenal_presets/gm_east.sqf
@@ -118,7 +118,76 @@ GRLIB_arsenal_items = [
     "gm_df7x40_grn", // Binocular
     "ItemMap",
     "ItemWatch",
-    "ItemRadio"
+    "ItemRadio",
+
+    // ACE Items
+    "ACE_adenosine",                                                // Adenosine autoinjector
+    "ACE_Altimeter",                                                // Altimeter Watch
+    "ACE_artilleryTable",                                           // Artillery Rangetable
+    "ACE_Banana",                                                   // Banana
+    "ACE_bloodIV_250",                                              // Blood IV (250 ml)
+    "ACE_bloodIV_500",                                              // Blood IV (500 ml)
+    "ACE_bloodIV",                                                  // Blood IV (1000 ml)
+    "ACE_bodyBag",                                                  // Bodybag
+    "ACE_CableTie",                                                 // Cable Tie
+    "ACE_Clacker",                                                  // M57 Firing Device
+    "ACE_DeadManSwitch",                                            // Dead Man's Switch
+    "ACE_DefusalKit",                                               // Defusal Kit
+    "ACE_EarPlugs",                                                 // Earplugs
+    "ACE_elasticBandage",                                           // Bandage (Elastic)
+    "ACE_EntrenchingTool",                                          // Entrenching Tool
+    "ACE_epinephrine",                                              // Epinephrine autoinjector
+    "ACE_fieldDressing",                                            // Bandage (Basic)
+    "ACE_Flashlight_KSF1",                                          // KSF-1
+    "ACE_Flashlight_Maglite_ML300L",                                // Maglite ML300L
+    "ACE_Flashlight_MX991",                                         // Fulton MX-991
+    "ACE_Flashlight_XL50",                                          // Maglite XL50
+    "ACE_M26_Clacker",                                              // M152 Firing Device
+    "ACE_MapTools",                                                 // Map Tools
+    "ACE_morphine",                                                 // Morphine autoinjector
+    "ACE_packingBandage",                                           // Bandage (Packing)
+    "ACE_personalAidKit",                                           // Personal Aid Kit
+    "ACE_plasmaIV_250",                                             // Plasma IV (250 ml)
+    "ACE_plasmaIV_500",                                             // Plasma IV (500 ml)
+    "ACE_plasmaIV",                                                 // Plasma IV (1000 ml)
+    "ACE_quikclot",                                                 // Bandage (QuickClot)
+    "ACE_RangeCard",                                                // Range Card
+    "ACE_RangeTable_82mm",                                          // 82 mm Rangetable
+    "ACE_rope12",                                                   // Rope 12.2 meters
+    "ACE_rope15",                                                   // Rope 15.2 meters
+    "ACE_rope18",                                                   // Rope 18.3 meters
+    "ACE_rope27",                                                   // Rope 27.4 meters
+    "ACE_rope36",                                                   // Rope 36.6 meters
+    "ACE_salineIV_250",                                             // Saline IV (250 ml)
+    "ACE_salineIV_500",                                             // Saline IV (500 ml)
+    "ACE_salineIV",                                                 // Saline IV (1000 ml)
+    "ACE_Sandbag_empty",                                            // Sandbag (empty)
+    "ACE_splint",                                                   // Splint
+    "ACE_surgicalKit",                                              // Surgical Kit
+    "ACE_tourniquet",                                               // Tourniquet (CAT)
+    "ACE_Tripod",                                                   // SSWT Kit
+    "ACE_wirecutter",                                               // Wirecutter
+
+    // ACRE Items
+    "ACRE_PRC117F",                                                 // AN/PRC-117F
+    "ACRE_PRC148",                                                  // AN/PRC-148
+    "ACRE_PRC152",                                                  // AN/PRC-152
+    "ACRE_PRC343",                                                  // AN/PRC-343
+    "ACRE_PRC77",                                                   // AN/PRC-77
+    "ACRE_SEM52SL",                                                 // SEM 52 SL
+    "ACRE_SEM70",                                                   // SEM 70
+    "ACRE_VHF30108",                                                // VHF30108 GSM
+    "ACRE_VHF30108MAST",                                            // VHF30108 Mast
+    "ACRE_VHF30108SPIKE",                                           // VHF30108 GS
+
+    // TFAR Items
+    "tf_anprc148jem",                                               // AN/PRC-148 JEM
+    "tf_anprc152",                                                  // AN/PRC-152
+    "tf_anprc154_1",                                                // AN/PRC-154
+    "tf_fadak",                                                     // FADAK
+    "tf_microdagr",                                                 // MicroDAGR Radio Programmer
+    "tf_pnr1000a_1",                                                // PNR-1000A
+    "tf_rf7800str"                                                  // PF-7800S-TR
 ];
 
 GRLIB_arsenal_backpacks = [

--- a/Missionframework/arsenal_presets/gm_west.sqf
+++ b/Missionframework/arsenal_presets/gm_west.sqf
@@ -167,7 +167,76 @@ GRLIB_arsenal_items = [
     "gm_watch_kosei_80",
     "ItemMap",
     "ItemWatch",
-    "ItemRadio"
+    "ItemRadio",
+
+    // ACE Items
+    "ACE_adenosine",                                                // Adenosine autoinjector
+    "ACE_Altimeter",                                                // Altimeter Watch
+    "ACE_artilleryTable",                                           // Artillery Rangetable
+    "ACE_Banana",                                                   // Banana
+    "ACE_bloodIV_250",                                              // Blood IV (250 ml)
+    "ACE_bloodIV_500",                                              // Blood IV (500 ml)
+    "ACE_bloodIV",                                                  // Blood IV (1000 ml)
+    "ACE_bodyBag",                                                  // Bodybag
+    "ACE_CableTie",                                                 // Cable Tie
+    "ACE_Clacker",                                                  // M57 Firing Device
+    "ACE_DeadManSwitch",                                            // Dead Man's Switch
+    "ACE_DefusalKit",                                               // Defusal Kit
+    "ACE_EarPlugs",                                                 // Earplugs
+    "ACE_elasticBandage",                                           // Bandage (Elastic)
+    "ACE_EntrenchingTool",                                          // Entrenching Tool
+    "ACE_epinephrine",                                              // Epinephrine autoinjector
+    "ACE_fieldDressing",                                            // Bandage (Basic)
+    "ACE_Flashlight_KSF1",                                          // KSF-1
+    "ACE_Flashlight_Maglite_ML300L",                                // Maglite ML300L
+    "ACE_Flashlight_MX991",                                         // Fulton MX-991
+    "ACE_Flashlight_XL50",                                          // Maglite XL50
+    "ACE_M26_Clacker",                                              // M152 Firing Device
+    "ACE_MapTools",                                                 // Map Tools
+    "ACE_morphine",                                                 // Morphine autoinjector
+    "ACE_packingBandage",                                           // Bandage (Packing)
+    "ACE_personalAidKit",                                           // Personal Aid Kit
+    "ACE_plasmaIV_250",                                             // Plasma IV (250 ml)
+    "ACE_plasmaIV_500",                                             // Plasma IV (500 ml)
+    "ACE_plasmaIV",                                                 // Plasma IV (1000 ml)
+    "ACE_quikclot",                                                 // Bandage (QuickClot)
+    "ACE_RangeCard",                                                // Range Card
+    "ACE_RangeTable_82mm",                                          // 82 mm Rangetable
+    "ACE_rope12",                                                   // Rope 12.2 meters
+    "ACE_rope15",                                                   // Rope 15.2 meters
+    "ACE_rope18",                                                   // Rope 18.3 meters
+    "ACE_rope27",                                                   // Rope 27.4 meters
+    "ACE_rope36",                                                   // Rope 36.6 meters
+    "ACE_salineIV_250",                                             // Saline IV (250 ml)
+    "ACE_salineIV_500",                                             // Saline IV (500 ml)
+    "ACE_salineIV",                                                 // Saline IV (1000 ml)
+    "ACE_Sandbag_empty",                                            // Sandbag (empty)
+    "ACE_splint",                                                   // Splint
+    "ACE_surgicalKit",                                              // Surgical Kit
+    "ACE_tourniquet",                                               // Tourniquet (CAT)
+    "ACE_Tripod",                                                   // SSWT Kit
+    "ACE_wirecutter",                                               // Wirecutter
+
+    // ACRE Items
+    "ACRE_PRC117F",                                                 // AN/PRC-117F
+    "ACRE_PRC148",                                                  // AN/PRC-148
+    "ACRE_PRC152",                                                  // AN/PRC-152
+    "ACRE_PRC343",                                                  // AN/PRC-343
+    "ACRE_PRC77",                                                   // AN/PRC-77
+    "ACRE_SEM52SL",                                                 // SEM 52 SL
+    "ACRE_SEM70",                                                   // SEM 70
+    "ACRE_VHF30108",                                                // VHF30108 GSM
+    "ACRE_VHF30108MAST",                                            // VHF30108 Mast
+    "ACRE_VHF30108SPIKE",                                           // VHF30108 GS
+
+    // TFAR Items
+    "tf_anprc148jem",                                               // AN/PRC-148 JEM
+    "tf_anprc152",                                                  // AN/PRC-152
+    "tf_anprc154_1",                                                // AN/PRC-154
+    "tf_fadak",                                                     // FADAK
+    "tf_microdagr",                                                 // MicroDAGR Radio Programmer
+    "tf_pnr1000a_1",                                                // PNR-1000A
+    "tf_rf7800str"                                                  // PF-7800S-TR
 ];
 
 GRLIB_arsenal_backpacks = [

--- a/Missionframework/kp_liberation_config.sqf
+++ b/Missionframework/kp_liberation_config.sqf
@@ -8,26 +8,28 @@ KP_liberation_medical_vehicles = [
     "B_T_Truck_01_medical_F",
     "B_Truck_01_medical_F",
     "C_Van_02_medevac_F",
-    "CUP_O_M113_Med_TKA",
     "CUP_B_BMP2_AMB_CDF",
-    "CUP_O_BMP2_AMB_CHDKZ",
-    "CUP_O_BMP2_AMB_sla",
+    "CUP_B_BMP2_AMB_CZ_Des",
+    "CUP_B_BMP2_AMB_CZ",
+    "CUP_B_FV432_GB_Ambulance",
+    "CUP_B_HMMWV_Ambulance_ACR",
     "CUP_B_HMMWV_Ambulance_USA",
     "CUP_B_HMMWV_Ambulance_USMC",
     "CUP_B_LR_Ambulance_CZ_D",
     "CUP_B_LR_Ambulance_CZ_W",
     "CUP_B_LR_Ambulance_GB_D",
     "CUP_B_LR_Ambulance_GB_W",
-    "CUP_O_LR_Ambulance_TKA",
-    "CUP_B_FV432_GB_Ambulance",
     "CUP_B_S1203_Ambulance_CDF",
     "CUP_B_UH1Y_MEV_USMC",
     "CUP_B_UH60M_Unarmed_FFV_MEV_US",
-    "CUP_B_BMP2_AMB_CZ",
-    "CUP_B_BMP2_AMB_CZ_Des",
-    "CUP_B_HMMWV_Ambulance_ACR",
+    "CUP_O_BMP2_AMB_CHDKZ",
+    "CUP_O_BMP2_AMB_sla",
+    "CUP_O_LR_Ambulance_TKA",
+    "CUP_O_M113_Med_TKA",
+    "gm_gc_airforce_mi2sr",
     "gm_gc_army_ural375d_medic_win",
     "gm_gc_army_ural375d_medic",
+    "gm_ge_airforce_do28d2_medevac",
     "gm_ge_army_u1300l_medic_win_rc",
     "gm_ge_army_u1300l_medic",
     "I_E_Truck_02_Medical_F",
@@ -167,7 +169,7 @@ KP_liberation_preset_civilians = 0;
 7  = Unsung US arsenal preset
 8  = SFP arsenal preset
 9  = BWMod arsenal preset
-10 = NATO MTP arsenal preset 
+10 = NATO MTP arsenal preset
 11 = NATO Tropic arsenal preset
 12 = NATO Woodland arsenal preset
 13 = CSAT Hex arsenal preset

--- a/Missionframework/presets/blufor/gm_east.sqf
+++ b/Missionframework/presets/blufor/gm_east.sqf
@@ -17,7 +17,7 @@ FOB_box_typename = "gm_gc_army_brdm2um";                                // This 
 FOB_truck_typename = "gm_gc_army_btr60pu12";                            // This is the FOB as a vehicle.
 Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
 Respawn_truck_typename = "gm_gc_army_ural375d_medic";                   // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_gc_army_btr60pa";                                  // This is Spartan 01, a multipurpose mobile respawn as a command BTR60.
+huron_typename = "gm_gc_airforce_mi2t";                                 // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
 crewman_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                // This defines the crew for vehicles.
 pilot_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                  // This defines the pilot for helicopters.
 KP_liberation_little_bird_classname = "gm_gc_bgs_p601";                 // Little birds replaced with unimog for container transportation.
@@ -67,6 +67,12 @@ heavy_vehicles = [
 ];
 
 air_vehicles = [
+    ["gm_gc_airforce_mi2p",300,0,175],                                  // Mi-2P
+    ["gm_gc_airforce_mi2sr",300,0,175],                                 // Mi-2SR
+    ["gm_gc_airforce_mi2us",300,100,175],                               // Mi-2US
+    ["gm_gc_airforce_mi2urn",300,120,175],                              // Mi-2URN
+    ["gm_gc_airforce_l410s_salon",350,0,200],                           // L-410S
+    ["gm_gc_airforce_l410t",350,0,200],                                 // L-410T
     ["len_mi8amt_nva",225,0,125],                                       // Mi8AMT
     ["len_mi24d_CAS_nva",550,550,250],                                  // Mi-24D (CAS)
     ["len_mi24d_AT_nva",550,550,250],                                   // Mi-24D (AT)

--- a/Missionframework/presets/blufor/gm_east_win.sqf
+++ b/Missionframework/presets/blufor/gm_east_win.sqf
@@ -17,7 +17,7 @@ FOB_box_typename = "gm_gc_army_brdm2um_win";                            // This 
 FOB_truck_typename = "gm_gc_army_btr60pu12_win";                        // This is the FOB as a vehicle.
 Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
 Respawn_truck_typename = "gm_gc_army_ural375d_medic_win";               // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_gc_army_btr60pa_win";                              // This is Spartan 01, a multipurpose mobile respawn as a command BTR60.
+huron_typename = "gm_gc_airforce_mi2t";                                 // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
 crewman_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                // This defines the crew for vehicles.
 pilot_classname = "gm_gc_army_crew_mpiaks74nk_80_blk";                  // This defines the pilot for helicopters.
 KP_liberation_little_bird_classname = "gm_gc_bgs_p601";                 // Little birds replaced with unimog for container transportation.
@@ -67,6 +67,12 @@ heavy_vehicles = [
 ];
 
 air_vehicles = [
+    ["gm_gc_airforce_mi2p",300,0,175],                                  // Mi-2P
+    ["gm_gc_airforce_mi2sr",300,0,175],                                 // Mi-2SR
+    ["gm_gc_airforce_mi2us",300,100,175],                               // Mi-2US
+    ["gm_gc_airforce_mi2urn",300,120,175],                              // Mi-2URN
+    ["gm_gc_airforce_l410s_salon",350,0,200],                           // L-410S
+    ["gm_gc_airforce_l410t",350,0,200],                                 // L-410T
     ["len_mi8amt_nva",225,0,125],                                       // Mi8AMT
     ["len_mi24d_CAS_nva",550,550,250],                                  // Mi-24D (CAS)
     ["len_mi24d_AT_nva",550,550,250],                                   // Mi-24D (AT)

--- a/Missionframework/presets/blufor/gm_west.sqf
+++ b/Missionframework/presets/blufor/gm_west.sqf
@@ -17,10 +17,10 @@ FOB_box_typename = "gm_ge_army_shelteraceI_command";                    // This 
 FOB_truck_typename = "gm_ge_army_bpz2a0";                               // This is the FOB as a vehicle.
 Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
 Respawn_truck_typename = "gm_ge_army_u1300l_medic";                     // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_ge_army_m113a1g_command";                          // This is Spartan 01, a multipurpose mobile respawn as a command M113.
+huron_typename = "gm_ge_army_ch53gs";                                   // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
 crewman_classname = "gm_ge_army_crew_mp2a1_80_oli";                     // This defines the crew for vehicles.
 pilot_classname = "gm_ge_army_crew_mp2a1_80_oli";                       // This defines the pilot for helicopters.
-KP_liberation_little_bird_classname = "gm_ge_army_u1300l_container";    // Little birds replaced with unimog for container transportation.
+KP_liberation_little_bird_classname = "gm_ge_army_bo105p1m_vbh_swooper";// These are the little birds which spawn on the Freedom or at Chimera base.
 KP_liberation_boat_classname = "B_Boat_Transport_01_F";                 // These are the boats which spawn at the stern of the Freedom.
 KP_liberation_truck_classname = "gm_ge_army_kat1_454_cargo";            // These are the trucks which are used in the logistic convoy system.
 KP_liberation_small_storage_building = "ContainmentArea_02_sand_F";     // A small storage area for resources.
@@ -78,7 +78,15 @@ heavy_vehicles = [
 ];
 
 air_vehicles = [
-    ["len_uh1d_bw",225,0,125]                                           // BW UH-1D
+    ["gm_ge_army_bo105m_vbh",200,0,100],                                // VBH 1
+    ["gm_ge_army_bo105p1m_vbh",200,0,100],                              // VBH 1A1
+    ["gm_ge_army_bo105p1m_vbh_swooper",200,0,100],                      // VBH 1A1 Swooper
+    ["gm_ge_army_bo105p_pah1",200,100,100],                             // PAH 1
+    ["gm_ge_army_bo105p_pah1a1",200,120,100],                           // PAH 1A1
+    ["len_uh1d_bw",225,0,125],                                          // BW UH-1D
+    ["gm_ge_army_ch53g",300,0,175],                                     // CH-53G
+    ["gm_ge_airforce_do28d2",350,0,200],                                // Do 28 D2
+    ["gm_ge_airforce_do28d2_medevac",350,0,200]                         // Do 28 D2 (Medevac)
 ];
 
 static_vehicles = [

--- a/Missionframework/presets/blufor/gm_west_win.sqf
+++ b/Missionframework/presets/blufor/gm_west_win.sqf
@@ -17,10 +17,10 @@ FOB_box_typename = "gm_ge_army_shelteraceI_command_win";                // This 
 FOB_truck_typename = "gm_ge_army_bpz2a0_win";                           // This is the FOB as a vehicle.
 Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
 Respawn_truck_typename = "gm_ge_army_u1300l_medic_win_rc";              // This is the mobile respawn (and medical) truck.
-huron_typename = "gm_ge_army_m113a1g_command_win";                      // This is Spartan 01, a multipurpose mobile respawn as a command M113.
+huron_typename = "gm_ge_army_ch53gs";                                   // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
 crewman_classname = "gm_ge_army_crew_mp2a1_80_win";                     // This defines the crew for vehicles.
 pilot_classname = "gm_ge_army_crew_mp2a1_80_win";                       // This defines the pilot for helicopters.
-KP_liberation_little_bird_classname = "gm_ge_army_u1300l_container_win";// Little birds replaced with unimog for container transportation.
+KP_liberation_little_bird_classname = "gm_ge_army_bo105p1m_vbh_swooper";// These are the little birds which spawn on the Freedom or at Chimera base.
 KP_liberation_boat_classname = "B_Boat_Transport_01_F";                 // These are the boats which spawn at the stern of the Freedom.
 KP_liberation_truck_classname = "gm_ge_army_kat1_454_cargo_win";        // These are the trucks which are used in the logistic convoy system.
 KP_liberation_small_storage_building = "ContainmentArea_02_sand_F";     // A small storage area for resources.
@@ -78,7 +78,15 @@ heavy_vehicles = [
 ];
 
 air_vehicles = [
-    ["len_uh1d_bw",225,0,125]                                           // BW UH-1D
+    ["gm_ge_army_bo105m_vbh",200,0,100],                                // VBH 1
+    ["gm_ge_army_bo105p1m_vbh",200,0,100],                              // VBH 1A1
+    ["gm_ge_army_bo105p1m_vbh_swooper",200,0,100],                      // VBH 1A1 Swooper
+    ["gm_ge_army_bo105p_pah1",200,100,100],                             // PAH 1
+    ["gm_ge_army_bo105p_pah1a1",200,120,100],                           // PAH 1A1
+    ["len_uh1d_bw",225,0,125],                                          // BW UH-1D
+    ["gm_ge_army_ch53g",300,0,175],                                     // CH-53G
+    ["gm_ge_airforce_do28d2",350,0,200],                                // Do 28 D2
+    ["gm_ge_airforce_do28d2_medevac",350,0,200]                         // Do 28 D2 (Medevac)
 ];
 
 static_vehicles = [

--- a/Missionframework/presets/opfor/gm_east.sqf
+++ b/Missionframework/presets/opfor/gm_east.sqf
@@ -113,11 +113,15 @@ opfor_troup_transports = [
     "gm_gc_army_ural4320_cargo",                                        // Truck gel. 5 Transport
     "gm_gc_army_btr60pa",                                               // SPW-60PA
     "gm_gc_army_btr60pb",                                               // SPW-60PB
-    "gm_gc_army_bmp1sp2"                                                // BMP-1 SP-2
+    "gm_gc_army_bmp1sp2",                                               // BMP-1 SP-2
+    "gm_gc_airforce_mi2p"                                               // Mi-2P
 ];
 
 // Enemy rotary-wings that will need to spawn in flight.
 opfor_choppers = [
+    "gm_gc_airforce_mi2p",                                              // Mi-2P
+    "gm_gc_airforce_mi2us",                                             // Mi-2US
+    "gm_gc_airforce_mi2urn",                                            // Mi-2URN
     "len_mi8amt_nva",                                                   // Mi8amt
     "len_mi24d_AT_nva",                                                 // Mi-24D (AT)
     "len_mi24d_CAS_nva",                                                // Mi-24D (CAS)

--- a/Missionframework/presets/opfor/gm_east_win.sqf
+++ b/Missionframework/presets/opfor/gm_east_win.sqf
@@ -113,11 +113,15 @@ opfor_troup_transports = [
     "gm_gc_army_ural4320_cargo_win",                                    // Truck gel. 5 Transport
     "gm_gc_army_btr60pa_win",                                           // SPW-60PA
     "gm_gc_army_btr60pb_win",                                           // SPW-60PB
-    "gm_gc_army_bmp1sp2_win"                                            // BMP-1 SP-2
+    "gm_gc_army_bmp1sp2_win",                                           // BMP-1 SP-2
+    "gm_gc_airforce_mi2p"                                               // Mi-2P
 ];
 
 // Enemy rotary-wings that will need to spawn in flight.
 opfor_choppers = [
+    "gm_gc_airforce_mi2p",                                              // Mi-2P
+    "gm_gc_airforce_mi2us",                                             // Mi-2US
+    "gm_gc_airforce_mi2urn",                                            // Mi-2URN
     "len_mi8amt_nva",                                                   // Mi8amt
     "len_mi24d_AT_nva",                                                 // Mi-24D (AT)
     "len_mi24d_CAS_nva",                                                // Mi-24D (CAS)

--- a/Missionframework/presets/opfor/gm_west.sqf
+++ b/Missionframework/presets/opfor/gm_west.sqf
@@ -115,11 +115,15 @@ opfor_troup_transports = [
     "gm_ge_army_fuchsa0_engineer",                                      // Fuchs (Engineer)
     "gm_ge_army_fuchsa0_reconnaissance",                                // Fuchs (Recon, MILAN)
     "gm_ge_army_m113a1g_apc",                                           // M113A3 (MG3)
-    "gm_ge_army_m113a1g_apc_milan"                                      // M113A3 (MILAN)
+    "gm_ge_army_m113a1g_apc_milan",                                     // M113A3 (MILAN)
+    "gm_ge_army_ch53g"                                                  // CH-53G
 ];
 
 // Enemy rotary-wings that will need to spawn in flight.
 opfor_choppers = [
+    "gm_ge_army_bo105p_pah1",                                           // PAH 1
+    "gm_ge_army_bo105p_pah1a1",                                         // PAH 1A1
+    "gm_ge_army_ch53g",                                                 // CH-53G
     "len_uh1d_bw"                                                       // BW UH-1D
 ];
 

--- a/Missionframework/presets/opfor/gm_west_win.sqf
+++ b/Missionframework/presets/opfor/gm_west_win.sqf
@@ -116,10 +116,14 @@ opfor_troup_transports = [
     "gm_ge_army_fuchsa0_reconnaissance_win",                            // Fuchs (Recon, MILAN)
     "gm_ge_army_m113a1g_apc_win",                                       // M113A3 (MG3)
     "gm_ge_army_m113a1g_apc_milan_win"                                  // M113A3 (MILAN)
+    "gm_ge_army_ch53g"                                                  // CH-53G
 ];
 
 // Enemy rotary-wings that will need to spawn in flight.
 opfor_choppers = [
+    "gm_ge_army_bo105p_pah1",                                           // PAH 1
+    "gm_ge_army_bo105p_pah1a1",                                         // PAH 1A1
+    "gm_ge_army_ch53g",                                                 // CH-53G
     "len_uh1d_bw"                                                       // BW UH-1D
 ];
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no |

### Description:
* Added helicopters from the GM update to blufor and opfor presets for East and West Germany.
* Added ACE, TFAR and ACRE items to the GM arsenal presets.