### PR TITLE
!F (SaveLoad) Added FileXT mod capability.

### DIFF
--- a/Missionframework/functions/fn_doSave.sqf
+++ b/Missionframework/functions/fn_doSave.sqf
@@ -17,6 +17,28 @@
 
 if (!isServer) exitWith {false};
 
+// Write data to FileXT storage
+// Param 0: (string) Filename
+// Param 1: (string) Save data
+fnc_saveFileXT = {
+    private _file = _this select 0;
+    private _data = _this select 1;
+    [_file] call filext_fnc_open; 
+    [_file, "Data", _data] call filext_fnc_set;
+    [_file] call filext_fnc_write;
+    [_file] call filext_fnc_close;
+};
+
+// Write data in the server profileNamespace
+// Param 0: (string) Variable name
+// Param 1: (string) Save data
+fnc_saveProfileNamespace = {
+    private _variable = _this select 0;
+    private _data = _this select 1;
+    profileNamespace setVariable [_variable, _data];
+    saveProfileNamespace;
+};
+
 if (!KPLIB_init) exitWith {
     ["Framework is not initalized, skipping save!", "SAVE"] call KPLIB_fnc_log;
     false
@@ -31,9 +53,12 @@ kp_liberation_saving = true;
 
 private _saveData = [] call KPLIB_fnc_getSaveData;
 
-// Write data in the server profileNamespace
-profileNamespace setVariable [GRLIB_save_key, str _saveData];
-saveProfileNamespace;
+// Check if FileXT is available
+if (isClass(configFile >> "CfgPatches" >> "filext")) then {
+    [GRLIB_save_key + ".savedata", str _saveData] call fnc_saveFileXT;
+} else { 
+    [GRLIB_save_key, str _saveData] call fnc_saveProfileNamespace;
+};
 
 kp_liberation_saving = false;
 

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -161,8 +161,49 @@ stats_vehicles_recycled = 0;
     _x setVariable ["KP_liberation_edenObject", true];
 } forEach (allMissionObjects "");
 
-// Get possible save data
-private _saveData = profileNamespace getVariable GRLIB_save_key;
+// Read data from FileXT storage
+// Return: (string) Save data
+// Param 0: (string) Filename
+fnc_loadFileXT = {
+    private _file = _this select 0;
+    private _data = nil;
+    
+    [format ["Loading from FileXT."], "SAVE"] call KPLIB_fnc_log;
+    
+    [_file] call filext_fnc_open; 
+    [_file] call filext_fnc_read;
+    _data = [_file, "Data"] call filext_fnc_get;
+    [_file] call filext_fnc_close;
+    if (!isNil "_data") then {
+        _data;
+    };
+};
+
+// Write data in the server profileNamespace
+// Return: (string) Save data
+// Param 0: (string) Variable name
+fnc_loadProfileNamespace = {
+    private _variable = _this select 0;
+    private _data = nil;
+    
+    [format ["Fallback - Loading from Profile Namespace."], "SAVE"] call KPLIB_fnc_log;
+    
+    _data = profileNamespace getVariable GRLIB_save_key;
+    if (!isNil "_data") then {
+        _data;
+    };
+};
+
+// Check if FileXT is available
+private _saveData = nil;
+if (isClass(configFile >> "CfgPatches" >> "filext")) then {  
+    _saveData = [GRLIB_save_key + ".savedata"] call fnc_loadFileXT;
+};
+
+// Fallback/Default to profileNamespace if _saveData is nil
+if (isNil "_saveData") then {
+    _saveData = [GRLIB_save_key] call fnc_loadProfileNamespace;
+};
 
 // Load save data, when retrieved
 if (!isNil "_saveData") then {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |

### Description:
Allows mission hosts to use the FileXT mod to save data to an external file instead of inside the profile.
- If there is no data yet in FileXT, then it will attempt to load from the profile namespace - allows for easy migration towards FileXT.
- If FileXT is not available, it will revert to the original profile namespace save/load system as usual.
- Files will be stored at: `ModsFolder/@FileXT/storage/KP_LIBERATION_(worldName)_SAVEGAME.savedata`

### Task List:
- [x] Add saving and loading of inventory items inside savable objects

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP
