### PR TITLE
Remove all addons for limited zeus, add param to disable zeus for commander

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added: LDF arsenal preset. Thanks to [lkvk](https://github.com/lkvk)
 * Added: Mission parameter for direct arsenal access without KPLIB Loadout Dialog.
 * Added: Config value for radio tower classnames.
+* Added: Parameter to disable Zeus for commander.
 * Removed: T-14 from RHS AFRF preset.
 * Tweaked: "FOB " removed from resource overlay, so it's just e.g. "ALPHA" again.
 * Fixed: Sector monitor got stuck after sector cap was reached until restarting the server.

--- a/Missionframework/functions/curator/fn_initCuratorHandlers.sqf
+++ b/Missionframework/functions/curator/fn_initCuratorHandlers.sqf
@@ -2,7 +2,7 @@
     File: fn_initCuratorHandlers.sqf
     Author: KP Liberation Dev Team - https://github.com/KillahPotatoes
     Date: 2020-08-07
-    Last Update: 2020-08-08
+    Last Update: 2020-08-30
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -62,13 +62,15 @@ if (isServer) then {
 
             _zeus setCuratorCoef ["Place", 0];
             _zeus setCuratorCoef ["Delete", 0];
+
+            removeAllCuratorAddons _zeus;
         };
 
         _zeus setVariable ["KPLIB_limited", _limited];
 
         _player assignCurator _zeus;
 
-        [true, "KPLIB_zeusAssigned", [_zeus]] remoteExecCall ["BIS_fnc_callScriptedEventHandler", _player];
+        [true, "KPLIB_zeusAssigned", [_zeus, _limited]] remoteExecCall ["BIS_fnc_callScriptedEventHandler", _player];
     }] call BIS_fnc_addScriptedEventHandler;
 
     [true, "KPLIB_activateZeusAddons", {
@@ -94,7 +96,8 @@ if (isServer) then {
 if (hasInterface) then {
     [true, "KPLIB_zeusAssigned", {
         params [
-            ["_zeus", objNull, [objNull]]
+            ["_zeus", objNull, [objNull]],
+            ["_limited", false, [true]]
         ];
 
         if !(_zeus getVariable ["KPLIB_drawCuratorLocations", false]) then {
@@ -102,8 +105,10 @@ if (hasInterface) then {
             [_zeus] call BIS_fnc_drawCuratorLocations;
         };
 
-        private _allAddons = ("true" configClasses (configFile >> "CfgPatches")) apply {configName _x};
-        [true, "KPLIB_activateZeusAddons", [_zeus, _allAddons]] remoteExecCall ["BIS_fnc_callScriptedEventHandler", 2];
+        if (!_limited) then {
+            private _allAddons = ("true" configClasses (configFile >> "CfgPatches")) apply {configName _x};
+            [true, "KPLIB_activateZeusAddons", [_zeus, _allAddons]] remoteExecCall ["BIS_fnc_callScriptedEventHandler", 2];
+        };
     }] call BIS_fnc_addScriptedEventHandler;
 };
 

--- a/Missionframework/scripts/client/init_client.sqf
+++ b/Missionframework/scripts/client/init_client.sqf
@@ -96,9 +96,11 @@ if (player isEqualTo ([] call KPLIB_fnc_getCommander)) then {
     if (KP_liberation_tutorial) then {
         [] call KPLIB_fnc_tutorial;
     };
-
-    [] spawn {
-        sleep 5;
-        [] call KPLIB_fnc_requestZeus;
+    // Request Zeus if enabled
+    if (KP_liberation_commander_zeus) then {
+        [] spawn {
+            sleep 5;
+            [] call KPLIB_fnc_requestZeus;
+        };
     };
 };

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -93,6 +93,7 @@ if(isServer) then {
     GET_PARAM(KP_liberation_allowEnemiesInImmobile, "AllowEnemiesInImmobile", 50);
     GET_PARAM(KP_liberation_delayDespawnMax, "DelayDespawnMax", 5);
     GET_PARAM_BOOL(KP_liberation_limited_zeus, "LimitedZeus", 1);
+    GET_PARAM_BOOL(KP_liberation_commander_zeus, "CommanderZeus", 1);
     GET_PARAM_BOOL(KP_liberation_enemies_zeus, "ZeusAddEnemies", 1);
     GET_PARAM_BOOL(KP_liberation_high_command, "HighCommand", 1);
     GET_PARAM(KP_liberation_suppMod, "SuppMod", 1);
@@ -422,6 +423,10 @@ if (!isDedicated && hasInterface) then {
 
     _param = localize "STR_PARAM_DELAY_DESPAWN_MAX";
     _value = if (KP_liberation_delayDespawnMax == 0) then {localize "STR_PARAMS_DISABLED";} else {KP_liberation_delayDespawnMax;};
+    _text = _text + format ["<font color='#ff8000'>%1</font><br />%2<br /><br />", _param, _value];
+
+    _param = localize "STR_PARAM_COMMANDERZEUS";
+    _value = if (KP_liberation_commander_zeus) then {localize "STR_PARAMS_ENABLED";} else {localize "STR_PARAMS_DISABLED";};
     _text = _text + format ["<font color='#ff8000'>%1</font><br />%2<br /><br />", _param, _value];
 
     _param = localize "STR_PARAM_LIMITEDZEUS";

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2860,6 +2860,15 @@
             <Turkish>Sektör kapanma üst limiti (Sektörün açılmasından 5 dakika sonra artmaya başlar)</Turkish>
             <Czech>Maximální zpoždění deaktivace sektoru (začíná se zvyšovat po 5. aktivační minutě)</Czech>
         </Key>
+        <Key ID="STR_PARAM_LIMITEDZEUS">
+            <Original>Limited Zeus interface</Original>
+            <German>Eingeschränkte Zeus Funktionen</German>
+            <Spanish>Interface de Zeus limitada</Spanish>
+            <Russian>Ограниченный интерфейс Zeus</Russian>
+            <Korean>제한된 제우스 인터페이스</Korean>
+            <Turkish>Sınırlı Zeus Arayüzü</Turkish>
+            <Czech>Omezené rozhraní Zeus</Czech>
+        </Key>
         <Key ID="STR_PARAM_COMMANDERZEUS">
             <Original>Zeus for Commander</Original>
         </Key>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2871,6 +2871,7 @@
         </Key>
         <Key ID="STR_PARAM_COMMANDERZEUS">
             <Original>Zeus for Commander</Original>
+            <German>Zeus für Kommandant</German>
         </Key>
         <Key ID="STR_PARAM_ALLOW_ENEMIES_IN_IMMOBILE">
             <Original>Chance that enemies will stay in immobile/damaged vehicles</Original>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2860,14 +2860,8 @@
             <Turkish>Sektör kapanma üst limiti (Sektörün açılmasından 5 dakika sonra artmaya başlar)</Turkish>
             <Czech>Maximální zpoždění deaktivace sektoru (začíná se zvyšovat po 5. aktivační minutě)</Czech>
         </Key>
-        <Key ID="STR_PARAM_LIMITEDZEUS">
-            <Original>Limited Zeus interface</Original>
-            <German>Eingeschränkte Zeus Funktionen</German>
-            <Spanish>Interface de Zeus limitada</Spanish>
-            <Russian>Ограниченный интерфейс Zeus</Russian>
-            <Korean>제한된 제우스 인터페이스</Korean>
-            <Turkish>Sınırlı Zeus Arayüzü</Turkish>
-            <Czech>Omezené rozhraní Zeus</Czech>
+        <Key ID="STR_PARAM_COMMANDERZEUS">
+            <Original>Zeus for Commander</Original>
         </Key>
         <Key ID="STR_PARAM_ALLOW_ENEMIES_IN_IMMOBILE">
             <Original>Chance that enemies will stay in immobile/damaged vehicles</Original>

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -287,6 +287,12 @@ class Params {
         texts[] = {$STR_PARAMS_DISABLED, "5", "10", "15", "20", "25", "30"};
         default = 5;
     };
+    class CommanderZeus {
+        title = $STR_PARAM_COMMANDERZEUS;
+        values[] = {1, 0};
+        texts[] = {$STR_PARAMS_ENABLED, $STR_PARAMS_DISABLED};
+        default = 1;
+    };
     class LimitedZeus {
         title = $STR_PARAM_LIMITEDZEUS;
         values[] = {1, 0};


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes  |
| New feature? | no |
| Needs wipe? | no  |

### Description:

Remove all addons for limited zeus, add param to disable zeus for commander.

No changelog entry as it's part of previous PR to 0.96.7a.

### Content:
- [x] Add an option to Limited zeus param to completely disable Zeus for commander
- [x] Do not add addons to Zeus if limited mode is enabled

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP
