### PR TITLE
0.86.8 bugfix: blufor_sectors has already changed to KPLIB_sectors_player

### DIFF
--- a/Missionframework/scripts/client/build/open_build_menu.sqf
+++ b/Missionframework/scripts/client/build/open_build_menu.sqf
@@ -149,7 +149,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
             { if ( ( _build_item select 0 ) == ( _x select 0 ) ) exitWith { _base_link = _x select 1; _linked = true; } } foreach KPLIB_vehicle_to_military_base_links;
 
             if ( _linked ) then {
-                if ( !(_base_link in blufor_sectors) ) then { _linked_unlocked = false };
+                if ( !(_base_link in KPLIB_sectors_player) ) then { _linked_unlocked = false };
             };
         };
     };

--- a/Missionframework/scripts/client/tutorial/fn_tutorial.fsm
+++ b/Missionframework/scripts/client/tutorial/fn_tutorial.fsm
@@ -491,7 +491,7 @@ class FSM
                                         priority = 1.000000;
                                         to="Slingload_crate";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"!KP_liberation_fob_vehicle"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!KPLIB_param_fobVehicle"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
@@ -502,7 +502,7 @@ class FSM
                                         priority = 0.000000;
                                         to="Drive_the_truck";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"KP_liberation_fob_vehicle"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"KPLIB_param_fobVehicle"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | not sure |

### Description:
On some previous commit, `blufor_sectors` was changed to `KPLIB_sectors_player`.
However, one in `Missionframework\scripts\client\build\open_build_menu.sqf` was forgotten to be changed.
This fix correct the wrong variable name `blufor_sectors` to the right one `KPLIB_sectors_player`.

### Content:
- [x] fix: blufor_sectors has already changed to KPLIB_sectors_player

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP

