### PR TITLE
Update init_arsenal.sqf

### DIFF
--- a/Missionframework/scripts/client/misc/init_arsenal.sqf
+++ b/Missionframework/scripts/client/misc/init_arsenal.sqf
@@ -91,6 +91,15 @@ if (KP_liberation_arsenalUsePreset) then {
         };
     } forEach KP_liberation_allowed_items;
 
+	{
+        if ((_x find "cup_optic") == 0) then {
+            KP_liberation_allowed_items_extension append [_x + "_3d", _x + "_pip"];
+        };
+        if ((_x find "cup_optic") == 0) then {
+            KP_liberation_allowed_items_extension append [_x + "_3d", _x + "_pip"];
+        };
+    } forEach KP_liberation_allowed_items;
+
     if ((count KP_liberation_allowed_items_extension) > 0) then {
         KP_liberation_allowed_items append KP_liberation_allowed_items_extension;
     };


### PR DESCRIPTION
Appends "_3d" and "_pip" to CUP scopes to prevent them from being pulled from loadouts even when not blacklisted.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no <!-- don't forget to update CHANGELOG.md file --> |
| Needs wipe? | no <!-- set to yes if save needs to be wiped to use new feature --> |

### Description:

Appends "_3d" and "_pip" to CUP scopes to prevent them from being pulled from loadouts even when not blacklisted.

### Content:
- [ ] Content part

<!--
Add things which are part of this pull request as checkboxes
to show if it's already finished and already part of the pull request.
-->

### Successfully tested on:
- [ ] Local MP
- [ ] Dedicated MP

<!--
As soon as you've tested your feature on the listed environment you can check the checkbox.
It has to work without any issues and errors in your own tests.
-->
