### PR TITLE
Workaround for Bug in Drone AI

### DIFF
--- a/Missionframework/scripts/client/actions/do_repair_drone_ai.sqf
+++ b/Missionframework/scripts/client/actions/do_repair_drone_ai.sqf
@@ -1,0 +1,9 @@
+params ["_target", "_caller", "_actionId", "_arguments"];
+
+// Delete the old crew
+{
+	(vehicle _x) deleteVehicleCrew _x;
+} forEach (crew _target);
+
+// Creates a new crew, which will work again.
+createVehicleCrew _target;

--- a/Missionframework/scripts/client/actions/repair_drone_ai.sqf
+++ b/Missionframework/scripts/client/actions/repair_drone_ai.sqf
@@ -22,7 +22,7 @@ while { true } do {
             } foreach _already_marked_drones;
 
             if ( !_next_vehicle_already_in_list ) then {
-                _idact_next = _next_vehicle addAction [ "<t color='#FFFF00'>" + localize "STR_REPAIR_DRONE_AI" + "</t>", "scripts\client\actions\do_repair_drone_ai.sqf", "", -1000, true, true, "", "build_confirmed == 0 && (_this distance _target < veh_action_distance) && (vehicle player == player)"];
+                _idact_next = _next_vehicle addAction [ "<t color='#FFFF00'>" + localize "STR_REPAIR_DRONE_AI" + "</t>", "scripts\client\actions\do_repair_drone_ai.sqf", "", -925, true, true, "", "build_confirmed == 0 && (_this distance _target < veh_action_distance) && (vehicle player == player)"];
                 _already_marked_drones pushback [ _next_vehicle, _idact_next ] ;
             };
         } foreach _detected_drones;

--- a/Missionframework/scripts/client/actions/repair_drone_ai.sqf
+++ b/Missionframework/scripts/client/actions/repair_drone_ai.sqf
@@ -22,7 +22,7 @@ while { true } do {
             } foreach _already_marked_drones;
 
             if ( !_next_vehicle_already_in_list ) then {
-                _idact_next = _next_vehicle addAction [ "<t color='#FFFF00'>" + localize "STR_REPAIR_DRONE_AI" + "</t>", "scripts\client\actions\do_repair_drone_ai.sqf", "", -925, true, true, "", "build_confirmed == 0 && (_this distance _target < veh_action_distance) && (vehicle player == player)"];
+                _idact_next = _next_vehicle addAction [ "<t color='#FFFF00'>" + localize "STR_REPAIR_DRONE_AI" + "</t>", "scripts\client\actions\do_repair_drone_ai.sqf", "", -925, true, true, "", "build_confirmed == 0 && (_this distance _target < veh_action_distance) && (vehicle player == player) && (isNull ((UAVControl _target) select 0))"];
                 _already_marked_drones pushback [ _next_vehicle, _idact_next ] ;
             };
         } foreach _detected_drones;

--- a/Missionframework/scripts/client/actions/repair_drone_ai.sqf
+++ b/Missionframework/scripts/client/actions/repair_drone_ai.sqf
@@ -1,0 +1,54 @@
+waitUntil {!isNil "GRLIB_permissions"};
+waitUntil {!(GRLIB_permissions isEqualTo []) || !GRLIB_permissions_param};
+
+private [ "_already_marked_drones", "_detected_drones", "_next_vehicle", "_next_vehicle_already_in_list", "_idact_next" ];
+
+_already_marked_drones = [];
+veh_action_distance = 10;
+
+while { true } do {
+
+    if ([5] call KPLIB_fnc_hasPermission) then {
+
+        _detected_drones = allUnitsUAV;
+		
+        {
+            _next_vehicle = _x;
+            _next_vehicle_already_in_list = false;
+            {
+                if ( (_x select 0) == _next_vehicle ) then {
+                    _next_vehicle_already_in_list = true;
+                };
+            } foreach _already_marked_drones;
+
+            if ( !_next_vehicle_already_in_list ) then {
+                _idact_next = _next_vehicle addAction [ "<t color='#FFFF00'>" + localize "STR_REPAIR_DRONE_AI" + "</t>", "scripts\client\actions\do_repair_drone_ai.sqf", "", -1000, true, true, "", "build_confirmed == 0 && (_this distance _target < veh_action_distance) && (vehicle player == player)"];
+                _already_marked_drones pushback [ _next_vehicle, _idact_next ] ;
+            };
+        } foreach _detected_drones;
+
+        {
+            _next_vehicle = _x;
+            _next_vehicle_already_in_list = false;
+            {
+                if ( _x == (_next_vehicle select 0) ) then {
+                    _next_vehicle_already_in_list = true;
+                };
+            } foreach _detected_drones;
+
+            if ( !_next_vehicle_already_in_list ) then {
+                (_next_vehicle select 0) removeAction (_next_vehicle select 1);
+                _already_marked_drones = _already_marked_drones - [ _next_vehicle ];
+            };
+
+        } foreach _already_marked_drones;
+
+    } else {
+        {
+            (_x select 0) removeAction (_x select 1);
+            _already_marked_drones = _already_marked_drones - [ _x ];
+        } foreach _already_marked_drones;
+    };
+
+    sleep 3;
+};

--- a/Missionframework/scripts/client/init_client.sqf
+++ b/Missionframework/scripts/client/init_client.sqf
@@ -35,6 +35,7 @@ kp_vehicle_permissions = compileFinal preprocessFileLineNumbers "scripts\client\
 execVM "scripts\client\actions\intel_manager.sqf";
 execVM "scripts\client\actions\recycle_manager.sqf";
 execVM "scripts\client\actions\unflip_manager.sqf";
+execVM "scripts\client\actions\repair_drone_ai.sqf";
 execVM "scripts\client\ammoboxes\ammobox_action_manager.sqf";
 execVM "scripts\client\build\build_overlay.sqf";
 execVM "scripts\client\build\do_build.sqf";

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -704,6 +704,9 @@
             <Portuguese>-- DESVIRAR</Portuguese>
             <Korean>-- 차량 바로잡기</Korean>
         </Key>
+        <Key ID="STR_REPAIR_DRONE_AI">
+            <English>-- REPAIR DRONE AI</English>
+        </Key>
         <Key ID="STR_GRID">
             <Original>-- Grid mode</Original>
             <French>-- Mode grille</French>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -705,7 +705,7 @@
             <Korean>-- 차량 바로잡기</Korean>
         </Key>
         <Key ID="STR_REPAIR_DRONE_AI">
-            <English>-- REPAIR DRONE AI</English>
+            <Original>-- REPAIR DRONE AI</Original>
         </Key>
         <Key ID="STR_GRID">
             <Original>-- Grid mode</Original>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kind of? |
| New feature? | yes |
| Needs wipe? | no |

### Description:

Currently there is a bug with Arma 3 that causes the AI unit inside an aerial drone to cease accepting new orders after it completes a "LAND" order. This, of course, makes it impossible to rearm and refuel them making them non-viable to actually use without constantly reloading the mission.

I found a workaround by deleting the "units" inside the drone and replacing them with a fresh set of units. This pull request adds another action onto any drone similar to the "unflip" action. It just deletes the old crew and puts in a new one with `createVehicleCrew`.

### Successfully tested on:
- [ ] Local MP
- [x] Dedicated MP

I've only tested on Dedicated MP as that was the easiest way for me to test, but considering 90% of my PR is copy pasted from the unflip action's code I wasn't in a rush to test it on Local MP.

The only original code in this PR is
```
params ["_target", "_caller", "_actionId", "_arguments"];

// Delete the old crew
{
	(vehicle _x) deleteVehicleCrew _x;
} forEach (crew _target);

// Creates a new crew, which will work again.
createVehicleCrew _target;
```